### PR TITLE
Get rid of ETag quotes and W/ prefix for ETag header.

### DIFF
--- a/lib/plugins/conditional_request.js
+++ b/lib/plugins/conditional_request.js
@@ -34,6 +34,9 @@ function conditionalRequest() {
     var matched = false;
 
     if (typeof (etag) === 'string' && etag.length !== 0) {
+      etag =
+        etag.replace(/^W\//, '').replace(/^"(\w*)"$/, '$1');
+
       if (req.headers['if-match']) {
         // RFC: http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.24
 


### PR DESCRIPTION
It was only getting rid of them for If-Match/If-None-Match, which meant the comparison never evaluated to true unless the client sent malformed If-Match/If-None-Match headers (i.e. ones with double quotes).

I never understood the `W/` prefix so I just removed that too since you do that later in the function?
