### PR TITLE
allow trailing slashes

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -105,7 +105,7 @@ function compileURL(options) {
 
     if (pattern === '^')
         pattern += '\\/';
-    pattern += '$';
+    pattern += '?(/)$';
 
     re = new RegExp(pattern, options.flags);
     re.restifyParams = params;


### PR DESCRIPTION
I'm using node-restify for a project where I don't have full control over the clients that talk to it, some clients add a trailing slash, this allows for that to be there.
