### PR TITLE
allow manually flushing gzipped responses

### DIFF
--- a/lib/plugins/gzip.js
+++ b/lib/plugins/gzip.js
@@ -23,6 +23,11 @@ function gzipResponse(opts) {
 
         var gz = zlib.createGzip(opts);
 
+        // Allow flushing the response
+        res.flush = function() {
+            gz.flush();
+        }
+
         gz.on('data', res.write.bind(res));
         gz.once('end', res.end.bind(res));
         gz.on('drain', res.emit.bind(res, 'drain'));


### PR DESCRIPTION
As of now there's no easy way to flush gzipped responses.
This is especially needed for Server-Sent Events.
