### PR TITLE
add routeSpec to a request

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -232,7 +232,8 @@ Router.prototype.mount = function mount(options) {
                         urlParamPattern: options.urlParamPattern
                 }),
                 type: type,
-                version: version
+                version: version,
+                spec: options
         };
         routes.push(route);
 
@@ -291,7 +292,7 @@ Router.prototype.find = function find(req, res, callback) {
         var ver;
 
         if ((cacheVal = this.cache.get(cacheKey))) {
-                callback(null, cacheVal.name, clone(cacheVal.params));
+                callback(null, cacheVal, clone(cacheVal.params));
                 return;
         }
 
@@ -349,10 +350,11 @@ Router.prototype.find = function find(req, res, callback) {
         if (params && r) {
                 cacheVal = {
                         name: r.name,
-                        params: params
+                        params: params,
+                        spec: r.spec
                 };
                 this.cache.set(cacheKey, cacheVal);
-                callback(null, r.name, clone(params));
+                callback(null, r, clone(params));
                 return;
         }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -478,7 +478,8 @@ Server.prototype._handle = function _handle(req, res) {
                         }
                 }
 
-                self.router.find(req, res, function onRoute(err, r, ctx) {
+                self.router.find(req, res, function onRoute(err, route, ctx) {
+                        var r = route && route.name;
                         if (err) {
                                 if (err.statusCode === 404 &&
                                     req.method === 'OPTIONS' &&
@@ -535,6 +536,7 @@ Server.prototype._handle = function _handle(req, res) {
                                 }
 
                                 req.context = req.params = ctx;
+                                req.routeSpec = route.spec;
                                 var chain = self.routes[r];
                                 self._run(req, res, r, chain, function done(e) {
                                         self.emit('after', req, res, r, e);


### PR DESCRIPTION
Make the original parameters given to create the route available per request, this comes in handy i.e. for authorization based on method, route spec and version.
