### PR TITLE
Added option `keepExtensions` to bodyParser plugin

### DIFF
--- a/docs/index.restdown
+++ b/docs/index.restdown
@@ -647,10 +647,11 @@ supported.
 
     server.use(restify.bodyParser({ mapParams: false }));
 
-You can pass in an options object; currently the only parameter honored is
-`mapParams`, which you can set to `false` to disable copying k/v pairs from
+You can pass in an options object; currently the only two parameters honored are
+`mapParams` and `keepExtensions`. You can set `mapParams` to `false` to disable copying k/v pairs from
 the request body into `req.params`; instead, `req.body` will be overwritten with
-the parsed object.  The default is to map params into `req.params`.
+the parsed object.  The default is to map params into `req.params`. The `keepExtensions` option is
+useful if you want the uploaded files to include the extensions of the original files. Default is `false`.
 
 ### Throttle
 

--- a/lib/plugins/multipart_parser.js
+++ b/lib/plugins/multipart_parser.js
@@ -36,6 +36,7 @@ function multipartBodyParser(options) {
       return next();
 
     var form = new formidable.IncomingForm();
+    form.keepExtensions = options.keepExtensions ? true : false;
 
     return form.parse(req, function (err, fields, files) {
       if (err)


### PR DESCRIPTION
The `keepExtensions` option is useful if you want the uploaded files to
include the extensions of the original files. Default is `false`.

It is simply a bridge to the formidable module option `keepExtensions`.
