### PR TITLE
Fix serveStatic to look in correct dir for 'default' file (again)

### DIFF
--- a/lib/plugins/static.js
+++ b/lib/plugins/static.js
@@ -71,7 +71,7 @@ function serveStatic(opts) {
                 fs.stat(file, function (err, stats) {
                         if (!err && stats.isDirectory() && opts.default) {
                                 // Serve an index.html page or similar
-                                file = path.join(opts.directory, opts.default);
+                                file = path.join(file, opts.default);
                                 fs.stat(file, function (dirErr, dirStats) {
                                         serveFileFromStats(file,
                                                            dirErr,


### PR DESCRIPTION
This was originally added in commit 69266a1 but regressed in
commit 4895f111.
