### PR TITLE
Use matched origin for non-credential CORS.

### DIFF
--- a/lib/plugins/cors.js
+++ b/lib/plugins/cors.js
@@ -97,9 +97,8 @@ function cors(opts) {
         }
 
         function corsOnHeader() {
-            origin = req.headers['origin'];
             if (opts.credentials) {
-                res.setHeader(AC_ALLOW_ORIGIN, origin);
+                res.setHeader(AC_ALLOW_ORIGIN, req.headers['origin']);
                 res.setHeader(AC_ALLOW_CREDS, 'true');
             } else {
                 res.setHeader(AC_ALLOW_ORIGIN, origin);


### PR DESCRIPTION
This means that we can return `Access-Control-Allow-Origin: *` for non-authenticated requests. Fixes #608