### PR TITLE
Small update to response.js to make compatible with node-logging.

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -330,7 +330,7 @@ function Response(options) {
 
   this.res.on('finish', function (src) {
     return self.emit('finish', src);
-  }
+  });
   // Finally write the default headers in
   this.defaultHeaders();
 }


### PR DESCRIPTION
I noticed that restify isn't compatible out of the box with node-logging https://github.com/HerdHound/node-logging. This is because the response wrapper is missing the function that captures the finish event and re-emits it. 
