### PR TITLE
bodyParser/multipartParser updated

### DIFF
--- a/lib/plugins/body_parser.js
+++ b/lib/plugins/body_parser.js
@@ -11,7 +11,7 @@ function bodyParser(options) {
         var parseMultipart = multipartParser(options);
 
         function parseBody(req, res, next) {
-                if (req.contentLength === 0 && !req.chunked)
+                if (req.getContentLength() === 0 && !req.isChunked())
                         return (next());
 
                 var parser;

--- a/lib/plugins/multipart_parser.js
+++ b/lib/plugins/multipart_parser.js
@@ -32,8 +32,8 @@ function multipartBodyParser(options) {
 
         var override = options.overrideParams;
         function parseMultipartBody(req, res, next) {
-                if (req.contentType !== 'multipart/form-data' ||
-                    (req.contentLength === 0 && !req.chunked))
+                if (req.getContentType() !== 'multipart/form-data' ||
+                    (req.getContentLength() === 0 && !req.isChunked()))
                         return (next());
 
                 var form = new formidable.IncomingForm();
@@ -52,6 +52,22 @@ function multipartBodyParser(options) {
 
                                            req.params[k] = fields[k];
                                            return (true);
+                                   });
+
+                                   Object.keys(files).forEach(function (f) {
+                                           if (req.params[f] && !override)
+                                                   return (false);
+                                           var fs = require('fs');
+                                           return fs.readFile(
+                                               files[f].path,
+                                               'utf8',
+                                               function (ex, data) {
+                                                   if (ex) {
+                                                        return (false);
+                                                   }
+                                                   req.params[f] = data;
+                                                   return (true);
+                                           });
                                    });
                            }
 


### PR DESCRIPTION
Fixes for the problems I've found on the v2.0 version with:
- bodyParser doing nothing, cause it never checked requests content type properly
- multipartParser not setting file contents to the proper k/v pairs in req.params.
