### PR TITLE
Added a RestSuccess to allow uniform response between success and error messages

### DIFF
--- a/lib/errors/rest_error.js
+++ b/lib/errors/rest_error.js
@@ -47,10 +47,10 @@ util.inherits(RestError, HttpError);
 RestError.prototype.name = 'RestError';
 
 function RestSuccess(message){
-	restify.RestError.call(this, 200, 'success', message, RestSuccess);
+	RestError.call(this, 200, 'success', message, RestSuccess);
   this.name = 'RestSuccess';
 }
-util.inherits(RestSuccess, restify.RestError);
+util.inherits(RestSuccess, RestError);
 
 ///--- Exports
 


### PR DESCRIPTION
Hi Mark,

I'd like to suggest to include a success message following the RestError pattern (code: 'success', message: some_result) to allow people to build more consistent API responses.

As it is now, when a client gots an error it has to parse a json response containing a code and a message but when the request is successful the structure to parsed is the object itself. This design sometimes leads to clients with a lot of "ifs" to handle both success and error messages.

A more consistent approach in my opinion would be to responde with the same root object, even in success cases, in which case  the code attribute would be "success" and the message would hold the object itself. 

Instead of writing something like:

``` javascript
server.head('/foo/:id', function (req, res, next) {
  res.send({hello: req.params.id});
  return next();
});
```

one would write:

``` javascript
server.head('/foo/:id', function (req, res, next) {
  res.send(new restify.RestSuccess({hello: req.params.id}));
  return next();
});
```

What do you think about this approach?

Cheers,

Eric
