### PR TITLE
adds emitting of "expectContinue"

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -480,8 +480,12 @@ Server.prototype._request = function _request(request, response, expect100) {
     setRequestLogger(req, self.log, route.name);
     res.log = req.log;
 
-    if (expect100)
+    if (expect100) {
+      if (self.listeners('expectContinue').length)
+        return self.emit('expectContinue', req, res, route);
+
       res.writeContinue();
+    }
 
     return route.run(req, res);
   }


### PR DESCRIPTION
before res.writeContinue checks for listeners, and emit if any are set.

allows users to handle expect 100 client requests and conditionally either writeContinue or handle response using restify's serverRequest (to obtain route params) instead of node's http serverRequest.
