### PR TITLE
Prevent the server from hanging when a non-Error, non-string argument is given to next().

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -652,12 +652,7 @@ Server.prototype._run = function _run(req, res, route, chain, cb) {
     function next(arg) {
         var done = false;
         if (arg) {
-            if (arg instanceof Error) {
-                log.trace({err: arg}, 'next(err=%s)',
-                    (arg.name || 'Error'));
-                res.send(arg);
-                done = true;
-            } else if (typeof (arg) === 'string') {
+            if (typeof (arg) === 'string') {
                 if (req._rstfy_chained_route) {
                     var _e = new errors.InternalError();
                     log.error({
@@ -684,6 +679,11 @@ Server.prototype._run = function _run(req, res, route, chain, cb) {
                     req._rstfy_chained_route = true;
                     self._run(req, res, r, _chain, cb);
                 });
+            } else {
+                log.trace({err: arg}, 'next(err=%s)',
+                    (arg.name || 'Error'));
+                res.send(arg);
+                done = true;
             }
         }
 


### PR DESCRIPTION
When something is passed to next() that is not an Error or a string, the server will hang indefinitely.  This change will make it at least clear what has happened, instead of hanging, which was difficult to debug.

Here's an example server that reproduces the issue I had.

```
var restify = require('restify');
var server = restify.createServer();

server.get('/error', function(req, res, next){
  next(new Error('Error!'));
});

server.get('/hangs', function(req, res, next){
  next({message: 'Error!'});
});

server.listen(8000, function(){
  console.log('Listening on', server.url);
});
```

Before this commit, accessing `/error` would produce `{"message":"Error!"}`, and accessing `/hangs` would hang indefinitely.  After this commit, both `/error` and `/hangs` produce `{"message":"Error!"}`.

Thanks.
