### PR TITLE
Drop unused semver require

### DIFF
--- a/lib/clients/http_client.js
+++ b/lib/clients/http_client.js
@@ -16,7 +16,6 @@ var backoff = require('backoff');
 var KeepAliveAgent = require('keep-alive-agent');
 var mime = require('mime');
 var once = require('once');
-var semver = require('semver');
 var uuid = require('node-uuid');
 
 var errors = require('../errors');


### PR DESCRIPTION
Would be helpful to clear this out so don't need to hack around it in a "light" distro of restify that just gets the pieces needed for restify client usage (which josh and I are working on for the smartos platform).
