### PR TITLE
Fix log binding when pre chaining

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -88,9 +88,11 @@ function parseContentLength(req) {
 
 module.exports = {
 
-  extendRequest: function extendRequest(req) {
-    var _url = url.parse(req.url);
+  extendRequest: function extendRequest(options) {
+    var req = options.request,
+        _url = url.parse(req.url);
 
+    req.log = options.log;
     req.chunked = req.headers['transfer-encoding'] === 'chunked';
     req.contentLength = parseContentLength(req); 
     req.contentType = parseContentType(req);

--- a/lib/server.js
+++ b/lib/server.js
@@ -460,7 +460,10 @@ Server.prototype._addRoute = function _addRoute(method, options, handlers) {
 Server.prototype._request = function _request(request, response, expect100) {
   var self = this;
 
-  var req = extendRequest(request);
+  var req = extendRequest({
+    log: self.log,
+    request: request
+  });
   var res = extendResponse({
     formatters: self.formatters,
     log: self.log,

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -692,6 +692,7 @@ test('GH-64 prerouting chain', function (t) {
   var server = restify.createServer({ dtrace: DTRACE, log: LOGGER });
 
   server.pre(function (req, res, next) {
+    req.log.info('prerouting chain');
     req.headers.accept = 'application/json';
     return next();
   });


### PR DESCRIPTION
Use of req.log in server.pre was causing "TypeError: Cannot call method 'info' of undefined"

Example:

server.pre(function (req, res, next) {
  req.log.info({req: req}, 'start');
  return next();
});
