### PR TITLE
param name not passed to param pre-conditions

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -588,8 +588,9 @@ Server.prototype._findRoute = function _findRoute(req, res) {
  */
 Server.prototype.param = function param(name, fn) {
 	return this.use(function (req, res, next) {
-		if (req.params && req.params[name])
-			return fn.call(this, req, res, next, name);
+		var value = req.params && req.params[name];
+		if (value)
+			return fn.call(this, req, res, next, value, name);
 
 		return next();
 	});


### PR DESCRIPTION
Adding a bit to the "minimal" param pre-condition. This change simply passes the param name along (like Express does) so you can have generic functions map to many param names.

Something like this...

``` javascript
function id(req, res, next, name){
  req.param[name] = parseInt(req.param[name], 10);  
}
server.param("userid", id);
server.param("companyid", id);
```

Thanks. Keep up the great work!
