### PR TITLE
url.path + path

### DIFF
--- a/lib/clients/http_client.js
+++ b/lib/clients/http_client.js
@@ -547,6 +547,11 @@ HttpClient.prototype._options = function (method, options) {
     if (this.socketPath)
         opts.socketPath = this.socketPath;
 
+    // url[http://localhost:3000/something] + get[/foo] -> http://localhost:3000/something/foo
+    if (opts.path) {
+        opts.path = this.url.path + opts.path;
+    }
+    
     Object.keys(this.url).forEach(function (k) {
         if (!opts[k])
             opts[k] = self.url[k];

--- a/lib/clients/http_client.js
+++ b/lib/clients/http_client.js
@@ -549,7 +549,12 @@ HttpClient.prototype._options = function (method, options) {
 
     // url[http://localhost:3000/something] + get[/foo] -> http://localhost:3000/something/foo
     if (opts.path) {
-        opts.path = this.url.path + opts.path;
+        if (this.url.path[this.url.path.length-1] == '/' && opts.path[0] == '/') {
+            opts.path = this.url.path + opts.path.substr(1);
+        }
+        else {
+            opts.path = this.url.path + opts.path;
+        }
     }
     
     Object.keys(this.url).forEach(function (k) {


### PR DESCRIPTION
Fixed erroneous path generation like below:
```
url[http://localhost:3000/something] + get[/foo] 
  ->  (should be)     http://localhost:3000/something/foo
  -x->(should not be) http://localhost:3000/foo
```