### PR TITLE
support requests with a binary body

### DIFF
--- a/lib/plugins/body_reader.js
+++ b/lib/plugins/body_reader.js
@@ -27,13 +27,33 @@ function bodyReader(options) {
 
         var maxBodySize = options.maxBodySize || 0;
 
+        function createBodyWriter(req) {
+          var contentType = req.contentType();
+          if (!contentType ||
+            contentType === 'application/json' ||
+            contentType === 'application/x-www-form-urlencoded' ||
+            contentType === 'multipart/form-data' ||
+            contentType.substr(0, 5) === 'text/') {
+
+            req.body = '';
+            return function(chunk) {
+              req.body += chunk.toString('utf8');
+            };
+          } else {
+            req.body = new Buffer(0);
+            return function(chunk) {
+              req.body = Buffer.concat([req.body, chunk]);
+            };
+          }
+        }
+
         function readBody(req, res, next) {
                 if ((req.getContentLength() === 0 && !req.isChunked()) ||
                     req.contentType() === 'multipart/form-data') {
                         next();
                         return;
                 }
-                req.body = '';
+                var bodyWriter = createBodyWriter(req);
 
                 function done() {
                         if (maxBodySize && bytesReceived > maxBodySize) {
@@ -43,7 +63,7 @@ function bodyReader(options) {
                                 return;
                         }
 
-                        if (!req.body) {
+                        if (!req.body.length) {
                                 next();
                                 return;
                         }
@@ -67,7 +87,7 @@ function bodyReader(options) {
                 if (req.headers['content-encoding'] === 'gzip') {
                         gz = zlib.createGunzip();
                         gz.on('data', function onData(chunk) {
-                                req.body += chunk.toString('utf8');
+                                bodyWriter(chunk);
                         });
                         gz.once('end', done);
                         req.once('end', gz.end.bind(gz));
@@ -88,7 +108,7 @@ function bodyReader(options) {
                         if (gz) {
                                 gz.write(chunk);
                         } else {
-                                req.body += chunk.toString('utf8');
+                                bodyWriter(chunk);
                         }
                 });
 


### PR DESCRIPTION
if no content-type is given, or the content-type is either
one of application/json, application/x-www-form-urlencoded,
multipart/form-data or starts with text/ then encode in utf8
otherwise let req.body be a buffer.

This allow for uploading of binary data i.e. uploading of JPEG and PNG images.
