### PR TITLE
Ensure body is given to JsonClient.post()

### DIFF
--- a/lib/clients/json_client.js
+++ b/lib/clients/json_client.js
@@ -31,7 +31,7 @@ module.exports = JsonClient;
 JsonClient.prototype.write = function write(options, body, callback) {
   if (typeof (options) !== 'object')
     throw new TypeError('options (Object) required');
-  if (body !== null && typeof (body) !== 'object')
+  if (!body || typeof (body) !== 'object')
     throw new TypeError('body (Object) required');
   if (typeof (callback) !== 'function')
     throw new TypeError('callback (Function) required');

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -178,6 +178,13 @@ test('POST json', function (t) {
   });
 });
 
+test('POST nothing', function (t) {
+    t.throws(function () {
+      client.post('/json/mcavage', function(){});
+    }, new TypeError('body (Object) required'));
+    t.end();
+});
+
 
 test('PUT json', function (t) {
   client.post('/json/mcavage', { hello: 'foo' }, function (err, req, res, obj) {


### PR DESCRIPTION
If body is was not defined, body would be null (which passes typeof
test because typeof null == 'object') and JSON.parse(body) would coerce
it to string 'null'. This got sent to the server and triggered
json_body_parser to send back InvalidContentError (Invalid JSON).

JsonClient should throw an error if body is falsy to prevent this.
