### PR TITLE
Send JSON by default for `HttpError`s.

### DIFF
--- a/lib/errors/http_error.js
+++ b/lib/errors/http_error.js
@@ -53,7 +53,7 @@ function HttpError(code, message, body, constructorOpt) {
   code = parseInt(code, 10);
 
   this.message = message || '';
-  this.body = body || message || '';
+  this.body = body || (message ? { message: message } : '');
   this.statusCode = this.httpCode = code;
 }
 util.inherits(HttpError, Error);


### PR DESCRIPTION
Right now if you happen to use a `HttpError` instead of a `RestError`, you end up sending a string for the body instead of JSON, unless you explicitly specify the body parameter. This change fixes that to default to sending a JSON body containing a `message` field, just like for `RestError`s. You can still override the body manually, of course.
