### PR TITLE
Don't override response code in res.send(code, errorObj)

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -163,6 +163,9 @@ Response.prototype.send = function send(code, body, headers) {
                 this.statusCode = 200;
         } else if (code.constructor.name === 'Number') {
                 this.statusCode = code;
+                if (body instanceof Error) {
+                        body.statusCode = this.statusCode;
+                }
         } else {
                 headers = body;
                 body = code;

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1482,3 +1482,31 @@ test('GH-401 regex routing broken', function (t) {
         CLIENT.get('/image', client_cb);
         CLIENT.get('/image/1.jpg', client_cb);
 });
+
+test('explicitly sending a 403 with custom error', function (t) {
+    function MyCustomError() {}
+    MyCustomError.prototype = Object.create(Error.prototype);
+
+    SERVER.get('/', function (req, res, next) {
+        res.send(403, new MyCustomError('bah!'));
+    });
+
+    CLIENT.get('/', function (err, _, res) {
+        t.ok(err);
+        t.equal(res.statusCode, 403);
+        t.end();
+    });
+});
+
+
+test('explicitly sending a 403 on error', function (t) {
+    SERVER.get('/', function (req, res, next) {
+        res.send(403, new Error('bah!'));
+    });
+
+    CLIENT.get('/', function (err, _, res) {
+        t.ok(err);
+        t.equal(res.statusCode, 403);
+        t.end();
+    });
+});


### PR DESCRIPTION
If you invoke res.send() with an error that has a statusCode attribute,
that will be used, otherwise a default of 500 will be used
(unless you're using res.send(4xx, new Error('blah)))."

http://mcavage.me/node-restify/#Error-handling

issue #493
