### PR TITLE
Fixes #379 Static plugin: NotAuthorizedError for file path with parentheses

### DIFF
--- a/lib/plugins/static.js
+++ b/lib/plugins/static.js
@@ -2,6 +2,7 @@
 
 var fs = require('fs');
 var path = require('path');
+var escapeRE = require('escape-regexp-component');
 
 var assert = require('assert-plus');
 var mime = require('mime');
@@ -26,7 +27,7 @@ function serveStatic(opts) {
         assert.optionalObject(opts.match, 'options.match');
 
         var p = path.normalize(opts.directory).replace(/\\/g, '/');
-        var re = new RegExp('^' + p + '/?.*');
+        var re = new RegExp('^' + escapeRE(p) + '/?.*');
 
         function serveFileFromStats(file, err, stats, isGzip, req, res, next) {
                 if (err) {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
                 "backoff": "2.1.0",
                 "bunyan": "0.21.1",
                 "deep-equal": "0.0.0",
+                "escape-regexp-component": "1.0.2",
                 "formidable": "1.0.13",
                 "http-signature": "0.9.11",
                 "keep-alive-agent": "0.0.1",

--- a/test/plugins.test.js
+++ b/test/plugins.test.js
@@ -713,13 +713,13 @@ test('gzip body json ok', function (t) {
 });
 
 
-function serveStaticTest(t, testDefault) {
+function serveStaticTest(t, testDefault, tmpDir) {
         var staticContent = '{"content": "abcdefg"}';
         var staticObj = JSON.parse(staticContent);
         var testDir = 'public';
         var testFileName = 'index.json';
         var routeName = 'GET wildcard';
-        var tmpPath = path.join(process.cwd(), '.tmp');
+        var tmpPath = path.join(process.cwd(), tmpDir);
         fs.mkdir(tmpPath, function (err) {
                 DIRS_TO_DELETE.push(tmpPath);
                 var folderPath = path.join(tmpPath, testDir);
@@ -758,9 +758,13 @@ function serveStaticTest(t, testDefault) {
 }
 
 test('static serves static files', function (t) {
-        serveStaticTest(t, false);
+        serveStaticTest(t, false, '.tmp');
 });
 
 test('static serves default file', function (t) {
-        serveStaticTest(t, true);
+        serveStaticTest(t, true, '.tmp');
+});
+
+test('GH-379 static serves file with parentheses in path', function (t) {
+        serveStaticTest(t, false, '.(tmp)');
 });


### PR DESCRIPTION
Preemptively, also escapes other characters used in regular expressions.
