### PR TITLE
Don't default contentLength to zero

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -88,7 +88,7 @@ module.exports = {
     var _url = url.parse(req.url);
 
     req.chunked = req.headers['transfer-encoding'] === 'chunked';
-    req.contentLength = req.headers['content-length'] || 0;
+    req.contentLength = req.headers['content-length'];
     req.contentType = parseContentType(req);
     req.href = _url.href;
     req.id = req.headers['x-request-id'] || uuid();


### PR DESCRIPTION
I need to differentiate between zero content length (i.e. actually zero) and one that wasn't set (unspecified content length, which might be valid, or might result in a 411 error).
