### PR TITLE
Route /\/.*/ does not match request /?

### DIFF
--- a/lib/plugins/pre/pre_path.js
+++ b/lib/plugins/pre/pre_path.js
@@ -18,7 +18,7 @@ function strip(path) {
                 if (i !== path.length - 1)
                         next = path.charAt(i + 1);
 
-                if (cur === '/' && (next === '/' || next === '?'))
+                if (cur === '/' && (next === '/' || (next === '?' && i > 0)))
                         continue;
 
                 str += cur;

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1066,6 +1066,23 @@ test('GH-323: <url>/<path>/?<queryString> broken', function (t) {
 });
 
 
+test('<url>/?<queryString> broken', function (t) {
+        SERVER.pre(restify.pre.sanitizePath());
+        SERVER.use(restify.queryParser());
+        SERVER.get(/\/.*/, function (req, res, next) {
+                res.send(req.params);
+        });
+
+        SERVER.listen(8080, function () {
+                CLIENT.get('/?bar=baz', function (err, _, __, obj) {
+                        t.ifError(err);
+                        t.deepEqual(obj, {bar: 'baz'});
+                        t.end();
+                });
+        });
+});
+
+
 test('content-type routing vendor', function (t) {
         SERVER.post({
                 name: 'foo',


### PR DESCRIPTION
**Steps to reproduce**
1. Set server to use pre-filter `restify.pre.sanitizePath()`
2. Register a route with pattern such as `/\/.*/`
3. Make a request to `/?`
4. Server returns ResourceNotFound instead of using the route

**Root cause**
1. `pre.sanitizePath` converts all sequences of `/?` into `?`, which makes sense for `/foo/?bar=baz`
2. In the case where the request path starts with `/?`, the sanitized path is now just `?`
3. Node's `url.parse` converts `?` into `{ pathname: null, ... }`
4. Restify uses the pathname to match routes, and matching against null would make most legitimate routes fail (and `/null/` would succeed, interestingly)

**Proposed resolution**
- In `pre.sanitizePath`, leave `/?` at the start of a request URL alone, instead of converting to `?`
