### PR TITLE
Curly braces parameters to routes

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -98,6 +98,15 @@ function compileURL(options) {
                                 pattern += '([a-zA-Z0-9-_~\\.%@]+)';
                         }
                         params.push(frag.slice(1));
+                // Add support for /foo/{id} syntax
+                } else if (frag.match(/^\{([^}]+)\}$/)) {
+                        if (options.urlParamPattern) {
+                                pattern += '(' + options.urlParamPattern + ')';
+                        } else {
+                                // Strictly adhere to RFC3986
+                                pattern += '([a-zA-Z0-9-_~\\.%@]+)';
+                        }
+                        params.push(frag.substring(1, frag.length-1));
                 } else {
                         pattern += frag;
                 }


### PR DESCRIPTION
E.g: /foo/{id}
This is the syntax used by
[crossroads](https://github.com/millermedeiros/crossroads.js) to perform client-
side routing. It would be nice to declare routes the same way, for both
client and server side.
