### PR TITLE
Add `rejectUnknown` option to body parser.

### DIFF
--- a/lib/plugins/body_parser.js
+++ b/lib/plugins/body_parser.js
@@ -28,7 +28,7 @@ function bodyParser(options) {
       return parseForm(req, res, next);
     } else if (req.contentType === 'multipart/form-data') {
       return parseMultipart(req, res, next);
-    } else {
+    } else if (options.rejectUnknown !== false) {
       return next(new UnsupportedMediaTypeError('Unsupported Content-Type: ' +
                                                 req.contentType));
     }


### PR DESCRIPTION
Defaults to `true`. Makes the behavior introduced in c7c7d4e33e19f5541d8e1e7ec5a06ba6cfb316ec optional, by explicitly setting `false`.
