### PR TITLE
Remove Content-Encoding header from HTTP 204 and 304 responses.

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -258,6 +258,7 @@ Response.prototype.writeHead = function restifyWriteHead() {
                 this.removeHeader('Content-Length');
                 this.removeHeader('Content-MD5');
                 this.removeHeader('Content-Type');
+                this.removeHeader('Content-Encoding');
         }
 
         this._writeHead.apply(this, arguments);


### PR DESCRIPTION
When using middleware which overrides content-related headers, such as gzip, Content-[Length|Type|MD5] is handled, but Content-Encoding was missed. As gzip content should either be returned in a chunked transfer encoding or with a content-length, several clients get confused because they set themselves up to perform decompression of a message which, per HTTP 204/304, has no message-body.
