### PR TITLE
Expose the Request and Response

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -155,6 +155,8 @@ if (!process.env.RESTIFY_CLIENT_ONLY) {
     module.exports.httpDate = require('./http_date');
     module.exports.realizeUrl = realizeUrl;
     module.exports.formatters = require('./formatters');
+    module.exports.Request = require('./request');
+    module.exports.Response = require('./response');
     module.exports.plugins = {};
     var plugins = require('./plugins');
     Object.keys(plugins).forEach(function (k) {

--- a/lib/request.js
+++ b/lib/request.js
@@ -315,3 +315,8 @@ Request.prototype.toString = function toString() {
 Request.prototype.userAgent = function userAgent() {
     return (this.headers['user-agent']);
 };
+
+
+///--- Exposure
+
+module.exports = Request;

--- a/lib/response.js
+++ b/lib/response.js
@@ -271,3 +271,8 @@ Response.prototype.writeHead = function restifyWriteHead() {
 
     this._writeHead.apply(this, arguments);
 };
+
+
+///--- Exposure
+
+module.exports = Response;


### PR DESCRIPTION
With these changes, one can check if the request object or response object are instanceof.

Assuming I have a (stupid) helper function like so:

``` javascript
var restify = require('restify');

exports.isLocalhost = function(ip, cb, req) {
  if (ip === '127.0.0.1') {
    if (req instanceof restify.Request) {
      req.log.warn('Request was made localhost');
    }
    return true;
  }
  return false;
}
```

One could unit test the isLocalhost helper without worrying about faking the request object.
