### PR TITLE
Check for callback prior to firing it

### DIFF
--- a/lib/clients/json_client.js
+++ b/lib/clients/json_client.js
@@ -81,7 +81,8 @@ JsonClient.prototype.parse = function parse(req, callback) {
         if (err)
             err.body = obj;
 
-        callback((err || null), req2, res, obj);
+        if (callback)
+            callback((err || null), req2, res, obj);
     }
 
     return (this._super.parse.call(this, req, parseResponse));


### PR DESCRIPTION
Prevents an error when client is used without a callback.
