### PR TITLE
Always parse the req.body as JSON when the header is set to 'application/json'. Shouldn't be depending on if mapParams is true or false.

### DIFF
--- a/lib/plugins/json_body_parser.js
+++ b/lib/plugins/json_body_parser.js
@@ -42,8 +42,6 @@ function jsonBodyParser(options) {
                         return;
                 }
 
-                req.body = params;
-
                 if (options.mapParams !== false) {
                         if (Array.isArray(params)) {
                                 req.params = params;
@@ -61,6 +59,8 @@ function jsonBodyParser(options) {
                 } else {
                         req._body = req.body;
                 }
+
+                req.body = params;
 
                 next();
         }


### PR DESCRIPTION
...' in header
