### PR TITLE
Helper to render a route with given parameters (for hypermedia APIs)

### DIFF
--- a/docs/index.restdown
+++ b/docs/index.restdown
@@ -239,6 +239,30 @@ Note that `foo` only gets run once in that example.  A few caveats:
   routing chain once (this is a limitation of the way routes are stored
   internally, and may be revisited someday).
 
+### Hypermedia
+
+If a parameterized route was defined with a string (not a regex), you can render it from other places in the server. This is useful to have HTTP responses that link to other resources, without having to hardcode URLs throughout the codebase. Both path and query strings parameters get URL encoded appropriately.
+
+```js
+server.get({name: 'city', path: '/cities/:slug'}, /* ... */);
+
+// in another route
+res.send({
+  country: 'Australia',
+  // render a URL by specifying the route name and parameters
+  capital: server.router.render('city', {slug: 'canberra'}, {details: true})
+});
+```
+
+Which returns:
+
+```json
+{
+  "country": "Australia",
+  "capital": "/cities/canberra?details=true"
+}
+```
+
 ### Versioned Routes
 
 Most REST APIs tend to need versioning, and restify ships with support

--- a/lib/router.js
+++ b/lib/router.js
@@ -165,6 +165,25 @@ util.inherits(Router, EventEmitter);
 module.exports = Router;
 
 
+Router.prototype.render = function render(routeName, params, query) {
+    function pathItem(match, key) {
+        if (params.hasOwnProperty(key) === false) {
+            throw new Error('Route <' + routeName + '> is missing parameter <' + key + '>');
+        }
+        return '/' + encodeURIComponent(params[key]);
+    }
+    function queryItem(key) {
+        return encodeURIComponent(key) + '=' + encodeURIComponent(query[key]);
+    }
+    var routeKey = routeName.replace(/\W/g, '').toLowerCase();
+    var route = this.mounts[routeKey];
+    if (!route) { return null; }
+    var url = route.spec.path.replace(/\/:([^/]+)/g, pathItem);
+    var items = Object.keys(query || {}).map(queryItem);
+    var queryString = items.length > 0 ? ('?' + items.join('&')) : '';
+    return url + queryString;
+}
+
 Router.prototype.mount = function mount(options) {
     assert.object(options, 'options');
     assert.string(options.method, 'options.method');

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -1,0 +1,91 @@
+// Copyright 2012 Mark Cavage, Inc.  All rights reserved.
+
+var assert = require('assert-plus');
+var restify = require('../lib');
+if (require.cache[__dirname + '/lib/helper.js'])
+  delete require.cache[__dirname + '/lib/helper.js'];
+var helper = require('./lib/helper.js');
+
+
+///--- Globals
+
+var realizeUrl = restify.realizeUrl;
+var test = helper.test;
+var mockResponse = function respond(req, res, next) {
+    res.send(200);
+};
+
+
+///--- Tests
+
+test('render route', function (t) {
+
+    var server = restify.createServer();
+    server.get({name: 'countries', path: '/countries'}, mockResponse);
+    server.get({name: 'country', path: '/countries/:name'}, mockResponse);
+    server.get({name: 'cities', path: '/countries/:name/states/:state/cities'}, mockResponse);
+
+    var countries = server.router.render('countries', {});
+    t.equal(countries, '/countries');
+
+    var country = server.router.render('country', {name: 'Australia'});
+    t.equal(country, '/countries/Australia');
+
+    var cities = server.router.render('cities', {name: 'Australia', state: 'New South Wales'});
+    t.equal(cities, '/countries/Australia/states/New%20South%20Wales/cities');
+
+    t.end();
+});
+
+
+test('render route (missing params)', function (t) {
+
+    var server = restify.createServer();
+    server.get({name: 'cities', path: '/countries/:name/states/:state/cities'}, mockResponse);
+
+    try {
+        server.router.render('cities', {name: 'Australia'});
+    } catch (ex) {
+        t.equal(ex, 'Error: Route <cities> is missing parameter <state>')
+    }
+
+    t.end();
+});
+
+test('render route (special charaters)', function (t) {
+
+    var server = restify.createServer();
+    server.get({name: 'my-route', path: '/countries/:name'}, mockResponse);
+
+    var link = server.router.render('my-route', {name: 'Australia'});
+    t.equal(link, '/countries/Australia')
+
+    t.end();
+});
+
+test('render route (with encode)', function (t) {
+
+    var server = restify.createServer();
+    server.get({name: 'my-route', path: '/countries/:name'}, mockResponse);
+
+    var link = server.router.render('my-route', {name: 'Trinidad & Tobago'});
+    t.equal(link, '/countries/Trinidad%20%26%20Tobago')
+
+    t.end();
+});
+
+
+test('render route (query string)', function (t) {
+
+    var server = restify.createServer();
+    server.get({name: 'country', path: '/countries/:name'}, mockResponse);
+
+    var country1 = server.router.render('country', {name: 'Australia'}, {state: 'New South Wales', 'cities/towns': 5});
+    t.equal(country1, '/countries/Australia?state=New%20South%20Wales&cities%2Ftowns=5');
+
+    var country2 = server.router.render('country', {name: 'Australia'}, {state: 'NSW & VIC', 'cities&towns': 5});
+    t.equal(country2, '/countries/Australia?state=NSW%20%26%20VIC&cities%26towns=5');
+
+    t.end();
+});
+


### PR DESCRIPTION
This is a new helper method for building hypermedia-driven APIs.
I didn't find any existing functionality for that, please let me know if I missed it!

Example taken from the tests:

``` js
// configuring named routes
var server = restify.createServer();
server.get({name: 'cities', path: '/countries/:name/states/:state/cities'}, doSomething);

// somewhere in another route
var cities = server.router.render('cities', {name: 'Australia', state: 'New South Wales'});
// will be /countries/Australia/states/New%20South%20Wales/cities

// or with optional query string parameters
var cities = server.router.render('cities', {name: 'Australia', state: 'New South Wales', {max: 5}});
// will be /countries/Australia/states/New%20South%20Wales/cities?max=5
```

This is useful for the typical hypermedia API:

`GET  /countries/Australia`

``` js
res.send(200, {
  "population": 23000000,
  "capital": "Canberra",
  "cities": {
    "NSW": "/countries/Australia/states/New%20South%20Wales/cities",
    "VIC": "/countries/Australia/states/Victoria/cities?max=5" 
  }
});
```
