### PR TITLE
Properly clone crypto buffers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -56,8 +56,13 @@ module.exports = {
                 // clone can't clone something with prototypes so we need to
                 // manually set opts.log and opts.router to the right objects:
                 opts.log =
-                        opts.log ? options.log : bunyan.createLogger(opts.name);
+                opts.log ? options.log : bunyan.createLogger(opts.name);
                 opts.router = opts.router ? options.router : createRouter(opts);
+
+                // the crypto buffers suffer the same malady as the logger
+                if(Buffer.isBuffer(options.key)) opts.key = options.key;
+                if(Buffer.isBuffer(options.certificate)) opts.certificate = options.certificate;
+                if(Buffer.isBuffer(options.ca)) opts.ca = options.ca;
 
                 server = new Server(opts);
                 server.on('uncaughtException', onUncaughtException);


### PR DESCRIPTION
node-clone doesn't properly clone node's Buffer class, this fixes that.  I've created a pull request for node-clone but I don't know for sure he's going to accept it.  You can find much more detail on the issue here: https://github.com/pvorb/node-clone/pull/15
