### PR TITLE
Support URLs that have a path component.

### DIFF
--- a/lib/clients/http_client.js
+++ b/lib/clients/http_client.js
@@ -6,6 +6,7 @@ var fs = require('fs');
 var http = require('http');
 var https = require('https');
 var os = require('os');
+var path = require('path');
 var querystring = require('querystring');
 var url = require('url');
 var util = require('util');
@@ -546,6 +547,10 @@ HttpClient.prototype._options = function (method, options) {
 
     if (this.socketPath)
         opts.socketPath = this.socketPath;
+
+    if (this.url.path && opts.path) {
+        opts.path = path.join(self.url.path, opts.path);
+    }
 
     Object.keys(this.url).forEach(function (k) {
         if (!opts[k])

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -36,7 +36,7 @@ function sendJson(req, res, next) {
 
 
 function sendText(req, res, next) {
-    var text = 'hello ' + (req.params.hello || req.params.name || ''); 
+    var text = 'hello ' + (req.params.hello || req.params.name || '');
 
     if (req.headers['range']){
         var matched = req.headers['range'].match(/bytes=([0-9]+)-([0-9]*)/);
@@ -817,6 +817,49 @@ test('create base client with url instead of opts', function(t) {
   client.agent = false;
 
   client.get('/str/mcavage', function (err, req, res, data) {
+    req.on('result', function(err, res) {
+        res.body = '';
+        res.setEncoding('utf8');
+        res.on('data', function(chunk) {
+            res.body += chunk;
+        });
+
+        res.on('end', function() {
+            t.equal(res.body, '"hello mcavage"');
+            t.end();
+        });
+    });
+  });
+});
+
+
+test('create JSON client with a path prefix and trailing slash', function (t) {
+  var client = restify.createJsonClient({url: 'http://127.0.0.1:' + PORT + '/json/' });
+  client.agent = false;
+
+  client.get('/mcavage', function (err, req, res, obj) {
+      t.deepEqual(obj, {hello: 'mcavage'});
+      t.end();
+  });
+});
+
+
+test('create JSON client with a path prefix', function (t) {
+  var client = restify.createJsonClient({url: 'http://127.0.0.1:' + PORT + '/json' });
+  client.agent = false;
+
+  client.get('/mcavage', function (err, req, res, obj) {
+      t.deepEqual(obj, {hello: 'mcavage'});
+      t.end();
+  });
+});
+
+
+test('create base client with a path prefix', function(t) {
+  var client = restify.createClient({url: 'http://127.0.0.1:' + PORT + '/str' });
+  client.agent = false;
+
+  client.get('/mcavage', function (err, req, res, data) {
     req.on('result', function(err, res) {
         res.body = '';
         res.setEncoding('utf8');


### PR DESCRIPTION
Rather than this:

```javascript
var client = restify.createJsonClient({url: 'https://api.twitter.com'});

client.get('/1.1/statuses/user_timeline.json');
client.get('/1.1/users/show.json');
```

This Pull Requests lets you do this:

```javascript
var client = restify.createJsonClient({url: 'https://api.twitter.com/1.1/'});

client.get('/statuses/user_timeline.json');
client.get('/users/show.json');
```

It uses `path.join()` to join the two fragments so you don't need to think about slashes.

This will break existing code if people have a URL with a path set in the client.