### PR TITLE
decode URI before building file path in order to serve files with specia...

### DIFF
--- a/lib/plugins/static.js
+++ b/lib/plugins/static.js
@@ -93,7 +93,7 @@ function serveStatic(opts) {
         }
 
         function serve(req, res, next) {
-                var file = path.join(opts.directory, req.path());
+                var file = path.join(opts.directory, decodeURIComponent(req.path()));
 
                 if (req.method !== 'GET' && req.method !== 'HEAD') {
                         next(new MethodNotAllowedError(req.method));


### PR DESCRIPTION
...l characters that need to be encoded in the URI
