### PR TITLE
RequestCaptureStream: dumpDefault, haveNonRawStreams, zero ring after dump

### DIFF
--- a/lib/bunyan_helper.js
+++ b/lib/bunyan_helper.js
@@ -39,6 +39,24 @@ function appendStream(streams, s) {
 
 ///--- API
 
+/**
+ * A Bunyan stream to capture records in a ring buffer and only pass through
+ * on a higher-level record. E.g. buffer up all records but only dump when
+ * getting a WARN or above.
+ *
+ * @param {Object} options contains the parameters:
+ *      - {Object} stream The stream to which to write when dumping captured
+ *        records. One of `stream` or `streams` must be specified.
+ *      - {Array} streams One of `stream` or `streams` must be specified.
+ *      - {Number|String} level The level at which to trigger dumping captured
+ *        records. Defaults to bunyan.WARN.
+ *      - {Number} maxRecords Number of records to capture. Default 100.
+ *      - {Number} maxRequestIds Number of simultaneous request id capturing
+ *        buckets to maintain. Default 1000.
+ *      - {Boolean} dumpDefault If true, then dump captured records on the
+ *        *default* request id when dumping. I.e. dump records logged without
+ *        a "req_id" field. Default false.
+ */
 function RequestCaptureStream(opts) {
         assert.object(opts, 'options');
         assert.optionalObject(opts.stream, 'options.stream');
@@ -46,17 +64,18 @@ function RequestCaptureStream(opts) {
         assert.optionalNumber(opts.level, 'options.level');
         assert.optionalNumber(opts.maxRecords, 'options.maxRecords');
         assert.optionalNumber(opts.maxRequestIds, 'options.maxRequestIds');
+        assert.optionalBool(opts.dumpDefault, 'options.dumpDefault');
 
         var self = this;
         Stream.call(this);
 
-        this.level = opts.level || bunyan.WARN;
+        this.level = opts.level ? bunyan.resolveLevel(opts.level) : bunyan.WARN;
         this.limit = opts.maxRecords || 100;
         this.maxRequestIds = opts.maxRequestIds || 1000;
         this.requestMap = LRU({
                 max: self.maxRequestIds
         });
-
+        this.dumpDefault = opts.dumpDefault;
 
         this._offset = -1;
         this._rings = [];
@@ -68,6 +87,14 @@ function RequestCaptureStream(opts) {
 
         if (opts.streams)
                 opts.streams.forEach(appendStream.bind(null, this.streams));
+
+        this.haveNonRawStreams = false;
+        for (var i = 0; i < this.streams.length; i++) {
+            if (!this.streams[i].raw) {
+                this.haveNonRawStreams = true;
+                break;
+            }
+        }
 }
 util.inherits(RequestCaptureStream, Stream);
 
@@ -95,12 +122,32 @@ RequestCaptureStream.prototype.write = function write(record) {
         assert.ok(ring, 'no ring found');
 
         if (record.level >= this.level) {
-                ring.records.forEach(function (r) {
-                        var ser = JSON.stringify(r, bunyan.safeCycles()) + '\n';
+                var i, r, ser;
+                for (i = 0; i < ring.records.length; i++) {
+                        r = ring.records[i];
+                        if (this.haveNonRawStreams) {
+                                ser = JSON.stringify(r,
+                                        bunyan.safeCycles()) + '\n';
+                        }
                         self.streams.forEach(function (s) {
                                 s.stream.write(s.raw ? r : ser);
                         });
-                });
+                }
+                ring.records.length = 0;
+                if (this.dumpDefault) {
+                        var defaultRing = self.requestMap.get(DEFAULT_REQ_ID);
+                        for (i = 0; i < defaultRing.records.length; i++) {
+                                r = defaultRing.records[i];
+                                if (this.haveNonRawStreams) {
+                                        ser = JSON.stringify(r,
+                                                bunyan.safeCycles()) + '\n';
+                                }
+                                self.streams.forEach(function (s) {
+                                        s.stream.write(s.raw ? r : ser);
+                                });
+                        };
+                        defaultRing.records.length = 0;
+                }
         } else {
                 ring.write(record);
         }


### PR DESCRIPTION
- Add 'dumpDefault' option to also dump captured records on the
  _default_ ring (i.e. those without a req_id field). Useful for
  when the app hasn't necessarily been nice passing around `req.log`
  and logging on that.
- Zero out the ring after dumping captured records so don't get
  those records _re-dumped_ after a second log.warn/error.
- Perf optimization to not serialize if don't have to.
