### PR TITLE
Add support for authority certificates

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -135,10 +135,11 @@ function Server(options) {
 
   if (options.certificate && options.key) {
     secure = true;
-    this.server = https.createServer({
-      cert: options.certificate,
-      key: options.key
-    });
+    var httpsOptions = { cert: options.certificate, key: options.key };
+    if (options.ca)
+      httpsOptions.ca = options.ca;
+
+    this.server = https.createServer(httpsOptions);
   } else {
     this.server = http.createServer();
   }


### PR DESCRIPTION
Need this for ssl certificates that rely on chained authority certificates.  Without this, some clients may not trust the certificate.
