### PR TITLE
Updates to documentation

### DIFF
--- a/docs/index.restdown
+++ b/docs/index.restdown
@@ -480,6 +480,12 @@ do this:
     Response-Time: 1
 
     I just don't like you
+    
+Alternatively, you can access the error classes via `restify.errors`. We can do this with a simple change to the previous example:
+
+    server.get('/hello/:name', function(req, res, next) {
+      return next(new restify.errors.ConflictError("I just don't like you"));
+    });
 
 The core thing to note about an `HttpError` is that it has a numeric
 code (statusCode) and a `body`.  The statusCode will automatically


### PR DESCRIPTION
I recently discovered two things, that I think should be documented:
1. That you can chain handlers in the route function. This is something that is also allowed in ExpressJS and  others but is never mentioned in the documentation.
2. The error classes are accessible via both `restify` and `restify.errors`
