### PR TITLE
exposed EXPOSE_HEADERS in cors.js to enable custom header in response re...

### DIFF
--- a/lib/plugins/cors.js
+++ b/lib/plugins/cors.js
@@ -121,6 +121,7 @@ function cors(opts) {
 module.exports = cors;
 // All of these are needed for the pre-flight code over in lib/router.js
 cors.ALLOW_HEADERS = ALLOW_HEADERS;
+cors.EXPOSE_HEADERS = EXPOSE_HEADERS;
 cors.credentials = false;
 cors.origins = [];
 cors.matchOrigin = matchOrigin;


### PR DESCRIPTION
I needed to add custom headers that are readable in the respons part of a request. Similar as adding allow  headers by pushing  values into ALLOW_HEADERS, I propose the same for EXPOSE_HEADERS.

Hence, I exposed the stack in the cors object.
