### PR TITLE
Cache-Control max-age should show seconds, but is instead showing seconds/1000 (e.g. 3.6 vs 3600)

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -32,7 +32,7 @@ Response.prototype.cache = function cache(type, options) {
 
         if (options && options.maxAge) {
                 assert.number(options.maxAge, 'options.maxAge');
-                type += ', max-age=' + (options.maxAge / 1000);
+                type += ', max-age=' + options.maxAge;
         }
 
         return (this.header('Cache-Control', type));

--- a/test/plugins.test.js
+++ b/test/plugins.test.js
@@ -684,6 +684,7 @@ function serveStaticTest(t, testDefault) {
                                 var p = '/' + testDir + '/' + testFileName;
                                 CLIENT.get(p, function (err4, req, res, obj) {
                                         t.ifError(err4);
+                                        t.equal(res.headers['cache-control'], 'public, max-age=3600');
                                         t.deepEqual(obj, staticObj);
                                         t.end();
                                 });


### PR DESCRIPTION
This commit is a proposed fix for issue #332.
