### PR TITLE
Fix audit logger plugin bug

### DIFF
--- a/lib/plugins/audit.js
+++ b/lib/plugins/audit.js
@@ -44,7 +44,7 @@ function auditLogger(options) {
                     headers: req.headers,
                     httpVersion: req.httpVersion,
                     trailers: req.trailers,
-                    version: req.version,
+                    version: req.version(),
                     body: options.body === true ?
                         req.body : undefined,
                     timers: timers


### PR DESCRIPTION
In request serializer, to properly allocate
request version value, req.version() should be called.
