### PR TITLE
req_id is not logging in audit logger plugin. I just fixed it.

### DIFF
--- a/lib/plugins/audit.js
+++ b/lib/plugins/audit.js
@@ -74,7 +74,7 @@ function auditLogger(options) {
                 var obj = {
                         remoteAddress: req.connection.remoteAddress,
                         remotePort: req.connection.remotePort,
-                        req_id: req.id,
+                        req_id: req.getId(),
                         req: req,
                         res: res,
                         err: err,


### PR DESCRIPTION
Hi Mark,

I just found that req_id property wasn't logging using audit logger. I fixed it. Please take time to merge it back to repo.

Cheers,
Khaja.
