### PR TITLE
Range Versioning

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -118,6 +118,7 @@ function Route(options) {
   this.method = options.method || 'GET';
   this.methods = [this.method];
   this.version = options.version ? options.version : false;
+  this.rangeVersioning = options.rangeVersioning || false;
 
   var self = this;
   this.__defineGetter__('dtrace', function() {
@@ -247,6 +248,9 @@ Route.prototype.matchesVersion = function matchesVersion(req) {
 
   if (!this.version || req.version === '*')
     return true;
+
+  if (this.rangeVersioning)
+    return semver.satisfies(req.version, this.version);
 
   return semver.satisfies(this.version, req.version);
 };

--- a/lib/server.js
+++ b/lib/server.js
@@ -117,6 +117,7 @@ function Server(options) {
   this.name = options.name || 'restify';
   this.routes = [];
   this.version = options.version || false;
+  this.rangeVersioning = options.rangeVersioning || false;
 
   var secure = false;
   if (options.certificate && options.key) {
@@ -370,6 +371,7 @@ Server.prototype._addRoute = function _addRoute(method, options, handlers) {
     handlers: chain,
     name: options.name,
     version: options.version || self.version,
+    rangeVersioning: options.rangeVersioning || self.rangeVersioning,
     dtrace: self.dtrace
   });
   route.on('error', function(err) {


### PR DESCRIPTION
Currently if I do a new API version that means I have to manually create routes for previous versions even though I haven't changed anything on other routes.

My use case

Server:
- Route A version >=1.1.0
- Route B version 1.2.0
- Route B version <=1.1.0

Client: Uses a unique version, sending:
    0.9.9 - 1.2.1 - 1.1.0
Instead of:
    >=0.9.8, <= 1.3.0, =1.2.1
