### PR TITLE
include 'error' in the 'after' event and get audit logging to include that

### DIFF
--- a/docs/index.restdown
+++ b/docs/index.restdown
@@ -491,7 +491,7 @@ is expected that if you listen for this event, you respond to the client.
 
 #### Event: 'after'
 
-`function (request, response, route) {}`
+`function (request, response, route, error) {}`
 
 Emitted after a route has finished all the handlers you registered.
 You can use this to write audit logs, etc.  The route parameter will be
@@ -745,7 +745,7 @@ Audit logging is a special plugin, as you don't use it with `.use()`, but with
 the `after` event:
 
     server.on('after', restify.auditLogger({
-      log: new Logger({
+      log: bunyan.createLogger({
         name: 'audit',
         stream: process.stdout
       })

--- a/lib/plugins/audit.js
+++ b/lib/plugins/audit.js
@@ -56,7 +56,7 @@ function auditLogger(options) {
                 }
         });
 
-        function audit(req, res, route) {
+        function audit(req, res, route, err) {
                 var latency = res.getHeader('X-Response-Time');
                 if (typeof (latency) !== 'number')
                         latency = Date.now() - req._time;
@@ -67,6 +67,7 @@ function auditLogger(options) {
                         req_id: req.id,
                         req: req,
                         res: res,
+                        err: err,
                         latency: latency,
                         secure: req.secure,
                         _audit: true

--- a/lib/server.js
+++ b/lib/server.js
@@ -477,8 +477,8 @@ Server.prototype._handle = function _handle(req, res) {
 
                                 req.context = ctx;
                                 var chain = self.routes[r];
-                                self._run(req, res, r, chain, function () {
-                                        self.emit('after', req, res, r);
+                                self._run(req, res, r, chain, function (e) {
+                                        self.emit('after', req, res, r, e);
                                 });
                         }
                 });

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         },
         "dependencies": {
                 "assert-plus": "0.1.0",
-                "bunyan": "0.13.5",
+                "bunyan": "0.14.5",
                 "clone": "0.1.0",
                 "byline": "2.0.2",
                 "formidable": "1.0.11",


### PR DESCRIPTION
Getting close to nice audit logging of an error looking like this:

```
[2012-10-11T22:56:54.734Z]  INFO: imgapi/44739 on 0525989e-2086-4270-b960-41dd661ebd7d (/opt/smartdc/imgapi/node_modules/restify/lib/plugins/audit.js:76 in audit): handled: 500 (3ms, audit=true, remoteAddress=10.2.207.2, remotePort=49091, _audit=true)
    GET /stat/foo HTTP/1.1
    user-agent: curl/7.27.0
    host: 10.2.207.13
    accept: application/json
    content-type: application/json
    --
    HTTP/1.1 500 Internal Server Error
    content-type: application/json
    content-length: 51

    {
      "code": "InternalError",
      "message": "could not stat"
    }
    --
    InternalError: could not stat; caused by Error: ENOENT, stat 'foo'
        at new Object.keys.forEach.module.exports.(anonymous function) (/opt/smartdc/imgapi/lib/errors.js:147:33)
        at /opt/smartdc/imgapi/lib/app.js:215:25
        at Object.oncomplete (fs.js:297:15)
    Caused by: Error: ENOENT, stat 'foo'
```
