### PR TITLE
Routes using regex may invalidate other routes

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -377,7 +377,7 @@ Server.prototype.close = function close(callback) {
                                 opts.name += '-' + opts.versions.join('--');
                         }
                 }
-                opts.name = opts.name.replace(/\W/g, '').toLowerCase();
+                opts.name = new Buffer(opts.name).toString('base64');
 
                 if (!(route = this.router.mount(opts)))
                         return (false);


### PR DESCRIPTION
To avoid duplicate method.names for different regexp a different sanitization has to be done.

In my case I've got two get routes

```
server.get("/image", routes.images.getImagesList);
server.get(/^(\/image\/)(.*)/, routes.images.getImage);
```

When setting it up like that, a request to `/image` will land a Resource not found error for `/image`, a request to `/image/1.jpg` works. When switching the order: `/image` does work, but `/image/1.jpg` does not work.

This seems to be due to a line in `server.js`:

```
opts.name = opts.name.replace(/\W/g, '').toLowerCase();
```

This will provide a name `getimage` for both routes.

When changing that line to `opts.name = new Buffer(opts.name).toString('base64');` the problem is solved.
