### PR TITLE
fix overwriting of 'options.type' in 'createJsonClient'

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -42,15 +42,25 @@ function createClient(options) {
 
 
 function createJsonClient(options) {
-        options = options || {};
+        var clone = require('clone');
+        options = options ? clone(options) : {};
         options.type = 'json';
         return (createClient(options));
 }
 
 
 function createStringClient(options) {
-        options = options || {};
+        var clone = require('clone');
+        options = options ? clone(options) : {};
         options.type = 'string';
+        return (createClient(options));
+}
+
+
+function createHttpClient(options) {
+        var clone = require('clone');
+        options = options ? clone(options) : {};
+        options.type = 'http';
         return (createClient(options));
 }
 
@@ -114,6 +124,7 @@ module.exports = {
         createJsonClient: createJsonClient,
         createJSONClient: createJsonClient,
         createStringClient: createStringClient,
+        createHttpClient: createHttpClient,
         get HttpClient() {
                 return (require('./clients').HttpClient);
         },


### PR DESCRIPTION
This breaks calling like this:

```
this.client = restify.createJsonClient(options);
this.rawClient = restify.createClient(options);
```

The `rawClient` would not be the expected HttpClient.
