### PR TITLE
Allow usernameless headers

### DIFF
--- a/lib/plugins/authorization.js
+++ b/lib/plugins/authorization.js
@@ -42,8 +42,12 @@ function parseBasic(string) {
     pieces = [decoded.slice(0, index), decoded.slice(index + 1)];
   }
 
-  if (!pieces || !pieces[0])
+  if (!pieces || typeof pieces[0] !== 'string')
     throw new InvalidHeaderError('Authorization header invalid');
+
+  // Allows for usernameless authentication
+  if (!pieces[0])
+    pieces[0] = null;
 
   // Allows for passwordless authentication
   if (!pieces[1])


### PR DESCRIPTION
Don't throw an error when the provided username is an empty string.

The username is optional according to RFC 2616 11.1 Basic Authentication Scheme
