### PR TITLE
support for HTTP patch

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -310,7 +310,7 @@ Server.prototype.close = function close(callback) {
 
 
 // Register all the routing methods
-['del', 'get', 'head', 'post', 'put'].forEach(function (method) {
+['del', 'get', 'head', 'post', 'put', 'patch'].forEach(function (method) {
 
   /**
    * Mounts a chain on the given path against this HTTP verb

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -377,6 +377,35 @@ test('PUT ok', function (t) {
 });
 
 
+test('PATCH ok', function (t) {
+  var server = restify.createServer({ dtrace: DTRACE, log: LOGGER });
+
+  server.patch('/foo/:id', function tester(req, res, next) {
+    t.ok(req.params);
+    t.equal(req.params.id, 'bar');
+    res.send();
+    return next();
+  });
+
+  server.listen(PORT, function () {
+    var opts = {
+      hostname: 'localhost',
+      port: PORT,
+      path: '/foo/bar',
+      method: 'PATCH',
+      agent: false
+    };
+    http.request(opts, function (res) {
+      t.equal(res.statusCode, 200);
+      server.close(function () {
+        t.end();
+      });
+    }).end();
+  });
+});
+
+
+
 test('HEAD ok', function (t) {
   var server = restify.createServer({ dtrace: DTRACE, log: LOGGER });
 


### PR DESCRIPTION
Our rest API is going to support the PATCH method for partial updates.   Thought this was a simple enough change to make and request.

I added a test for PATCH, however I could not run the tests on windows due to dtrace-provider.
