### PR TITLE
Use `restCode` and `httpCode` instead of `statusCode`.

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -384,7 +384,7 @@ Response.prototype.send = function send(body) {
       this.statusCode = body;
       body = null;
     } else if (body instanceof Error) {
-      this.statusCode = body.statusCode || 500;
+      this.statusCode = body.restCode || body.httpCode || 500;
     }
     break;
 


### PR DESCRIPTION
This avoids collisions with other frameworks that use `statusCode` for their custom errors, e.g. wantworthy/dynode. It is also more consistent with line 128.

We were passing dynode errors up through our chain of callbacks, and ended up sending the user 400 Bad Request when it was really us, internally, sending bad requests to Amazon.

This is somewhat of a breaking change :-/.
