### PR TITLE
Updated the Static module to Send .gz files if they exist.

### DIFF
--- a/lib/plugins/gzip.js
+++ b/lib/plugins/gzip.js
@@ -26,6 +26,15 @@ function gzipResponse(opts) {
                 gz.on('data', res.write.bind(res));
                 gz.once('end', res.end.bind(res));
 
+                var origWrite = res.write;
+                var origEnd = res.end;
+                var origWriteHead = res.writeHead;
+                res.handledGzip = function() {
+                    res.write = origWrite;
+                    res.end = origEnd;
+                    res.writeHead = origWriteHead;
+                }
+
                 res.write = gz.write.bind(gz);
                 res.end = gz.end.bind(gz);
 

--- a/lib/plugins/static.js
+++ b/lib/plugins/static.js
@@ -28,7 +28,7 @@ function serveStatic(opts) {
         var p = path.normalize(opts.directory).replace(/\\/g, '/');
         var re = new RegExp('^' + p + '/?.*');
 
-        function serveFileFromStats(file, err, stats, req, res, next) {
+        function serveFileFromStats(file, err, stats, isGzipped, req, res, next) {
                 if (err) {
                         next(new ResourceNotFoundError(err,
                                                 req.path()));
@@ -38,17 +38,50 @@ function serveStatic(opts) {
                         return;
                 }
 
-                var fstream = fs.createReadStream(file);
+                if (res.handledGzip && isGzipped) {
+                    res.handledGzip();
+                }
+
+                var fstream = fs.createReadStream(file + (isGzipped ? '.gz' : ''));
                 fstream.once('open', function (fd) {
                         res.cache({maxAge: opts.maxAge || 3600});
                         res.set('Content-Length', stats.size);
                         res.set('Content-Type', mime.lookup(file));
                         res.set('Last-Modified', stats.mtime);
+                        if (opts.etag) {
+                            res.set('ETag', opts.etag(stats, opts));
+                        }
                         res.writeHead(200);
                         fstream.pipe(res);
                         fstream.once('end', function () {
                                 next(false);
                         });
+                });
+        }
+
+        function serveNormal(file, req, res, next) {
+                fs.stat(file, function (err, stats) {
+                        if (!err && stats.isDirectory() && opts.default) {
+                                // Serve an index.html page or similar
+                                file = path.join(opts.directory, opts.default);
+                                fs.stat(file, function (dirErr, dirStats) {
+                                        serveFileFromStats(file,
+                                                           dirErr,
+                                                           dirStats,
+                                                           false,
+                                                           req,
+                                                           res,
+                                                           next);
+                                });
+                        } else {
+                                serveFileFromStats(file,
+                                                   err,
+                                                   stats,
+                                                   false,
+                                                   req,
+                                                   res,
+                                                   next);
+                        }
                 });
         }
 
@@ -70,27 +103,25 @@ function serveStatic(opts) {
                         return;
                 }
 
-                fs.stat(file, function (err, stats) {
-                        if (!err && stats.isDirectory() && opts.default) {
-                                // Serve an index.html page or similar
-                                file = path.join(file, opts.default);
-                                fs.stat(file, function (dirErr, dirStats) {
-                                        serveFileFromStats(file,
-                                                           dirErr,
-                                                           dirStats,
-                                                           req,
-                                                           res,
-                                                           next);
-                                });
-                        } else {
-                                serveFileFromStats(file,
+                if (opts.gzip && req.acceptsEncoding('gzip')) {
+                    fs.stat(file+".gz", function (err, stats) {
+                        if (!err) {
+                            res.setHeader('Content-Encoding', 'gzip');
+                            serveFileFromStats(file,
                                                    err,
                                                    stats,
+                                                   true,
                                                    req,
                                                    res,
                                                    next);
+                        } else {
+                            serveNormal(file, req, res, next);
                         }
-                });
+                    });
+                } else {
+                   serveNormal(file, req, res, next);
+                }
+
         }
 
         return (serve);


### PR DESCRIPTION
(i.e. files ending with a .gz)   So if the request is "abc.js" and a "abc.js.gz" file exists it will serve that one first.   Will work with the gzip module and disable the gzipping for that request.
