### PR TITLE
Adding req.matchedVersion()

### DIFF
--- a/docs/index.restdown
+++ b/docs/index.restdown
@@ -334,7 +334,31 @@ You can default the versions on routes by passing in a version field at
 server creation time.  Lastly, you can support multiple versions in the API
 by using an array:
 
-      server.get({path: PATH, version: ['2.0.0', '2.1.0']}, sendV2);
+      server.get({path: PATH, version: ['2.0.0', '2.1.0', '2.2.0']}, sendV2);
+
+In this case you may need to know more information such as what the
+original requested version string was, and what the matching
+version from the routes supported version array was. Two methods make
+this info available:
+
+    var PATH = '/version/test';
+    server.get({path: PATH, version: ['2.0.0', '2.1.0', '2.2.0']}, function (req) {
+      res.send(200, {
+        requestedVersion: req.version(),
+        matchedVersion: req.matchedVersion()
+      });
+    });
+
+Hitting this route:
+
+    $ curl -s -H 'accept-version: <2.2.0' localhost:8080/version/test | json
+    {
+      "requestedVersion": "<2.2.0",
+      "matchedVersion": "2.1.0"
+    }
+
+
+In response to the above
 
 ## Upgrade Requests
 
@@ -961,8 +985,8 @@ is expected that you are going to map it to a route, as below:
       default: 'index.html'
     }));
 
-The above `route` and `directory` combination will serve a file located in  
-`./documentation/v1/docs/current/index.html` when you attempt to hit 
+The above `route` and `directory` combination will serve a file located in
+`./documentation/v1/docs/current/index.html` when you attempt to hit
 `http://localhost:8080/docs/current/`.
 
 The plugin will enforce that all files under `directory` are served. The

--- a/lib/request.js
+++ b/lib/request.js
@@ -203,6 +203,13 @@ Request.prototype.getVersion = function getVersion() {
 };
 Request.prototype.version = Request.prototype.getVersion;
 
+Request.prototype.matchedVersion = function matchedVersion() {
+    if (this._matchedVersion !== undefined) {
+        return (this._matchedVersion);
+    } else {
+        return (this.version());
+    }
+};
 
 Request.prototype.header = function header(name, value) {
     assert.string(name, 'name');

--- a/lib/router.js
+++ b/lib/router.js
@@ -367,6 +367,7 @@ Router.prototype.find = function find(req, res, callback) {
         }
     }
 
+    var maxV;
     if (!r) {
         // If upload and typed
         if (typed) {
@@ -390,7 +391,6 @@ Router.prototype.find = function find(req, res, callback) {
         }
 
         if (versioned) {
-            var maxV;
             candidates.forEach(function (c) {
                 var k = c.r.versions;
                 var v = semver.maxSatisfying(k, req.version());
@@ -420,6 +420,11 @@ Router.prototype.find = function find(req, res, callback) {
             params: params,
             spec: r.spec
         };
+
+        if (versioned) {
+            req._matchedVersion = maxV;
+        }
+
         this.cache.set(cacheKey, cacheVal);
         res.methods = reverse.slice();
         callback(null, cacheVal, shallowCopy(params));

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1076,6 +1076,34 @@ test('gh-283 maximum available versioned route matching', function (t) {
     });
 });
 
+test('routes matching multiple versions should know what the max matched version was', function (t) {
+    var p = '/' + uuid.v4();
+
+    SERVER.get({
+        path: p,
+        version: ['1.2.0', '1.2.1', '1.2.2']
+    }, function (req, res, next) {
+        res.json(200, {
+            requestedVersion: req.version(),
+            matchedVersion: req.matchedVersion()
+        });
+        next();
+    });
+
+    var opts = {
+        path: p,
+        headers: {
+            'accept-version': '<1.2.2'
+        }
+    };
+
+    CLIENT.get(opts, function (err, _, res, obj) {
+        t.equal(obj.requestedVersion, '<1.2.2');
+        t.equal(obj.matchedVersion, '1.2.1');
+        t.end();
+    });
+});
+
 /* JSSTYLED */
 test('versioned route matching should prefer first match if equal versions', function (t) {
     var p = '/' + uuid.v4();


### PR DESCRIPTION
When a route is defined as responding to multiple version numbers then if the client supplies a version range that it can accept such as `accept-version: <2.2.0` it can be useful for the route to know exactly which version number from its array of supported versions matched the clients version specification.

req.version() already exposes the clients version string but it is often a range such as <2.2.0 or 2.*
req.matchedVersion() allows a route which matches versions 2.0.0, 2.1.0, and 2.2.0 to know that a client who specified `accept-version: <2.2.0` reached the route because 2.1.0 matched the request header.

This pull request includes documentation, and a test.