### PR TITLE
plugins/static.js serveStatic - opts.subst() for file location control.

### DIFF
--- a/lib/plugins/static.js
+++ b/lib/plugins/static.js
@@ -24,7 +24,7 @@ function serveStatic(opts) {
         assert.string(opts.directory, 'options.directory');
         assert.optionalNumber(opts.maxAge, 'options.maxAge');
         assert.optionalObject(opts.match, 'options.match');
-        assert.optionalObject(opts.subst, 'options.subst');
+        assert.optionalFunc(opts.subst, 'options.subst');
 
         var p = path.normalize(opts.directory).replace(/\\/g, '/');
         var re = new RegExp('^' + p + '/?.*');
@@ -54,8 +54,7 @@ function serveStatic(opts) {
         }
 
         function serve(req, res, next) {
-                var file = path.join(opts.directory, 
-                                     'function' === typeof opts.subst ?
+                var file = path.join(opts.directory, opts.subst ?
                                      opts.subst(req.path()) : req.path());
 
                 if (req.method !== 'GET' && req.method !== 'HEAD') {


### PR DESCRIPTION
This patch is useful for users that want static location control. Here is the problem. If req.path() is /test then static files must be in ./public/test and i'm in situation where it's not possible to create dirs or move files around. In the other words, all html files are placed in ./public. So if i use path other then '/' serving static file is not possible. Solution is this onliner patch:

How to use it:

```
server.get(regx, restify.serveStatic({
    directory: './public',
    subst: function(rpath) {
        var match = rpath.match(new RegExp('^(' + url + ')' + '\/(.*)'));

        if(match && 3 === match.length) {
            return match[2];
        }

        return null;
    }
}))
```

subst argument (rpath) is req.path() so method should be safe.
Method returns new path that will reside inside './public' and will be used to find files.

What do you think?
