### PR TITLE
body_reader bug

### DIFF
--- a/lib/plugins/body_reader.js
+++ b/lib/plugins/body_reader.js
@@ -61,7 +61,7 @@ function bodyReader(options) {
                                 next();
                                 return;
                         }
-                        
+
                         if (hash && md5 !== (digest = hash.digest('base64'))) {
                                 next(new BadDigestError(MD5_MSG, md5, digest));
                                 return;


### PR DESCRIPTION
using chunk.toString('utf8') method  may slice a more than one byte character into two.
