### PR TITLE
DELETE without body

### DIFF
--- a/lib/plugins/body_parser.js
+++ b/lib/plugins/body_parser.js
@@ -43,7 +43,7 @@ function bodyParser(options) {
             }
         }
         if (req.method === 'DELETE') {
-          if (req.contentLength() === 0) {
+          if (!req.body) {
             next();
             return;
           }


### PR DESCRIPTION
Currently, 415 "Unsupported Media Type" is returned when some DELETE route is requested without body, which is wrong. DELETE shouldn't be forced to have a body.
