### PR TITLE
Allow an `options` object to be passed into the authorization plugin.

### DIFF
--- a/lib/plugins/authorization.js
+++ b/lib/plugins/authorization.js
@@ -58,11 +58,11 @@ function parseBasic(string) {
 }
 
 
-function parseSignature(request) {
+function parseSignature(request, options) {
+    options = options || {};
+    options.algorithms = OPTIONS.algorithms;
     try {
-        return (httpSignature.parseRequest(request, {
-            algorithms: OPTIONS.algorithms
-        }));
+        return (httpSignature.parseRequest(request, options));
     } catch (e) {
         throw new InvalidHeaderError('Authorization header invalid: ' +
             e.message);
@@ -89,7 +89,7 @@ function parseSignature(request) {
  * @return {Function} restify handler.
  * @throws {TypeError} on bad input
  */
-function authorizationParser() {
+function authorizationParser(options) {
 
     function parseAuthorization(req, res, next) {
         req.authorization = {};
@@ -117,7 +117,7 @@ function authorizationParser() {
 
                 case 'signature':
                     req.authorization.signature =
-                        parseSignature(req);
+                        parseSignature(req, options);
                     req.username =
                         req.authorization.signature.keyId;
                     break;


### PR DESCRIPTION
The `options` will be applied to the `httpSignature.parseRequest` method.  This will allow one to pass in any of the accepted options for `httpSignature.parseRequest`.
