### PR TITLE
GZip prevents Content-Length from being set

### DIFF
--- a/lib/plugins/gzip.js
+++ b/lib/plugins/gzip.js
@@ -5,6 +5,10 @@ var zlib = require('zlib');
 var assert = require('assert-plus');
 
 
+function _writeHead(originalFunction) {
+        this.removeHeader('Content-Length');
+        originalFunction.apply(this, Array.prototype.slice.call(arguments, 1));
+}
 
 ///--- API
 
@@ -25,6 +29,7 @@ function gzipResponse(opts) {
                 res.write = gz.write.bind(gz);
                 res.end = gz.end.bind(gz);
 
+                res.writeHead = _writeHead.bind(res, res.writeHead);
                 res.setHeader('Content-Encoding', 'gzip');
                 next();
         }

--- a/lib/plugins/static.js
+++ b/lib/plugins/static.js
@@ -58,10 +58,7 @@ function serveStatic(opts) {
                         var fstream = fs.createReadStream(file);
                         fstream.once('open', function (fd) {
                                 res.cache({maxAge: opts.maxAge || 3600});
-
-                                if (res.get('Content-Encoding') !== 'gzip')
-                                        res.set('Content-Length', stats.size);
-
+                                res.set('Content-Length', stats.size);
                                 res.set('Content-Type', mime.lookup(file));
                                 res.set('Last-Modified', stats.mtime);
                                 res.writeHead(200);

--- a/lib/response.js
+++ b/lib/response.js
@@ -159,9 +159,6 @@ Response.prototype.send = function send(code, body, headers) {
                         self.setHeader(k, headers[k]);
                 });
 
-                if (self.getHeader('content-encoding') ===  'gzip')
-                        self.removeHeader('content-length');
-
                 self.writeHead(self.statusCode);
 
                 if (self._data && !(isHead || code === 204 || code === 304))
@@ -238,8 +235,6 @@ Response.prototype.writeHead = function restifyWriteHead() {
                 this.removeHeader('Content-Length');
                 this.removeHeader('Content-MD5');
                 this.removeHeader('Content-Type');
-        } else if (this._rstfy_gzip) {
-                this.setHeader('Content-Encoding', 'gzip');
         }
 
         this._writeHead.apply(this, arguments);


### PR DESCRIPTION
Currently the GZip plugin fails if the Content-Length header is set.  To compensate for this, implementations of various plugins (static) and infrastructure (response) have to take this fact into account.  The side-effect of this is that gzip knowledge isn't completely contained inside of the GZip plugin (poor isolation and cohesion).  In addition, it means that any library used with restify (e.g. filed) must also take this fact into account.  In reality they shouldn't have to and generally don't.

The better solution is that the GZip plugin needs to enforce the Content-Length header requirement itself and should not depend on other parts of the code to do it.  To this end, the implementation now decorates the writeHead() function such that the Content-Length header is always removed.  In addition, other references to gzip throughout the code have been removed as they are no longer needed.
