### PR TITLE
only a shallow copy of given `options` to avoid clone-of-prototype surprises

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,20 +7,22 @@
 // and enables much faster load times
 //
 
+var shallowCopy = require('./utils').shallowCopy;
+
+
 function createClient(options) {
         var assert = require('assert-plus');
         var bunyan = require('./bunyan_helper');
         var clients = require('./clients');
-        var clone = require('clone');
 
         assert.object(options, 'options');
 
         var client;
-        var opts = clone(options);
+        var opts = shallowCopy(options);
         opts.agent = options.agent;
         opts.name = opts.name || 'restify';
         opts.type = opts.type || 'application/octet-stream';
-        opts.log = options.log || bunyan.createLogger(opts.name);
+        opts.log = opts.log || bunyan.createLogger(opts.name);
 
         switch (opts.type) {
         case 'json':
@@ -42,24 +44,21 @@ function createClient(options) {
 
 
 function createJsonClient(options) {
-        var clone = require('clone');
-        options = options ? clone(options) : {};
+        options = options ? shallowCopy(options) : {};
         options.type = 'json';
         return (createClient(options));
 }
 
 
 function createStringClient(options) {
-        var clone = require('clone');
-        options = options ? clone(options) : {};
+        options = options ? shallowCopy(options) : {};
         options.type = 'string';
         return (createClient(options));
 }
 
 
 function createHttpClient(options) {
-        var clone = require('clone');
-        options = options ? clone(options) : {};
+        options = options ? shallowCopy(options) : {};
         options.type = 'http';
         return (createClient(options));
 }
@@ -67,20 +66,16 @@ function createHttpClient(options) {
 
 function createServer(options) {
         var bunyan = require('./bunyan_helper');
-        var clone = require('clone');
         var InternalError = require('./errors').InternalError;
         var Router = require('./router');
         var Server = require('./server');
 
-        var opts = clone(options || {});
+        var opts = shallowCopy(options || {});
         var server;
 
         opts.name = opts.name || 'restify';
-        // clone can't clone something with prototypes so we need to
-        // manually set opts.log and opts.router to the right objects:
-        opts.log =
-                opts.log ? options.log : bunyan.createLogger(opts.name);
-        opts.router = opts.router ? options.router : new Router(opts);
+        opts.log = opts.log || bunyan.createLogger(opts.name);
+        opts.router = opts.router || new Router(opts);
 
         server = new Server(opts);
         server.on('uncaughtException', function (req, res, route, e) {

--- a/lib/plugins/bunyan.js
+++ b/lib/plugins/bunyan.js
@@ -1,7 +1,8 @@
 // Copyright 2012 Mark Cavage, Inc.  All rights reserved.
 
 var assert = require('assert-plus');
-var clone = require('clone');
+
+var shallowCopy = require('../utils').shallowCopy;
 
 
 
@@ -13,7 +14,7 @@ function requestLogger(options) {
 
         var props;
         if (options.properties) {
-                props = clone(options.properties);
+                props = shallowCopy(options.properties);
         } else {
                 props = {};
         }

--- a/lib/router.js
+++ b/lib/router.js
@@ -5,10 +5,10 @@ var url = require('url');
 var util = require('util');
 
 var assert = require('assert-plus');
-var clone = require('clone');
 var LRU = require('lru-cache');
 var semver = require('semver');
 
+var shallowCopy = require('./utils').shallowCopy;
 var errors = require('./errors');
 
 
@@ -291,7 +291,7 @@ Router.prototype.find = function find(req, res, callback) {
         var ver;
 
         if ((cacheVal = this.cache.get(cacheKey))) {
-                callback(null, cacheVal.name, clone(cacheVal.params));
+                callback(null, cacheVal.name, shallowCopy(cacheVal.params));
                 return;
         }
 
@@ -352,7 +352,7 @@ Router.prototype.find = function find(req, res, callback) {
                         params: params
                 };
                 this.cache.set(cacheKey, cacheVal);
-                callback(null, r.name, clone(params));
+                callback(null, r.name, shallowCopy(params));
                 return;
         }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -8,7 +8,6 @@ var url = require('url');
 var util = require('util');
 
 var assert = require('assert-plus');
-var clone = require('clone');
 var mime = require('mime');
 var once = require('once');
 var spdy = require('spdy');
@@ -16,6 +15,7 @@ var spdy = require('spdy');
 var dtrace = require('./dtrace');
 var errors = require('./errors');
 var formatters = require('./formatters');
+var shallowCopy = require('./utils').shallowCopy;
 
 // Ensure these are loaded
 require('./request');
@@ -291,7 +291,7 @@ Server.prototype.close = function close(callback) {
                                 path: opts
                         };
                 } else if (typeof (opts) === 'object') {
-                        opts = clone(opts);
+                        opts = shallowCopy(opts);
                 } else {
                         throw new TypeError('path (string) required');
                 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -54,10 +54,26 @@ function sanitizePath(path) {
 }
 
 
+/**
+ * Return a shallow copy of the given object;
+ */
+function shallowCopy(obj) {
+        if (!obj) {
+                return (obj);
+        }
+        var copy = {};
+        Object.keys(obj).forEach(function (k) {
+                copy[k] = obj[k];
+        });
+        return (copy);
+}
+
+
 
 ///--- Exports
 
 module.exports = {
         parseQuality: parseQuality,
-        sanitizePath: sanitizePath
+        sanitizePath: sanitizePath,
+        shallowCopy: shallowCopy
 };

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
                 "assert-plus": "0.1.2",
                 "backoff": "2.0.0",
                 "bunyan": "0.18.2",
-                "clone": "0.1.5",
                 "dtrace-provider": "0.2.7",
                 "formidable": "1.0.11",
                 "http-signature": "0.9.10",


### PR DESCRIPTION
This is for create*Client, <server>.{get|put|...}, etc. APIs.

Commit f49e2c2 introduced potential cloning of given `options.log`
Bunyan Logger objects in the `create{Json,String,Http}Client()` APIs.
This would result in an abort on the first log write:

```
Assertion failed: (args.Holder()->InternalFieldCount() > 0), function WriteStringImpl, file ../src/stream_wrap.cc, line 298.
    Abort trap
```

(Alternative to pull #311)
