### PR TITLE
Documentation Error, outdated reference to restify.ConflictError

### DIFF
--- a/docs/index.restdown
+++ b/docs/index.restdown
@@ -348,7 +348,7 @@ HTTP status codes as a subclass of `HttpError`.  So, for example, you can
 do this:
 
     server.get('/hello/:name', function(req, res, next) {
-      return next(new restify.ConflictError("I just don't like you"));
+      return next(new restify.InvalidArgumentError("I just don't like you"));
     });
 
     $ curl -is -H 'accept: text/*' localhost:8080/hello/mark


### PR DESCRIPTION
Error handling section includes usage of once-deprecated, now non-existant restify.ConflictError. Should be replaced with restify.InvalidArgument for 409 Conflict
