### PR TITLE
server: handle invalid content-type on typed routes

### DIFF
--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1271,6 +1271,28 @@ test('content-type routing params only', function (t) {
     });
 });
 
+test('malformed content type', function (t) {
+    SERVER.post({
+        name: 'foo',
+        path: '/',
+        contentType: 'application/json'
+    }, function (req, res, next) {
+        res.send(201);
+    });
+
+    var opts = {
+        path: '/',
+        headers: {
+            'content-type': 'boom'
+        }
+    };
+
+    CLIENT.post(opts, {}, function (err, _, res) {
+        t.ok(err);
+        t.equal(res.statusCode, 415);
+        t.end();
+    });
+});
 
 test('gh-193 basic', function (t) {
     SERVER.get({


### PR DESCRIPTION
A request with a malformed content-type header (`content-type: boom`)
on a typed route like

```
app.post({ path: '/', contentType: 'text/html' })
```

will cause restify to crash due to a null pointer in the negotiator
plugin. Add a failing test as a reminder to upgrade negotiatior once
it's resolved upstream (0).

(0): https://github.com/federomero/negotiator/pull/21
