### PR TITLE
DTrace Config Option Improvement

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -77,20 +77,27 @@ function logger(log, name) {
   });
 }
 
+function getDummyDTrace() {
+    return {
+      addProbe: function addProbe() {},
+      enable: function enable() {},
+      fire: function fire() {}
+    };
+}
 
 function defaultDTrace(name) {
   // see https://github.com/mcavage/node-restify/issues/80 and
   // https://github.com/mcavage/node-restify/issues/100
   if (!DTRACE) {
-    try {
-      var d = require('dtrace-provider');
-      DTRACE = d.createDTraceProvider(name.replace(/\W+/g, '-'));
-    } catch (e) {
-      DTRACE = {
-        addProbe: function addProbe() {},
-        enable: function enable() {},
-        fire: function fire() {}
-      };
+    if (typeof name == "string") {
+      try {
+        var d = require('dtrace-provider');
+        DTRACE = d.createDTraceProvider(name.replace(/\W+/g, '-'));
+      } catch (e) {
+        DTRACE = getDummyDTrace();
+      }
+    } else {
+      DTRACE = getDummyDTrace();
     }
   }
 
@@ -113,8 +120,13 @@ module.exports = {
       options = {};
     if (!options.name)
       options.name = 'restify';
-    if (!options.dtrace)
-      options.dtrace = defaultDTrace(options.name);
+    if (!options.dtrace) { // is it equal false? then ...
+      if (typeof options.dtrace == "undefined") { // is it undefined? then set default DTrace
+        options.dtrace = defaultDTrace(options.name);
+      } else { // maybe? config going to set null value to bypass dtrace
+        options.dtrace = getDummyDTrace();
+      }
+    }
 
     options.log = logger(options.log, options.name);
 
@@ -135,8 +147,13 @@ module.exports = {
       options.name = 'restify';
     if (!options.type)
       options.type = 'application/octet-stream';
-    if (!options.dtrace)
-      options.dtrace = defaultDTrace(options.name);
+    if (!options.dtrace) { // is it equal false? then ...
+      if (typeof options.dtrace == "undefined") { // is it undefined? then set default DTrace
+        options.dtrace = defaultDTrace(options.name);
+      } else { // maybe? config going to set null value to bypass dtrace
+        options.dtrace = getDummyDTrace();
+      }
+    }
 
     options.log = logger(options.log, options.name);
 


### PR DESCRIPTION
I added functionality to config's dtrace property both `createServer` and `createClient` functions
of index.js module.

This functionality support to bind dtrace to dummy hooks already exists. When `createServer` and
`createClient` function called with `options.dtrace = null`. Then restify uses dummy provider
instead of really dtrace provider.
