### PR TITLE
Fix defaultResponseHeaders setter

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -216,5 +216,5 @@ module.exports.__defineSetter__('defaultResponseHeaders', function (f) {
     throw new TypeError('defaultResponseHeaders must be a function');
   }
 
-  http.ServerResponse.prototype.defaultHeaders = f;
+  http.ServerResponse.prototype.defaultResponseHeaders = f;
 });


### PR DESCRIPTION
`defaultResponseHeaders` wasn't being overwritten, as the new function was being assigned to `defaultHeaders` by the setter. The following example demonstrates the behaviour:

``` javascript

var restify = require('./lib/index');

server = restify.createServer();

var message = "Error! defaultResponseHeaders was not overridden.";
restify.defaultResponseHeaders = function() {
  message = "Success! defaultResponseHeaders was overridden.";
}

server.listen(9912);

client = restify.createClient({url: 'http://127.0.0.1:9912', type: 'json'});
client.get('/', function (err, req, res, obj) {
  server.close();
  console.log(message);
});
```
