### PR TITLE
Simplify and correct path segment regexp

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -94,8 +94,7 @@ function compileURL(options) {
                         if (options.urlParamPattern) {
                                 pattern += '(' + options.urlParamPattern + ')';
                         } else {
-                                // Strictly adhere to RFC3986
-                                pattern += '([a-zA-Z0-9-_~\\.%@]+)';
+                                pattern += '([^/]*)';
                         }
                         params.push(frag.slice(1));
                 } else {


### PR DESCRIPTION
http://tools.ietf.org/html/rfc3986#section-3.3 explicitly includes sub-delims:

sub-delims    = "!" / "$" / "&" / "'" / "(" / ")"
                 / "*" / "+" / "," / ";" / "="

It also includes the colon and the empty string.

Restify paths don't need to consider the query part of the URL as those are
already split by the node http server. This leaves us with basically zero or
more chars that are not a slash, which is what you'd expect when matching a
path component.
