### PR TITLE
add options() and delete() methods to router

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -341,9 +341,11 @@ Server.prototype.close = function close(callback) {
  */
 [
     'del',
+    'delete',
     'get',
     'head',
     'opts',
+    'options',
     'post',
     'put',
     'patch'


### PR DESCRIPTION
express framework seems to use them instead of simply opts()
and del()
I've changed docrouter to make it comptatible with restify.
it was not too much work as it's comptatible with express.
but it would need this patchs to fully work, with the methods
defined as delete() instead of del()
