### PR TITLE
Pass in copied HTTP Signature parser options, to avoid overwriting

### DIFF
--- a/lib/plugins/authorization.js
+++ b/lib/plugins/authorization.js
@@ -62,7 +62,9 @@ function parseBasic(string) {
 
 function parseSignature(request) {
         try {
-                return (httpSignature.parseRequest(request, OPTIONS));
+                return (httpSignature.parseRequest(request, {
+                        algorithms: OPTIONS.algorithms
+                }));
         } catch (e) {
                 throw new InvalidHeaderError('Authorization header invalid: ' +
                                              e.message);


### PR DESCRIPTION
See #449.
