### PR TITLE
adds absoluteUri to request object

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -217,3 +217,10 @@ Request.prototype.toString = function toString() {
   return this.method + ' ' + this.url + ' HTTP/' + this.httpVersion + '\n' +
     str;
 };
+
+
+Request.prototype.absoluteUri = function absoluteUri(relativePath) {
+  var protocol = this.secure ? "https://" : "http://";
+  var hostname = this.header("Host");
+  return url.resolve(protocol + hostname + this.path + "/", relativePath);
+};


### PR DESCRIPTION
Useful for setting headers like Location which should be absolute uri's.

We needed this in a few places in our current application, so thought it would be nice to have in restify. The request object contains all the info needed to create the uri, so figured it belonged there.
