### PR TITLE
Add 449 Error for backwards compatibility with v0.5

### DIFF
--- a/lib/errors/http_error.js
+++ b/lib/errors/http_error.js
@@ -21,6 +21,8 @@ function codeToErrorName(code) {
       status = 'Too Many Requests';
     } else if (code === 431) {
       status = 'Request Header Fields Too Large';
+    } else if (code === 449) {
+      status = 'Retry With';
     } else if (code === 511) {
       status = 'Network Authentication Required';
     } else {
@@ -84,7 +86,7 @@ module.exports = {
 var codes = Object.keys(http.STATUS_CODES);
 
 // Until https://github.com/joyent/node/pull/2371 is in
-codes.push(428, 429, 431, 511);
+codes.push(428, 429, 431, 449, 511);
 codes.forEach(function (code) {
   if (code < 400)
     return;


### PR DESCRIPTION
Which is the reason for joyent/node-smartdc#19 failures.
