### PR TITLE
Provide hook in HttpClient for request signing

### DIFF
--- a/docs/index.restdown
+++ b/docs/index.restdown
@@ -1234,6 +1234,15 @@ restify HTTP errors).  If `obj` looks like a `RestError`:
 then `err` gets "upconverted" into a `RestError` for you.  Otherwise
 it will be an `HttpError`.
 
+If you need to interpose additional headers in the request before it is
+sent on to the server, you can provide a synchronous callback function
+as the `signRequest` option when creating a client.  This is particularly
+useful with
+[node-http-signature](https://github.com/joyent/node-http-signature),
+which needs to attach a cryptographic signature of selected outgoing
+headers.  If provided, this callback will be invoked with a single parameter:
+the outgoing `http.ClientRequest` object.
+
 ### createJsonClient(options)
 
     var client = restify.createJsonClient({
@@ -1250,6 +1259,7 @@ Options:
 ||headers||Object||HTTP headers to set in all requests||
 ||log||Object||[bunyan](https://github.com/trentm/node-bunyan) instance||
 ||retry||Object||options to provide to node-retry; defaults to 3 retries||
+||signRequest||Function||synchronous callback for interposing headers before request is sent||
 ||url||String||Fully-qualified URL to connect to||
 ||userAgent||String||user-agent string to use; restify inserts one, but you can override it||
 ||version||String||semver string to set the accept-version||

--- a/lib/clients/http_client.js
+++ b/lib/clients/http_client.js
@@ -74,6 +74,8 @@ function HttpClient(options) {
     throw new TypeError('options.url (String) required');
   if (options.socketPath && typeof (options.socketPath) !== 'string')
     throw new TypeError('options.socketPath (String) required');
+  if (options.signRequest && typeof (options.signRequest) !== 'function')
+    throw new TypeError('options.signRequest (Function) required');
 
   EventEmitter.call(this);
 
@@ -86,6 +88,8 @@ function HttpClient(options) {
     (options.retry || { retries: 3 }) : false;
 
   this.socketPath = options.socketPath || false;
+
+  this.signRequest = options.signRequest || false;
 
   this.url = options.url ? url.parse(options.url) : {};
   
@@ -220,6 +224,7 @@ HttpClient.prototype.request = function request(options, callback) {
   var log = this.log.child({log_id: uuid()}, true);
   var operation = newRetryOperation(options);
   var proto = options.protocol === 'https:' ? https : http;
+  var signRequest = this.signRequest;
 
   return operation.attempt(function retryCallback(currentAttempt) {
     var timer = false;
@@ -250,6 +255,9 @@ HttpClient.prototype.request = function request(options, callback) {
 
       return req.emit('result', err, res);
     });
+
+    if (signRequest)
+      signRequest(req);
 
     req.log = log;
 


### PR DESCRIPTION
If you wish to sign requests with HttpClient (or, by extension, JsonClient)
then you need access to the ClientRequest object to read the headers sent
already and add an Authorization header with this request's signature.  This
is, for example, useful with node-http-signature.

(fix #184)
