### PR TITLE
Piping large response bodies with Gzip in Node 0.10 hangs the response

### DIFF
--- a/lib/plugins/gzip.js
+++ b/lib/plugins/gzip.js
@@ -25,6 +25,7 @@ function gzipResponse(opts) {
 
                 gz.on('data', res.write.bind(res));
                 gz.once('end', res.end.bind(res));
+                gz.on('drain', res.emit.bind(res, 'drain'));
 
                 res.write = gz.write.bind(gz);
                 res.end = gz.end.bind(gz);


### PR DESCRIPTION
##### Steps to reproduce
1. Use Node 0.10 (does not occur in 0.8).
2. Set up restify to serve static files with Gzip.
3. Request a file larger than the fs.createReadStream buffer size, which is 65536 by default (I encountered this using a 468K file).
4. Client receives 15 bytes of body content before the connection hangs until timing out.
##### Root cause
1. The static module's fstream writes the first chunk to the Gzip stream.
2. Gzip's write returns false indicating a full Gzip buffer.
3. Later, Gzip's stream emits a drain event, so it is time to write more.
4. Nothing in the restify gzip plugin is listening for this drain event, so the fstream makes no more progress.
##### Proposed fix
- In the gzip plugin, forward the Gzip stream drain event to the response stream.
