### PR TITLE
HTTP Upgrade requests should be able to use the regular request processing path

### DIFF
--- a/docs/index.restdown
+++ b/docs/index.restdown
@@ -142,6 +142,7 @@ below (and `listen()` takes the same arguments as node's
 ||name||String||By default, this will be set in the `Server` response header, default is `restify` ||
 ||spdy||Object||Any options accepted by [node-spdy](https://github.com/indutny/node-spdy)||
 ||version||String||A default version to set for all routes||
+||handleUpgrades||Boolean||Hook the `upgrade` event from the node HTTP server, pushing `Connection: Upgrade` requests through the regular request handling chain; defaults to `false`||
 
 ## Common handlers: server.use()
 
@@ -293,6 +294,45 @@ server creation time.  Lastly, you can support multiple versions in the API
 by using an array:
 
       server.get({path: PATH, version: ['2.0.0', '2.1.0']}, sendV2);
+
+## Upgrade Requests
+
+Incoming HTTP requests that contain a `Connection: Upgrade` header are treated
+somewhat differently by the node HTTP server.  If you want restify to push
+Upgrade requests through the regular routing chain, you need to enable
+`handleUpgrades` when creating the server.
+
+To determine if a request is eligible for Upgrade, check for the existence of
+`res.claimUpgrade()`.  This method will return an object with two properties:
+the `socket` of the underlying connection, and the first received data `Buffer`
+as `head` (may be zero-length).
+
+Once `res.claimUpgrade()` is called, `res` itself is marked unusable for
+further HTTP responses; any later attempt to `send()` or `end()`, etc, will
+throw an `Error`.  Likewise if `res` has already been used to send at least
+part of a response to the client, `res.claimUpgrade()` will throw an `Error`.
+Upgrades and regular HTTP Response behaviour are mutually exclusive on any
+particular connection.
+
+Using the Upgrade mechanism, you can use a library like
+[watershed](https://github.com/jclulow/node-watershed) to negotiate WebSockets
+connections.  For example:
+    var ws = new Watershed();
+    server.get('/websocket/attach', function upgradeRoute(req, res, next) {
+      if (!res.claimUpgrade) {
+        next(new Error('Connection Must Upgrade For WebSockets'));
+        return;
+      }
+
+      var upgrade = res.claimUpgrade();
+      var shed = ws.accept(req, upgrade.socket, upgrade.head);
+      shed.on('text', function(msg) {
+        console.log('Received message from websocket client: ' + msg);
+      });
+      shed.send('hello there!');
+
+      next(false);
+    });
 
 ## Content Negotiation
 
@@ -1643,3 +1683,32 @@ Since it hasn't been mentioned yet, this convenience method (available
 on all clients), just sets the `Authorization` header for all HTTP requests:
 
     client.basicAuth('mark', 'mysupersecretpassword');
+
+### Upgrades
+
+If you successfully negotiate an Upgrade with the HTTP server, an
+`upgradeResult` event will be emitted with the arguments `err`, `res`, `socket`
+and `head`.  You can use this functionality to establish a WebSockets
+connection with a server.  For example, using the
+[watershed](https://github.com/jclulow/node-watershed) library:
+
+    var ws = new Watershed();
+    var wskey = ws.generateKey();
+    var options = {
+      path: '/websockets/attach',
+      headers: {
+        connection: 'upgrade',
+        upgrade: 'websocket',
+        'sec-websocket-key': wskey,
+      }
+    };
+    client.get(options, function(err, res, socket, head) {
+      req.once('upgradeResult', function(err, res, socket, head) {
+        var shed = ws.connect(res, socket, head, wskey);
+        shed.on('text', function(msg) {
+          console.log('message from server: ' + msg);
+          shed.end();
+        });
+        shed.send('greetings program');
+      });
+    });

--- a/lib/clients/http_client.js
+++ b/lib/clients/http_client.js
@@ -152,6 +152,24 @@ function rawRequest(opts, cb) {
                 }
         });
 
+        req.once('upgrade', function onUpgrade(res, socket, _head) {
+                clearTimeout(timer);
+                dtrace._rstfy_probes['client-response'].fire(function () {
+                        return ([ id, res.statusCode, res.headers ]);
+                });
+                log.trace({client_res: res}, 'Upgrade Response received');
+
+                res.log = log;
+
+                var err;
+                if (res.statusCode >= 400)
+                        err = errors.codeToHttpError(res.statusCode);
+
+                req.removeAllListeners('error');
+                req.removeAllListeners('socket');
+                req.emit('upgradeResult', (err || null), res, socket, _head);
+        });
+
         req.once('socket', function onSocket(socket) {
                 if (socket.writable && !socket._connecting) {
                         clearTimeout(timer);
@@ -443,3 +461,4 @@ HttpClient.prototype._options = function (method, options) {
 
         return (opts);
 };
+// vim: set ts=8 sts=8 sw=8 et:

--- a/lib/request.js
+++ b/lib/request.js
@@ -86,6 +86,11 @@ Request.prototype.getContentLength = function getContentLength() {
         if (this._clen !== undefined)
                 return (this._clen === false ? undefined : this._clen);
 
+        // We should not attempt to read and parse the body of an
+        // Upgrade request, so force Content-Length to zero:
+        if (this.isUpgradeRequest())
+                return (0);
+
         var len = this.header('content-length');
         if (!len) {
                 this._clen = false;
@@ -273,6 +278,14 @@ Request.prototype.isSecure = function isSecure() {
 
         this._secure = this.connection.encrypted ? true : false;
         return (this._secure);
+};
+
+
+Request.prototype.isUpgradeRequest = function isUpgradeRequest() {
+        if (this._upgradeRequest !== undefined)
+                return (this._upgradeRequest);
+        else
+                return (false);
 };
 
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -17,6 +17,7 @@ var dtrace = require('./dtrace');
 var errors = require('./errors');
 var formatters = require('./formatters');
 var shallowCopy = require('./utils').shallowCopy;
+var upgrade = require('./upgrade');
 
 var semver = require('semver');
 var maxSatisfying = semver.maxSatisfying;
@@ -41,8 +42,7 @@ var PROXY_EVENTS = [
         'connection',
         'error',
         'listening',
-        'secureConnection',
-        'upgrade'
+        'secureConnection'
 ];
 
 
@@ -216,6 +216,8 @@ function Server(options) {
 
         this.router.on('mount', this.emit.bind(this, 'mount'));
 
+        if (!options.handleUpgrades)
+                PROXY_EVENTS.push('upgrade');
         PROXY_EVENTS.forEach(function (e) {
                 self.server.on(e, self.emit.bind(self, e));
         });
@@ -233,6 +235,16 @@ function Server(options) {
                 self._setupRequest(req, res);
                 self._handle(req, res, true);
         });
+
+        if (options.handleUpgrades) {
+                this.server.on('upgrade', function onUpgrade(req, socket,
+                    head) {
+                        req._upgradeRequest = true;
+                        var res = upgrade.createResponse(req, socket, head);
+                        self._setupRequest(req, res);
+                        self._handle(req, res);
+                });
+        }
 
         this.server.on('request', function onRequest(req, res) {
                 /* JSSTYLED */
@@ -771,3 +783,5 @@ Server.prototype._setupRequest = function _setupRequest(req, res) {
         res.serverName = this.name;
         res.version = this.router.versions[this.router.versions.length - 1];
 };
+
+// vim: set et ts=8 sts=8 sw=8:

--- a/lib/upgrade.js
+++ b/lib/upgrade.js
@@ -1,0 +1,181 @@
+// Copyright (c) 2013, Joyent, Inc. All rights reserved.
+
+var EventEmitter = require('events').EventEmitter;
+var util = require('util');
+var assert = require('assert-plus');
+
+function InvalidUpgradeStateError(msg) {
+        if (Error.captureStackTrace)
+                Error.captureStackTrace(this, InvalidUpgradeStateError);
+
+        this.message = msg;
+        this.name = 'InvalidUpgradeStateError';
+}
+util.inherits(InvalidUpgradeStateError, Error);
+
+//
+// The Node HTTP Server will, if we handle the 'upgrade' event, swallow any
+// Request with the 'Connection: upgrade' header set.  While doing this it
+// detaches from the 'data' events on the Socket and passes the socket to
+// us, so that we may take over handling for the connection.
+//
+// Unfortunately, the API does not presently provide a http.ServerResponse
+// for us to use in the event that we do not wish to upgrade the connection.
+// This factory method provides a skeletal implementation of a
+// restify-compatible response that is sufficient to allow the existing
+// request handling path to work, while allowing us to perform _at most_ one
+// of either:
+//
+//   - Return a basic HTTP Response with a provided Status Code and
+//     close the socket.
+//   - Upgrade the connection and stop further processing.
+//
+// To determine if an upgrade is requested, a route handler would check for
+// the 'claimUpgrade' method on the Response.  The object this method
+// returns will have the 'socket' and 'head' Buffer emitted with the
+// 'upgrade' event by the http.Server.  If the upgrade is not possible, such
+// as when the HTTP head (or a full request) has already been sent by some
+// other handler, this method will throw.
+//
+function createServerUpgradeResponse(req, socket, head) {
+        return (new ServerUpgradeResponse(socket, head));
+}
+
+function ServerUpgradeResponse(socket, head) {
+        assert.object(socket, 'socket');
+        assert.buffer(head, 'head');
+
+        EventEmitter.call(this);
+
+        this.sendDate = true;
+        this.statusCode = 400;
+
+        this._upgrade = {
+                socket: socket,
+                head: head
+        };
+
+        this._headWritten = false;
+        this._upgradeClaimed = false;
+}
+util.inherits(ServerUpgradeResponse, EventEmitter);
+
+function notImplemented(method) {
+        if (!method.throws) {
+                return function () {
+                        return (method.returns);
+                };
+        } else {
+                return function () {
+                        throw (new Error('Method ' + method.name + ' is not ' +
+                            'implemented!'));
+                };
+        }
+}
+
+var NOT_IMPLEMENTED = [
+        { name: 'writeContinue', throws: true },
+        { name: 'setHeader', throws: false, returns: null },
+        { name: 'getHeader', throws: false, returns: null },
+        { name: 'getHeaders', throws: false, returns: {} },
+        { name: 'removeHeader', throws: false, returns: null },
+        { name: 'addTrailer', throws: false, returns: null },
+        { name: 'cache', throws: false, returns: 'public' },
+        { name: 'format', throws: true },
+        { name: 'set', throws: false, returns: null },
+        { name: 'get', throws: false, returns: null },
+        { name: 'headers', throws: false, returns: {} },
+        { name: 'header', throws: false, returns: null },
+        { name: 'json', throws: false, returns: null },
+        { name: 'link', throws: false, returns: null }
+];
+NOT_IMPLEMENTED.forEach(function (method) {
+        ServerUpgradeResponse.prototype[method.name] = notImplemented(method);
+});
+
+ServerUpgradeResponse.prototype._writeHeadImpl = function _writeHeadImpl(
+statusCode, reason) {
+        if (this._headWritten)
+                return;
+        this._headWritten = true;
+
+        if (this._upgradeClaimed)
+                throw new InvalidUpgradeStateError('Upgrade already claimed!');
+
+        var head = [
+                'HTTP/1.1 ' + statusCode + ' ' + reason,
+                'Connection: close'
+        ];
+        if (this.sendDate)
+                head.push('Date: ' + new Date().toUTCString());
+
+        this._upgrade.socket.write(head.join('\r\n') + '\r\n');
+};
+
+ServerUpgradeResponse.prototype.status = function status(code) {
+        assert.number(code, 'code');
+        this.statusCode = code;
+        return (code);
+};
+
+ServerUpgradeResponse.prototype.send = function send(code, body) {
+        if (typeof (code) === 'number')
+                this.statusCode = code;
+        else
+                body = code;
+
+        if (typeof (body) === 'object') {
+                if (typeof (body.statusCode) === 'number')
+                        this.statusCode = body.statusCode;
+                if (typeof (body.message) === 'string')
+                        this.statusReason = body.message;
+        }
+
+        return (this.end());
+};
+
+ServerUpgradeResponse.prototype.end = function end() {
+        this._writeHeadImpl(this.statusCode, 'Connection Not Upgraded');
+        this._upgrade.socket.end('\r\n');
+        return (true);
+};
+
+ServerUpgradeResponse.prototype.write = function write() {
+        this._writeHeadImpl(this.statusCode, 'Connection Not Upgraded');
+        return (true);
+};
+
+ServerUpgradeResponse.prototype.writeHead = function writeHead(statusCode,
+reason) {
+        assert.number(statusCode, 'statusCode');
+        assert.optionalString(reason, 'reason');
+
+        this.statusCode = statusCode;
+        if (!reason)
+                reason = 'Connection Not Upgraded';
+
+        if (this._headWritten)
+                throw new Error('Head already written!');
+
+        return (this._writeHeadImpl(statusCode, reason));
+};
+
+ServerUpgradeResponse.prototype.claimUpgrade = function claimUpgrade() {
+        if (this._upgradeClaimed)
+                throw new InvalidUpgradeStateError('Upgrade already claimed!');
+
+        if (this._headWritten)
+                throw new InvalidUpgradeStateError('Upgrade already aborted!');
+
+        this._upgradeClaimed = true;
+
+        return (this._upgrade);
+};
+
+module.exports = {
+        createResponse: createServerUpgradeResponse,
+
+        InvalidUpgradeStateError: InvalidUpgradeStateError
+};
+
+// vim: set et ts=8 sts=8 sw=8:

--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
         "devDependencies": {
                 "cover": "0.2.8",
                 "filed": "0.0.7",
-                "nodeunit": "0.8.0"
+                "nodeunit": "0.8.0",
+                "watershed": "0.1.0"
         },
         "scripts": {
                 "test": "nodeunit ./test"

--- a/test/lib/helper.js
+++ b/test/lib/helper.js
@@ -52,7 +52,7 @@ module.exports = {
         get dtrace() {
                 var dtp;
                 try {
-                        var d = require('dtrace-prodiver');
+                        var d = require('dtrace-provider');
                         dtp = d.createDTraceProvider('restifyUnitTest');
                 } catch (e) {
                         dtp = null;

--- a/test/upgrade.test.js
+++ b/test/upgrade.test.js
@@ -1,0 +1,413 @@
+// Copyright (c) 2013, Joyent, Inc. All rights reserved.
+// vim: set ts=8 sts=8 sw=8 et:
+
+var http = require('http');
+
+var Watershed = require('watershed').Watershed;
+
+var HttpError = require('../lib/errors').HttpError;
+var RestError = require('../lib/errors').RestError;
+var InvalidUpgradeStateError =
+        require('../lib/upgrade').InvalidUpgradeStateError;
+var restify = require('../lib');
+
+if (require.cache[__dirname + '/lib/helper.js'])
+        delete require.cache[__dirname + '/lib/helper.js'];
+var helper = require('./lib/helper.js');
+
+
+
+///--- Globals
+
+var after = helper.after;
+var before = helper.before;
+var test = helper.test;
+
+var PORT = process.env.UNIT_TEST_PORT || 0;
+var CLIENT;
+var SERVER;
+var WATERSHED = new Watershed();
+var SHEDLIST = [];
+
+var TIMEOUT = 15000;
+
+///--- Test Helper
+
+function
+finish_latch(_test, _names)
+{
+        var complete = false;
+        var t = _test;
+        var names = _names;
+        var iv = setTimeout(function () {
+                if (complete)
+                        return;
+
+                complete = true;
+                t.ok(false, 'timeout after ' + TIMEOUT + 'ms');
+                t.ok(false, 'remaining latches: ' +
+                            Object.keys(names).join(', '));
+                t.done();
+        }, TIMEOUT);
+        return (function (name, err) {
+                if (complete)
+                        return;
+
+                if (names[name] === undefined) {
+                        complete = true;
+                        t.ok(false, 'latch name "' + name +
+                            '" not expected');
+                        t.ok(false, 'remaining latches: ' +
+                            Object.keys(names).join(', '));
+                        t.done();
+                        return;
+                }
+
+                if (--names[name] === 0)
+                        delete names[name];
+
+                /*
+                 * Check that all latch names are done, and if so,
+                 * end the test:
+                 */
+                if (Object.keys(names).length === 0) {
+                        complete = true;
+                        clearTimeout(iv);
+                        iv = null;
+                        t.done();
+                }
+        });
+}
+
+
+///--- Tests
+
+before(function (cb) {
+        try {
+                SERVER = restify.createServer({
+                        dtrace: helper.dtrace,
+                        log: helper.getLog('server'),
+                        version: ['2.0.0', '0.5.4', '1.4.3'],
+                        handleUpgrades: true
+                });
+                SERVER.listen(PORT, '127.0.0.1', function () {
+                        PORT = SERVER.address().port;
+                        CLIENT = restify.createHttpClient({
+                                url: 'http://127.0.0.1:' + PORT,
+                                dtrace: helper.dtrace,
+                                retry: false
+                        });
+
+                        cb();
+                });
+        } catch (e) {
+                console.error(e.stack);
+                process.exit(1);
+        }
+});
+
+
+after(function (cb) {
+        try {
+                CLIENT.close();
+                SERVER.close(function () {
+                        CLIENT = null;
+                        SERVER = null;
+                        cb();
+                });
+                while (SHEDLIST.length > 0) {
+                        SHEDLIST.pop().destroy();
+                }
+        } catch (e) {
+                console.error(e.stack);
+                process.exit(1);
+        }
+});
+
+
+test('GET without upgrade headers', function (t) {
+        var done = finish_latch(t, {
+                'client response': 1,
+                'server response': 1
+        });
+
+        SERVER.get('/attach', function (req, res, next) {
+                t.ok(!res.claimUpgrade, 'res.claimUpgrade not present');
+                res.send(400);
+                next();
+                done('server response');
+        });
+
+        var options = {
+                headers: {
+                        'uprgade': 'ebfrockets'
+                },
+                path: '/attach'
+        };
+        CLIENT.get(options, function (err, req) {
+                t.ifError(err);
+                req.on('error', function (err2) {
+                        t.ifError(err2);
+                        done('client error');
+                });
+                req.on('result', function (err2, res) {
+                        if (err2 && err2.name !== 'BadRequestError')
+                                t.ifError(err2);
+                        t.equal(res.statusCode, 400);
+                        res.on('end', function () {
+                                done('client response');
+                        });
+                });
+                req.on('upgradeResult', function (err2, res) {
+                        done('server upgraded unexpectedly');
+                });
+        });
+});
+
+
+test('Dueling upgrade and response handling 1', function (t) {
+        var done = finish_latch(t, {
+                'expected requestUpgrade error': 1,
+                'client response': 1
+        });
+
+        SERVER.get('/attach', function (req, res, next) {
+                try {
+                        res.send(400);
+                } catch (ex) {
+                        t.ifError(ex);
+                        done('unxpected res.send error');
+                        return;
+                }
+
+                try {
+                        var upg = res.claimUpgrade();
+                        upg.socket.destroy();
+                } catch (ex) {
+                        done('expected requestUpgrade error');
+                }
+                next(false);
+        });
+
+        var wskey = WATERSHED.generateKey();
+        var options = {
+                headers: {
+                        'connection': 'upgrade',
+                        'upgrade': 'websocket',
+                        'sec-websocket-key': wskey
+                },
+                path: '/attach'
+        };
+        CLIENT.get(options, function (err, req) {
+                t.ifError(err);
+                req.on('error', function (err2) {
+                        t.ifError(err2);
+                        done('client error');
+                });
+                req.on('result', function (err2, res) {
+                        if (err2 && err2.name !== 'BadRequestError')
+                                t.ifError(err2);
+                        t.equal(res.statusCode, 400);
+                        res.on('end', function () {
+                                done('client response');
+                        });
+                });
+                req.on('upgradeResult', function (err2, res) {
+                        done('server upgraded unexpectedly');
+                });
+        });
+});
+
+
+test('Dueling upgrade and response handling 2', function (t) {
+        var done = finish_latch(t, {
+                'expected res.send error': 1,
+                'expected server to reset': 1
+        });
+
+        SERVER.get('/attach', function (req, res, next) {
+                try {
+                        var upg = res.claimUpgrade();
+                        upg.socket.destroy();
+                } catch (ex) {
+                        t.ifError(ex);
+                        done('unexpected requestUpgrade error');
+                }
+
+                try {
+                        res.send(400);
+                } catch (ex) {
+                        if (ex.name !== 'InvalidUpgradeStateError')
+                                t.ifError(ex);
+                        done('expected res.send error');
+                        return;
+                }
+
+                next(false);
+        });
+
+        var wskey = WATERSHED.generateKey();
+        var options = {
+                headers: {
+                        'connection': 'upgrade',
+                        'upgrade': 'websocket',
+                        'sec-websocket-key': wskey
+                },
+                path: '/attach'
+        };
+        CLIENT.get(options, function (err, req) {
+                t.ifError(err);
+                done('expected server to reset');
+                return;
+        });
+});
+
+
+test('GET with upgrade headers', function (t) {
+        var done = finish_latch(t, {
+                'client shed end': 1,
+                'server shed end': 1
+        });
+
+        SERVER.get('/attach', function (req, res, next) {
+                t.ok(res.claimUpgrade, 'res.claimUpgrade present');
+                t.doesNotThrow(function () {
+                        var upgrade = res.claimUpgrade();
+                        var shed = WATERSHED.accept(req, upgrade.socket,
+                            upgrade.head);
+                        SHEDLIST.push(shed);
+                        shed.end('ok we\'re done here');
+                        shed.on('error', function (err) {
+                                t.ifError(err);
+                                done('server shed error');
+                        });
+                        shed.on('end', function () {
+                                done('server shed end');
+                        });
+                        next(false);
+                });
+        });
+
+        var wskey = WATERSHED.generateKey();
+        var options = {
+                headers: {
+                        'connection': 'upgrade',
+                        'upgrade': 'websocket',
+                        'sec-websocket-key': wskey
+                },
+                path: '/attach'
+        };
+        CLIENT.get(options, function (err, req) {
+                t.ifError(err);
+                req.on('result', function (err2, res) {
+                        t.ifError(err2);
+                        t.ok(false, 'server did not upgrade');
+                        done(true);
+                });
+                req.on('upgradeResult', function (err2, res, socket, head) {
+                        t.ifError(err2);
+                        t.ok(true, 'server upgraded');
+                        t.equal(res.statusCode, 101);
+                        t.equal(typeof (socket), 'object');
+                        t.ok(Buffer.isBuffer(head), 'head is Buffer');
+                        t.doesNotThrow(function () {
+                                var shed = WATERSHED.connect(res, socket, head,
+                                    wskey);
+                                SHEDLIST.push(shed);
+                                shed.end('ok, done');
+                                shed.on('error', function (err3) {
+                                        t.ifError(err3);
+                                        done('client shed error');
+                                });
+                                shed.on('end', function () {
+                                        done('client shed end');
+                                });
+                        });
+                });
+        });
+});
+
+
+test('GET with some websocket traffic', function (t) {
+        var done = finish_latch(t, {
+                'client shed end': 1,
+                'server shed end': 1,
+                'server receive message': 5,
+                'client receive message': 3
+        });
+
+        SERVER.get('/attach', function (req, res, next) {
+                t.ok(res.claimUpgrade, 'res.claimUpgrade present');
+                t.doesNotThrow(function () {
+                        var upgrade = res.claimUpgrade();
+                        var shed = WATERSHED.accept(req, upgrade.socket,
+                            upgrade.head);
+                        SHEDLIST.push(shed);
+                        shed.on('error', function (err) {
+                                t.ifError(err);
+                                done('server shed error');
+                        });
+                        shed.on('text', function (msg) {
+                                if (msg === 'to server')
+                                        done('server receive message');
+                        });
+                        shed.on('end', function () {
+                                done('server shed end');
+                        });
+                        shed.send('to client');
+                        shed.send('to client');
+                        shed.send('to client');
+                        next(false);
+                });
+        });
+
+        var wskey = WATERSHED.generateKey();
+        var options = {
+                headers: {
+                        'connection': 'upgrade',
+                        'upgrade': 'websocket',
+                        'sec-websocket-key': wskey
+                },
+                path: '/attach'
+        };
+        CLIENT.get(options, function (err, req) {
+                t.ifError(err);
+                req.on('result', function (err2, res) {
+                        t.ifError(err2);
+                        t.ok(false, 'server did not upgrade');
+                        done(true);
+                });
+                req.on('upgradeResult', function (err2, res, socket, head) {
+                        t.ifError(err2);
+                        t.ok(true, 'server upgraded');
+                        t.equal(res.statusCode, 101);
+                        t.equal(typeof (socket), 'object');
+                        t.ok(Buffer.isBuffer(head), 'head is Buffer');
+                        t.doesNotThrow(function () {
+                                var shed = WATERSHED.connect(res, socket, head,
+                                    wskey);
+                                SHEDLIST.push(shed);
+                                shed.on('error', function (err3) {
+                                        t.ifError(err3);
+                                        done('client shed error');
+                                });
+                                shed.on('end', function () {
+                                        done('client shed end');
+                                });
+                                shed.on('text', function (msg) {
+                                        if (msg === 'to client')
+                                                done('client receive message');
+                                });
+                                var count = 5;
+                                var iv = setInterval(function () {
+                                        if (--count < 0) {
+                                                clearInterval(iv);
+                                                shed.end();
+                                        } else {
+                                                shed.send('to server');
+                                        }
+                                }, 100);
+                        });
+                });
+        });
+});


### PR DESCRIPTION
This PR contains changes to provide better support for HTTP Upgrades on both the Server and Client:
- HTTP Upgrade requests should be able to use the regular request processing path
- HTTP Client should support handling Upgrade responses
- Provide Tests for HTTP Upgrade Support
