### PR TITLE
Updated list of allowed signature types in authorization plugin

### DIFF
--- a/lib/plugins/authorization.js
+++ b/lib/plugins/authorization.js
@@ -15,7 +15,10 @@ var httpSignatureOptions = {
     'rsa-sha1',
     'rsa-sha256',
     'rsa-sha512',
-    'dsa-sha1'
+    'dsa-sha1',
+    'hmac-sha1',
+    'hmac-sha256',
+    'hmac-sha512'
   ]
 };
 


### PR DESCRIPTION
I've just updated the list of allowed algorithms to keep it in line with the http-signature project.

In its current state, if you try to use any algorithm outside the existing list (even though it is in the http-signature documentation), you will get an exception indicating that you have chosen an unsupported algorithm.

This took me a little while to track down, so I figured I'd leave this here for others.
