### PR TITLE
Use the given path prefix on the API base url for requests.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -67,7 +67,17 @@ function RestClient(options) {
   }
   assert.ok(this.proto);
 
-  this.path = options.path || url.pathname || '/';
+  // https://github.com/joyent/node/issues/711 introduced a bug, IMO,
+  // where `pathname=="/"` even for, e.g., "http://example.com". Ignore
+  // the '/' in that case.
+  this.path = options.path || '';
+  if (!this.path && this.url
+      && !(this.url.pathname === '/'
+           && options.url[options.url.length-1] !== '/'))
+  {
+    this.path = this.url.pathname;
+  }
+
   this.headers = {
     Accept: 'application/json'
   };
@@ -426,7 +436,9 @@ RestClient.prototype._newHttpOptions = function(method) {
   utils.extend(self.headers, opts.headers);
   if (self.url) {
     opts.host = self.url.hostname.toString();
-    opts.port = self.url.port.toString();
+    if (self.url.port !== undefined) {
+      opts.port = self.url.port.toString();
+    }
   } else {
     opts.socketPath = self.socketPath.toString();
   }
@@ -445,11 +457,13 @@ RestClient.prototype._processArguments = function(expect,
       callback = options;
     } else {
       var headers = opts.headers;
+      var path = opts.path + options.path;
       utils.extend(options, opts);
       opts.headers = headers;
       if (options.headers) {
         utils.extend(options.headers, opts.headers);
       }
+      opts.path = path;
     }
   }
   if (callback && typeof(callback) !== 'function')


### PR DESCRIPTION
Before this, a restify client with
`url=="http://example.com/subpath/to/api"` didn't use the
`/subpath/to/api` in API request.

Also fix a buglet presuming that `self.url` has a "port" field.
The result of `url.parse` doesn't include "port" field if there isn't
one in the given URL string.
