### PR TITLE
Sanitize paths ending in / or ?. Fixes GH-353

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -150,10 +150,10 @@ Request.prototype.id = Request.prototype.getId;
 
 Request.prototype.getPath = function getPath() {
         if (this._path !== undefined)
-                return (this._path);
+                return (sanitizePath(this._path));
 
         this._path = this.getUrl().pathname;
-        return (this._path);
+        return (sanitizePath(this._path));
 };
 Request.prototype.path = Request.prototype.getPath;
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -16,6 +16,10 @@ function sanitizePath(path) {
         // Be nice like apache and strip out any //my//foo//bar///blah
         path = path.replace(/\/\/+/g, '/');
 
+        // Kill a trailing '?'
+        if (path.lastIndexOf('?') === (path.length - 1) && path.length > 1)
+                path = path.substr(0, path.length - 1);
+
         // Kill a trailing '/'
         if (path.lastIndexOf('/') === (path.length - 1) && path.length > 1)
                 path = path.substr(0, path.length - 1);

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -160,6 +160,25 @@ test('GH-115 GET path with spaces', function (t) {
         });
 });
 
+test('GH-353 GET path with trailing /', function (t) {
+        JSON_CLIENT.get('/json/mcavage/', function (err, req, res, obj) {
+                t.ifError(err);
+                t.ok(req);
+                t.ok(res);
+                t.deepEqual(obj, {hello: 'mcavage'});
+                t.end();
+        });
+});
+
+test('GH-353 GET path with trailing ?', function (t) {
+        JSON_CLIENT.get('/json/mcavage/?', function (err, req, res, obj) {
+                t.ifError(err);
+                t.ok(req);
+                t.ok(res);
+                t.deepEqual(obj, {hello: 'mcavage'});
+                t.end();
+        });
+});
 
 test('Check error (404)', function (t) {
         JSON_CLIENT.get('/' + uuid(), function (err, req, res, obj) {


### PR DESCRIPTION
I noticed that the util.sanitizePath method was no longer getting applied to the request path. This patch simply adds `?` sanitization and applies the dormant functionality to the request.getPath method.
