### PR TITLE
Remove CORS headers from fullResponse (can conflict with restify.CORS)

### DIFF
--- a/lib/plugins/full_response.js
+++ b/lib/plugins/full_response.js
@@ -5,48 +5,12 @@ var crypto = require('crypto');
 var httpDate = require('../http_date');
 
 
-///--- Globals
-
-var ALLOW_HEADERS = [
-    'Accept',
-    'Accept-Version',
-    'Content-Length',
-    'Content-MD5',
-    'Content-Type',
-    'Date',
-    'Api-Version',
-    'Response-Time'
-].join(', ');
-
-var EXPOSE_HEADERS = [
-    'Api-Version',
-    'Request-Id',
-    'Response-Time'
-].join(', ');
-
-
 ///--- API
 
 function setHeaders(req, res) {
     var hash;
     var now = new Date();
     var methods;
-
-    if (!res.getHeader('Access-Control-Allow-Origin'))
-        res.setHeader('Access-Control-Allow-Origin', '*');
-
-    if (!res.getHeader('Access-Control-Allow-Headers'))
-        res.setHeader('Access-Control-Allow-Headers', ALLOW_HEADERS);
-
-    if (!res.getHeader('Access-Control-Allow-Methods')) {
-        if (res.methods && res.methods.length > 0) {
-            methods = res.methods.join(', ');
-            res.setHeader('Access-Control-Allow-Methods', methods);
-        }
-    }
-
-    if (!res.getHeader('Access-Control-Expose-Headers'))
-        res.setHeader('Access-Control-Expose-Headers', EXPOSE_HEADERS);
 
     if (!res.getHeader('Connection')) {
         res.setHeader('Connection',

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -711,10 +711,6 @@ test('full response', function (t) {
         t.equal(res.statusCode, 200);
         var headers = res.headers;
         t.ok(headers, 'headers ok');
-        t.ok(headers['access-control-allow-origin']);
-        t.ok(headers['access-control-allow-headers']);
-        t.ok(headers['access-control-expose-headers']);
-        t.ok(headers['access-control-allow-methods']);
         t.ok(headers.date);
         t.ok(headers['request-id']);
         t.ok(headers['response-time'] >= 0);


### PR DESCRIPTION
The new `CORS` middleware has great support for cross-origin requests, including:

- defining a list of allowed origins
- defining a list of custom exposed headers

The `fullResponse` middleware also does some of this, but unfortunately:

- not as configurable
- sometimes conflicts with choices made by the CORS middleware

For example, it will not override `Access-Control-Allow-Origin` if it's already set ([see code](https://github.com/mcavage/node-restify/blob/master/lib/plugins/full_response.js#L35)), which is good. However the CORS module might decide **not** to add the header, for example if the request doesn't match the allowed origins ([see code](https://github.com/mcavage/node-restify/blob/master/lib/plugins/cors.js#L94)). In this case setting it as `*` later is probably not the right behaviour.

There might be ways to arrange the middlewares & configs to avoid these clashes, but I think having a single full-featured `CORS` middleware is preferable to having CORS support added in a few places. Thoughts?
