### PR TITLE
update to bunyan 0.20.0, bunyan 0.18.3 introduce a serializer bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "dependencies": {
                 "assert-plus": "0.1.2",
                 "backoff": "2.0.0",
-                "bunyan": "0.19.0",
+                "bunyan": "0.20.0",
                 "deep-equal": "0.0.0",
                 "formidable": "1.0.11",
                 "http-signature": "0.9.11",


### PR DESCRIPTION
Details:
https://github.com/trentm/node-bunyan/blob/master/CHANGES.md#bunyan-0183

This will only affect restify users using bunyan 0.18.3 or 0.19.0 that _also set custom serializers_. The serializers in restify itself have sufficient guards to not be hit by this. If the user is using restify's bunyan node_module, then restify versions 2.3.2, 2.3.3 and 2.3.4 are affected.
