### PR TITLE
Allow `HttpError` bodies to inform the response.

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -124,8 +124,8 @@ function formatJSON(req, res, body) {
   }
 
   if (body instanceof Error) {
-    // snoop for RestError, but don't rely on instanceof
-    if (body.restCode && body.body) {
+    // snoop for RestError or HttpError, but don't rely on instanceof
+    if ((body.restCode || body.httpCode) && body.body) {
       body = body.body;
     } else {
       body = {


### PR DESCRIPTION
Currently just `RestError`'s get their `body` property stuffed into JSON responses. This fixes the code to allow `HttpError`s the same properties.
