### PR TITLE
Fix tests on Windows by using scripts shorthand

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,6 @@
                 "nodeunit": "0.7.4"
         },
         "scripts": {
-                "test": "./node_modules/.bin/nodeunit ./test"
+                "test": "nodeunit ./test"
         }
 }


### PR DESCRIPTION
Remember that scripts run with all devDependency binaries available in the path, as per https://npmjs.org/doc/scripts.html#path. This solves the issue wherein trying to execute the tests on Windows gives "'.' is not recognized as an internal or external command, operable program or batch file."
