### PR TITLE
Fixed issue with OPTIONS calls not sending back the Access-Control-Allow...

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -67,6 +67,7 @@ function default404Handler(req, res, server) {
 function default405Handler(req, res, methods, server) {
   res.header('Allow', methods.join(', '));
   if (req.method === 'OPTIONS') {
+    res.header('Access-Control-Allow-Methods', methods.join(', '));
     res.send(200);
   } else {
     var msg = req.url + ' does not support ' + req.method;

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -439,11 +439,13 @@ test('DELETE ok', function (t) {
 test('OPTIONS', function (t) {
   var server = restify.createServer({ dtrace: DTRACE, log: LOGGER });
 
-  server.get('/foo/:id', function tester(req, res, next) {
-    t.ok(req.params);
-    t.equal(req.params.id, 'bar');
-    res.send();
-    return next();
+  ['get', 'post', 'put', 'del'].forEach(function(method){
+    server[method]('/foo/:id', function tester(req, res, next) {
+      t.ok(req.params);
+      t.equal(req.params.id, 'bar');
+      res.send();
+      return next();
+    });
   });
 
   server.listen(PORT, function () {
@@ -457,6 +459,7 @@ test('OPTIONS', function (t) {
     http.request(opts, function (res) {
       t.equal(res.statusCode, 200);
       t.ok(res.headers.allow);
+      t.equal(res.headers['access-control-allow-methods'], 'GET, POST, PUT, DELETE');
       server.close(function () {
         t.end();
       });


### PR DESCRIPTION
...-Methods header

We noticed this while testing PUT requests to our newly-restified service (great framework by the way!).  The fix seems simple enough, hopefully you'll think so too!
