### PR TITLE
Very small change that will allow contentWriters to make use of the res o

### DIFF
--- a/lib/http_extra.js
+++ b/lib/http_extra.js
@@ -81,7 +81,8 @@ http.ServerResponse.prototype.send = function(options) {
       data = JSON.stringify(_opts.body);
       //data = data + '\n';
     } else if (this._config.contentWriters[this._accept]) {
-      data = this._config.contentWriters[this._accept](_opts.body);
+      var fn = this._config.contentWriters[this._accept]
+      data = fn(_opts.body);
     } else {
       // Just pass it through "broken", since we should never
       // actually be in this case.


### PR DESCRIPTION
Hey,

Thanks for an awesome module that has saved me from all the mess I was having with getting connect set up as a rest API. Really is awesome :)

My application unfortunately requires cross domain calls and hence I need to use JSONP. As I think is the normal way, the callback name that the response should be wrapped in will be added to the query string by the client. This means that I need access to more data than is available (unless I have a magic key in the object passed in). 

This very small change that will allow contentWriters to make use of the res object as this if extra parameters are required. This change unifies the style with the contentHandler also.

Thanks,
Ben
