### PR TITLE
Fix connecting socket detection

### DIFF
--- a/lib/clients/http_client.js
+++ b/lib/clients/http_client.js
@@ -172,7 +172,8 @@ function rawRequest(opts, cb) {
         });
 
         req.once('socket', function onSocket(socket) {
-                if (socket.writable && !socket._connecting) {
+                var connecting = socket._connecting || socket.socket && socket.socket._connecting;
+                if (socket.writable && !connecting) {
                         clearTimeout(timer);
                         cb(null, req);
                         return;


### PR DESCRIPTION
I'm using node v0.10.22 and connectTimeout in restify isn't taken into account in some cases. Example:

```
var restify = require('restify');
var client = new restify.createJSONClient({url: 'https://8.8.8.8', connectTimeout: 1000, retry: false});
var start = new Date().getTime();
client.get({path: '/ping'}, function (err, req, res, body) {
    console.log('Finished in: ' + (new Date().getTime() - start));
    process.exit();
});
```

Expected: 'Finished in 1000'
Actual: 'Finished in 76345'

The problem here is that socket is mistakenly treated as 'connected' instead of 'connecting'. _connecting property is actually inside 'socket' property of the socket and not in it's root.
