### PR TITLE
Allow uploadDir to be set for file uploads

### DIFF
--- a/lib/plugins/multipart_parser.js
+++ b/lib/plugins/multipart_parser.js
@@ -37,6 +37,7 @@ function multipartBodyParser(options) {
 
     var form = new formidable.IncomingForm();
     form.keepExtensions = options.keepExtensions ? true : false;
+	if (options.uploadDir) form.uploadDir = options.uploadDir;
 
     return form.parse(req, function (err, fields, files) {
       if (err)


### PR DESCRIPTION
Since we're already allowing "keepExtensions", I went ahead and added "uploadDir" to the list of recognized options. I got tired of everything getting thrown into /tmp. :)
