### PR TITLE
add new server.versionedUse()

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -17,6 +17,9 @@ var dtrace = require('./dtrace');
 var errors = require('./errors');
 var formatters = require('./formatters');
 
+var semver = require('semver');
+var maxSatisfying = semver.maxSatisfying;
+
 // Ensure these are loaded
 require('./request');
 require('./response');
@@ -359,6 +362,50 @@ Server.prototype.param = function param(name, fn) {
         this.use(function _param(req, res, next) {
                 if (req.params && req.params[name]) {
                         fn.call(this, req, res, next, req.params[name], name);
+                } else {
+                        next();
+                }
+        });
+
+        return (this);
+};
+
+
+/**
+ * Piggy-backs on the `server.use` method. It attaches a new middleware
+ * function that only fires if the specified version matchtes the request.
+ *
+ * Note that if the client does not request a specific version, the middleware
+ * function always fires. If you don't want this set a default version with a
+ * pre handler on requests where the client omits one.
+ *
+ * Exposes an API:
+ *   server.versionedUse("version", function (req, res, next, ver) {
+ *     // do stuff that only applies to routes of this API version
+ *   });
+ *
+ * @param {String|Array} The version or versions of the URL to respond to
+ * @param {Function} The middleware function to execute, the fourth parameter
+ *                   will be the selected version
+ */
+Server.prototype.versionedUse = function versionedUse(versions, fn) {
+        if (!Array.isArray(versions))
+                versions = [versions];
+        assert.arrayOfString(versions, 'versions');
+
+        versions.forEach(function (v) {
+                if (semver.valid(v))
+                        return (true);
+
+                throw new InvalidArgumentError('%s is not a valid semver', v);
+        });
+
+        this.use(function _versionedUse(req, res, next) {
+                var ver;
+                if (req.version() === '*' ||
+                    (ver = maxSatisfying(versions,
+                                         req.version()) || false)) {
+                        fn.call(this, req, res, next, ver);
                 } else {
                         next();
                 }


### PR DESCRIPTION
To bind server.use to specific versions.

I found this necessary when serving multiple major API versions in one server process.
