### PR TITLE
Fix for issue #378. Properly save route on the request.

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -576,7 +576,9 @@ Server.prototype._handle = function _handle(req, res) {
                 self._route(req, res, function (route, context) {
                         req.context = req.params = context;
                         req.route = route.spec;
-                        var chain = self.routes[route];
+
+                        var r = route ? route.name : null;
+                        var chain = self.routes[r];
 
                         self._run(req, res, route, chain, function done(e) {
                                 self.emit('after', req, res, route, e);
@@ -628,7 +630,7 @@ Server.prototype._route = function _route(req, res, name, cb) {
                         err = new ResourceNotFoundError(req.path());
                         emitRouteError(self, res, res, err);
                 } else {
-                        cb(r, ctx);
+                        cb(route, ctx);
                 }
         });
 };


### PR DESCRIPTION
Fix for issue #378. Pass the entire route (rather than just the route name) to the callback passed to _route. This ensures that the route is properly saved on the request and can be accessed in other handlers.
