### PR TITLE
Making error objects a bit more user-friendly.

### DIFF
--- a/lib/errors/http_error.js
+++ b/lib/errors/http_error.js
@@ -51,18 +51,13 @@ function HttpError(code, message, body, constructorOpt) {
     Error.captureStackTrace(this, constructorOpt || HttpError);
 
   code = parseInt(code, 10);
-  this.name = 'HttpError';
+
   this.message = message || '';
   this.body = body || message || '';
-
-  this.__defineGetter__('statusCode', function () {
-    return code;
-  });
-  this.__defineGetter__('httpCode', function () {
-    return code;
-  });
+  this.statusCode = this.httpCode = code;
 }
 util.inherits(HttpError, Error);
+HttpError.prototype.name = 'HttpError';
 
 
 
@@ -102,8 +97,7 @@ codes.forEach(function (code) {
                    message,
                    body || null,
                    caller || this.constructor);
-
-    this.name = name;
   };
   util.inherits(module.exports[name], HttpError);
+  module.exports[name].displayName = module.exports[name].prototype.name = name;
 });

--- a/lib/errors/rest_error.js
+++ b/lib/errors/rest_error.js
@@ -41,16 +41,10 @@ function RestError(statusCode, restCode, message, caller) {
                  },
                  caller || this.constructor);
 
-  this.name = restCode;
-  if (!/\w+Error$/.test(this.name))
-    this.name += 'Error';
-
-  this.code = restCode;
-  this.__defineGetter__('restCode', function () {
-    return restCode;
-  });
+  this.code = this.restCode = restCode;
 }
 util.inherits(RestError, HttpError);
+RestError.prototype.name = 'RestError';
 
 
 
@@ -61,7 +55,10 @@ module.exports = {
 };
 
 Object.keys(CODES).forEach(function (k) {
-  var name = k + 'Error';
+  var name = k;
+  if (!/\w+Error$/.test(name))
+    name += 'Error';
+
   module.exports[name] = function () {
     var message = util.format.apply(util, arguments);
     RestError.call(this,
@@ -69,8 +66,7 @@ Object.keys(CODES).forEach(function (k) {
                    k,
                    message,
                    this.constructor);
-
-    this.name = name;
   };
   util.inherits(module.exports[name], RestError);
+  module.exports[name].displayName = module.exports[name].prototype.name = name;
 });


### PR DESCRIPTION
- Don't use getters for `code`/`restCode`/`statusCode`/`httpCode`. Fixes GH-112.
- Put `name` properties on the prototype, to better match native error types and the patterns expected of them.
- Set `displayName` on the constructors, since otherwise they are anonymous functions in any stack traces.

---

The only missing thing that makes these errors behave unlike real errors is that, e.g.,

``` js
NotFoundError.name === ""
```

This causes problems for some libraries like <a href="https://github.com/logicalparadox/chai/blob/master/lib/assertion.js#L889-892">Chai</a>, which assume the existence of a `name` property.

Unfortunately the only way to fix this would be `eval`, since `name` is non-writable and non-configurable. Something like:

``` js
eval('module.exports[name] = function ' + name + '(message, body, caller) {
  HttpError.call(this,
                 code,
                 message,
                 body || null,
                 caller || this.constructor);
};');
```

If you think that's worth the cost let me know and I can add it to this pull request. I'm on the fence personally.
