### PR TITLE
Fix example code missing a comma inside MyError definition.

### DIFF
--- a/docs/index.restdown
+++ b/docs/index.restdown
@@ -537,7 +537,7 @@ You can always add your own by subclassing `restify.RestError` like:
 
     function MyError(message) {
       restify.RestError.call(this, {
-        restCode: 'MyError'
+        restCode: 'MyError',
         statusCode: 418,
         message: message,
         constructorOpt: MyError


### PR DESCRIPTION
Simple addition of a missing comma inside the documentation.
