### PR TITLE
Fix usage of `clone` to not clone prototypes in create*Client().

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,11 +16,11 @@ function createClient(options) {
         assert.object(options, 'options');
 
         var client;
-        var opts = clone(options);
+        var opts = clone.clonePrototype(options);
         opts.agent = options.agent;
         opts.name = opts.name || 'restify';
         opts.type = opts.type || 'application/octet-stream';
-        opts.log = options.log || bunyan.createLogger(opts.name);
+        opts.log = opts.log || bunyan.createLogger(opts.name);
 
         switch (opts.type) {
         case 'json':
@@ -43,7 +43,7 @@ function createClient(options) {
 
 function createJsonClient(options) {
         var clone = require('clone');
-        options = options ? clone(options) : {};
+        options = options ? clone.clonePrototype(options) : {};
         options.type = 'json';
         return (createClient(options));
 }
@@ -51,7 +51,7 @@ function createJsonClient(options) {
 
 function createStringClient(options) {
         var clone = require('clone');
-        options = options ? clone(options) : {};
+        options = options ? clone.clonePrototype(options) : {};
         options.type = 'string';
         return (createClient(options));
 }
@@ -59,7 +59,7 @@ function createStringClient(options) {
 
 function createHttpClient(options) {
         var clone = require('clone');
-        options = options ? clone(options) : {};
+        options = options ? clone.clonePrototype(options) : {};
         options.type = 'http';
         return (createClient(options));
 }
@@ -72,15 +72,12 @@ function createServer(options) {
         var Router = require('./router');
         var Server = require('./server');
 
-        var opts = clone(options || {});
+        var opts = clone.clonePrototype(options || {});
         var server;
 
         opts.name = opts.name || 'restify';
-        // clone can't clone something with prototypes so we need to
-        // manually set opts.log and opts.router to the right objects:
-        opts.log =
-                opts.log ? options.log : bunyan.createLogger(opts.name);
-        opts.router = opts.router ? options.router : new Router(opts);
+        opts.log = opts.log || bunyan.createLogger(opts.name);
+        opts.router = opts.router || new Router(opts);
 
         server = new Server(opts);
         server.on('uncaughtException', function (req, res, route, e) {


### PR DESCRIPTION
Commit f49e2c2 introduced potential cloning of given `options.log`
Bunyan Logger objects in the `create{Json,String,Http}Client()` APIs.
This would result in an abort on the first log write:

```
Assertion failed: (args.Holder()->InternalFieldCount() > 0), function WriteStringImpl, file ../src/stream_wrap.cc, line 298.
Abort trap
```

Note: This also involves a semantic change in that only a _shallow_
copy of `options` is done for createServer, createClient, and
create*Client methods.
