### PR TITLE
Add support for HTTP 415 Unsupported Media Type

### DIFF
--- a/lib/plugins/body_parser.js
+++ b/lib/plugins/body_parser.js
@@ -4,6 +4,10 @@ var jsonParser = require('./json_body_parser');
 var formParser = require('./form_body_parser');
 var multipartParser = require('./multipart_parser');
 
+var errors = require('../errors');
+
+var UnsupportedMediaTypeError = errors.UnsupportedMediaTypeError;
+
 
 function bodyParser(options) {
 
@@ -21,6 +25,8 @@ function bodyParser(options) {
       return parseForm(req, res, next);
     } else if (req.contentType === 'multipart/form-data') {
       return parseMultipart(req, res, next);
+    } else {
+      return next(new UnsupportedMediaTypeError('Unsupported Content-Type: ' + req.contentType));
     }
 
     return next();


### PR DESCRIPTION
When a request body specifies a Content-Type that is unsupported by the body_parser, the correct HTTP status to return is 415 Unsupported Media Type
