### PR TITLE
Adding `Route.prototype.realize`.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,7 @@ var clients = require('./clients');
 var errors = require('./errors');
 var plugins = require('./plugins');
 
+var sanitizePath = require('./utils').sanitizePath;
 
 
 ///--- Globals
@@ -174,6 +175,21 @@ module.exports = {
 
     options.type = 'string';
     return module.exports.createClient(options);
+  },
+
+
+  /**
+    * Returns a string representation of a URL pattern , with its parameters
+    * filled in by the passed hash.
+    *
+    * If a key is not found in the hash for a param, it is left alone.
+    *
+    * @param {Object} a hash of parameter names to values for substitution.
+    */
+  realizeUrl: function realizeUrl(pattern, params) {
+    return sanitizePath(pattern.replace(/\/:([^/]+)/g, function (wholeMatch, key) {
+      return params.hasOwnProperty(key) ? '/' + params[key] : wholeMatch;
+    }));
   },
 
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -9,6 +9,7 @@ var mime = require('mime');
 var qs = require('qs');
 var uuid = require('node-uuid');
 
+var sanitizePath = require('./utils').sanitizePath;
 
 
 ///--- Globals
@@ -18,26 +19,6 @@ var Request = http.IncomingMessage;
 
 
 ///--- Helpers
-
-/**
- * Cleans up sloppy URL paths, like /foo////bar/// to /foo/bar.
- *
- * @param {String} path the HTTP resource path.
- * @return {String} Cleaned up form of path.
- */
-function sanitizePath(path) {
-  assert.ok(path);
-
-  // Be nice like apache and strip out any //my//foo//bar///blah
-  path = path.replace(/\/\/+/g, '/');
-
-  // Kill a trailing '/'
-  if (path.lastIndexOf('/') === (path.length - 1) && path.length > 1)
-    path = path.substr(0, path.length - 1);
-
-  return path;
-}
-
 
 // The following three functions are courtesy of expressjs
 // as is req.accepts(), and req.is() below.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,22 @@
+// Copyright 2012 Mark Cavage, Inc.  All rights reserved.
+
+var assert = require('assert');
+
+/**
+ * Cleans up sloppy URL paths, like /foo////bar/// to /foo/bar.
+ *
+ * @param {String} path the HTTP resource path.
+ * @return {String} Cleaned up form of path.
+ */
+exports.sanitizePath = function sanitizePath(path) {
+  assert.ok(path);
+
+  // Be nice like apache and strip out any //my//foo//bar///blah
+  path = path.replace(/\/\/+/g, '/');
+
+  // Kill a trailing '/'
+  if (path.lastIndexOf('/') === (path.length - 1) && path.length > 1)
+    path = path.substr(0, path.length - 1);
+
+  return path;
+};

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,23 @@
+﻿// Copyright 2012 Mark Cavage, Inc.  All rights reserved.
+
+var test = require('tap').test;
+
+
+var restify = require('../lib/index');
+
+
+
+///--- Tests
+
+test('realize', function (t) {
+  var pattern = '/foo/:bar/:baz';
+
+  t.equal(restify.realizeUrl(pattern, {}), '/foo/:bar/:baz');
+  t.equal(restify.realizeUrl(pattern, {bar: 'BAR'}), '/foo/BAR/:baz');
+  t.equal(restify.realizeUrl(pattern, {bar: 'BAR', baz: 'BAZ'}), '/foo/BAR/BAZ');
+  t.equal(restify.realizeUrl(pattern, {bar: 'BAR', baz: 'BAZ', quux: 'QUUX'}), '/foo/BAR/BAZ');
+
+  t.equal(restify.realizeUrl('/foo////bar///:baz', {baz: 'BAZ'}), '/foo/bar/BAZ');
+
+  t.end();
+});


### PR DESCRIPTION
Gives you a route's URL with params replaced by a passed hash's values.

I'm about 90% sure it conforms to restify's route-matching rules, which seem to be that route params can only be path segments (i.e. sandwiched between `/`s), and have no restrictions on valid characters.

I think there might be better places in the API for this, but `Route` was pretty convenient. It is a bit strange though since it is really a URL-level operation, not a route-level one. (That is, method is entirely ignored.)

An alternative might be just `restify.realizeUrl(url, params)`.

Also feel free to suggest a better name.
