### PR TITLE
Log uncaught exceptions as errors

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -776,7 +776,7 @@ Server.prototype._run = function _run(req, res, route, chain, cb) {
                 if (err._restify_next) {
                         err._restify_next(err);
                 } else {
-                        log.trace({err: err}, 'uncaughtException');
+                        log.error({err: err}, 'uncaughtException');
                         self.emit('uncaughtException', req, res, route, err);
                 }
         });


### PR DESCRIPTION
Currently uncaught exceptions are logged at trace level, but they are errors and should be logged as such.
