### PR TITLE
Error trying to read octet-stream

### DIFF
--- a/lib/plugins/body_reader.js
+++ b/lib/plugins/body_reader.js
@@ -53,7 +53,8 @@ function bodyReader(options) {
 
         function readBody(req, res, next) {
                 if ((req.getContentLength() === 0 && !req.isChunked()) ||
-                    req.contentType() === 'multipart/form-data') {
+                    req.contentType() === 'multipart/form-data' ||
+                    req.contentType() === 'application/octet-stream') {
                         next();
                         return;
                 }


### PR DESCRIPTION
This is a fix. The good way to handle all cases would be to read only recognized content-types.
