### PR TITLE
Remove superflous return for URLs like "socket.io"

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -248,9 +248,6 @@ function Server(options) {
 
     this.server.on('request', function onRequest(req, res) {
         self.emit('request', req, res);
-        /* JSSTYLED */
-        if (/^\/socket.io.*/.test(req.url))
-            return;
 
         self._setupRequest(req, res);
         self._handle(req, res);


### PR DESCRIPTION
A weird regex with a return means that requests to any restify server with a URL like
/socket.io
/socket.ioXXX
/socketXio
/socketXioXXX
will all just hang. I have no idea what this code was supposed to do, it looks like a paste error. Removing allowed our server to serve socket.io again.
