### PR TITLE
add the `client_res` serializer even if there are no serializers at all ...

### DIFF
--- a/lib/clients/http_client.js
+++ b/lib/clients/http_client.js
@@ -215,7 +215,7 @@ function HttpClient(options) {
         this.connectTimeout = options.connectTimeout || false;
         this.headers = options.headers || {};
         this.log = options.log;
-        if (!this.log.serializers.client_res) {
+        if (!this.log.serializers || !this.log.serializers.client_res) {
             // Ensure logger has a reasonable serializer for `client_res`
             // logged in this module.
             this.log = this.log.child({


### PR DESCRIPTION
...in the HttpClient logger (see #358)
