### PR TITLE
fix toString() for  restify error subclasses of WError

### DIFF
--- a/lib/clients/json_client.js
+++ b/lib/clients/json_client.js
@@ -6,7 +6,7 @@ var util = require('util');
 
 var assert = require('assert-plus');
 
-var codeToHttpError = require('../errors/http_error').codeToHttp;
+var codeToHttpError = require('../errors/http_error').codeToHttpError;
 var RestError = require('../errors').RestError;
 var StringClient = require('./string_client');
 

--- a/lib/errors/http_error.js
+++ b/lib/errors/http_error.js
@@ -54,7 +54,6 @@ function HttpError(options) {
                 message: options.message || self.message
         };
         this.message = options.message || self.message;
-        this.name = this.constructor.name || options.name;
 }
 util.inherits(HttpError, WError);
 


### PR DESCRIPTION
This fixes `(new restify.ResourceNotFoundError(msg)).toString()`
including a 'undefined: ' prefix instead of the intended
'ResourceNotFoundError: '.

Depends on https://github.com/davepacheco/node-verror/pull/4

Also fix a reference typo in json_client.js.
