### PR TITLE
Update cors.js

### DIFF
--- a/lib/plugins/cors.js
+++ b/lib/plugins/cors.js
@@ -97,8 +97,8 @@ function cors(opts) {
                 }
 
                 function corsOnHeader() {
+                        origin = req.headers['origin'];
                         if (opts.credentials) {
-                                origin = req.headers['origin'];
                                 res.setHeader(AC_ALLOW_ORIGIN, origin);
                                 res.setHeader(AC_ALLOW_CREDS, 'true');
                         } else {


### PR DESCRIPTION
Allow origin to be echoed back in response header (as per OWASP recommendations) regardless of credentials set to true.  Related to issue #446.
