### PR TITLE
 ensure have a reasonable client_req serializer (see similar #358)

### DIFF
--- a/lib/clients/http_client.js
+++ b/lib/clients/http_client.js
@@ -215,18 +215,18 @@ function HttpClient(options) {
         this.connectTimeout = options.connectTimeout || false;
         this.headers = options.headers || {};
         this.log = options.log;
-        if (!this.log.serializers
-            || !this.log.serializers.client_res
-            || !this.log.serializers.client_req)
+        if (!this.log.serializers ||
+            !this.log.serializers.client_res ||
+            !this.log.serializers.client_req)
         {
-            // Ensure logger has a reasonable serializer for `client_res`
-            // and `client_req` logged in this module.
-            var serializers = {};
-            if (!this.log.serializers.client_res)
-                serializers.client_res = bunyan.serializers.client_res;
-            if (!this.log.serializers.client_req)
-                serializers.client_req = bunyan.serializers.client_req;
-            this.log = this.log.child({serializers: serializers});
+                // Ensure logger has a reasonable serializer for `client_res`
+                // and `client_req` logged in this module.
+                var serializers = {};
+                if (!this.log.serializers.client_res)
+                        serializers.client_res = bunyan.serializers.client_res;
+                if (!this.log.serializers.client_req)
+                        serializers.client_req = bunyan.serializers.client_req;
+                this.log = this.log.child({serializers: serializers});
         }
         this.key = options.key;
         this.name = options.name || 'HttpClient';


### PR DESCRIPTION
Without this, a logger at trace level to the restify client will crash
(on eventual memory exhaustion) attempting to log the raw `client_req`.
