### PR TITLE
adds beforeSend event

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -397,6 +397,8 @@ Response.prototype.send = function send(body) {
   // the formatter might tack in Content- headers, so fill in headers after
   // serialization
   var data = body ? this.format(body) : null;
+  this.emit('beforeSend', data);
+  
   this.defaultResponseHeaders(data);
   this.writeHead(this.statusCode, this.headers);
   if (data && !head && this.statusCode !== 204 && this.statusCode !== 304) {


### PR DESCRIPTION
emit in response.send before default headers are sent and when we know the body response data

needed a hook that let us send headers as soon as we know the body response.  without this, the pre hook was too early, after hook to late, and plugins early/late.

use case for us was to create an ETag header on all 200 requests that return JSON.  We md5 the response object.  So we need ability to send header and obtain the body response.
