### PR TITLE
change regex in router to allow trailing slashes

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -105,8 +105,8 @@ function compileURL(options) {
 
     if (pattern === '^')
         pattern += '\\/';
-    pattern += '(?:\/|$)';
-
+    pattern += '(?:\/?)$';
+    
     re = new RegExp(pattern, options.flags);
     re.restifyParams = params;
 


### PR DESCRIPTION
these changes allows you to use routes with a trailing slashes 
e.g. /foo/bar is the same like /foo/bar/

passed all tests at travis https://travis-ci.org/scheckmedia/node-restify
