### PR TITLE
Fix probe arguments definitions

### DIFF
--- a/lib/dtrace.js
+++ b/lib/dtrace.js
@@ -27,6 +27,7 @@ function addProbes(dtrace, name) {
                                      'char *',
                                      'int',
                                      'char *',
+                                     'int',
                                      'int');
 
         // id, requestid, statusCode, content-type, content-length,
@@ -38,7 +39,6 @@ function addProbes(dtrace, name) {
                                     'char *',
                                     'int',
                                     'int',
-                                    'char *',
                                     'char *');
 
         obj.start = function fireProbeStart(req) {


### PR DESCRIPTION
Please, check that the right value on `fireProbeDone` for `res.get('content-md5')` is of type `int`.

Other than that, this PR just makes sure that the number of arguments you define for a probe matches the number of values you return when the probe is fired.
