### PR TITLE
Allow content-length header in DELETE

### DIFF
--- a/lib/clients/http_client.js
+++ b/lib/clients/http_client.js
@@ -457,7 +457,7 @@ HttpClient.prototype._options = function (method, options) {
                         delete opts.headers['content-type'];
                 if (opts.headers['content-md5'])
                         delete opts.headers['content-md5'];
-                if (opts.headers['content-length'])
+                if (opts.headers['content-length'] && method !== 'DELETE')
                         delete opts.headers['content-length'];
                 if (opts.headers['transfer-encoding'])
                         delete opts.headers['transfer-encoding'];

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -90,6 +90,14 @@ before(function (callback) {
                         res.send(200, '<html><head/><body/></html>');
                         next();
                 });
+                SERVER.del('/contentLengthAllowed', function(req, res, next) {
+                        if(req.header('content-length')) {
+                                res.send(200, 'Allowed');
+                        } else {
+                                res.send(200, 'Not allowed');
+                        }
+                        next();
+                });
 
                 SERVER.get('/json/:name', sendJson);
                 SERVER.head('/json/:name', sendJson);
@@ -396,6 +404,22 @@ test('DELETE text', function (t) {
         });
 });
 
+test('DELETE allows content-length', function (t) {
+        var opts = {
+                path: '/contentLengthAllowed',
+                headers: {
+                        'content-length': '0'
+                }
+        };
+
+        STR_CLIENT.del(opts, function (err, req, res, obj) {
+                t.ifError(err);
+                t.ok(req);
+                t.ok(res);
+                t.deepEqual(obj, 'Allowed');
+                t.end();
+        });
+});
 
 test('GET raw', function (t) {
         RAW_CLIENT.get('/str/mcavage', function (connectErr, req) {


### PR DESCRIPTION
Be more tolerant and allow a content-length header in DELETE.  

Nginx requires a 'content-length' header in http DELETE messages. If the header does not exist, nginx returns a 411 error. A simple workaround is to add a 'content-length' header with value 0. Currently restify strips away 'content-length' headers in DELETE but this pull request changes that. 
