### PR TITLE
do not compute the MD5 Hash of a partial content

### DIFF
--- a/lib/clients/string_client.js
+++ b/lib/clients/string_client.js
@@ -155,7 +155,7 @@ StringClient.prototype.parse = function parse(req, callback) {
             var gz;
             var hash;
             var md5 = res.headers['content-md5'];
-            if (md5 && req.method !== 'HEAD')
+            if (md5 && req.method !== 'HEAD' && res.statusCode !== 206)
                 hash = crypto.createHash('md5');
 
             if (res.headers['content-encoding'] === 'gzip') {


### PR DESCRIPTION
RFC 1864 (https://tools.ietf.org/html/rfc1864#section-2)
"
   The Content-MD5 field is generated by only an originating user agent.
   Message relays and gateways are expressly forbidden from generating a
   Content-MD5 field.
".

When a partial document is requested and the data are not served directly form the originator server (if the requested document is cached for example), the MD5 received in the content-md5 header is the one computed against the whole content, not the partial document MD5 check sum.

This patch ignore the content-md5 header, only if the content is partially received (HTTP Status code 206 Partial Content).
