### PR TITLE
Fix route name in DTrace probes

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -706,7 +706,7 @@ Server.prototype._run = function _run(req, res, route, chain, cb) {
                         dtrace._rstfy_probes['handler-done'].fire(function () {
                                 return ([
                                         self.name,
-                                        route !== null ? route : 'pre',
+                                        route !== null ? route.name : 'pre',
                                         _name,
                                         id
                                 ]);
@@ -725,7 +725,7 @@ Server.prototype._run = function _run(req, res, route, chain, cb) {
                         dtrace._rstfy_probes['handler-start'].fire(function () {
                                 return ([
                                         self.name,
-                                        route !== null ? route : 'pre',
+                                        route !== null ? route.name : 'pre',
                                         chain[i].name || ('handler-' + i),
                                         id
                                 ]);
@@ -739,7 +739,7 @@ Server.prototype._run = function _run(req, res, route, chain, cb) {
                 dtrace._rstfy_probes['route-done'].fire(function () {
                         return ([
                                 self.name,
-                                route !== null ? route : 'pre',
+                                route !== null ? route.name : 'pre',
                                 id,
                                 res.statusCode || 200,
                                 res.headers()
@@ -760,7 +760,7 @@ Server.prototype._run = function _run(req, res, route, chain, cb) {
         dtrace._rstfy_probes['route-start'].fire(function () {
                 return ([
                         self.name,
-                        route !== null ? route : 'pre',
+                        route !== null ? route.name : 'pre',
                         id,
                         req.method,
                         req.href(),


### PR DESCRIPTION
Before, route names were showing up as "[object Object]" rather than "getfoo"
