### PR TITLE
fix for auth parsing of passwords containing ':'

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -167,7 +167,15 @@ function _parseAuthorization(req, res) {
       return false;
     }
 
-    pieces = decoded !== null ? decoded.split(':', 2) : null;
+    if (decoded !== null) {
+      var idx = decoded.indexOf(':');
+      if (idx === -1) {
+        pieces = [decoded];
+      } else {
+        pieces = [decoded.slice(0, idx), decoded.slice(idx+1)];
+      }
+    }
+
     if (!(pieces !== null ? pieces[0] : null) ||
         !(pieces !== null ? pieces[1] : null)) {
       res.sendError(newError({


### PR DESCRIPTION
NB: not linted 'cause gjslint keeps erroring out.
