### PR TITLE
modify type of `option.gzip` of StringClient to boolean

### DIFF
--- a/lib/clients/string_client.js
+++ b/lib/clients/string_client.js
@@ -17,7 +17,7 @@ var HttpClient = require('./http_client');
 
 function StringClient(options) {
     assert.object(options, 'options');
-    assert.optionalObject(options.gzip, 'options.gzip');
+    assert.optionalBool(options.gzip, 'options.gzip');
 
     options.accept = options.accept || 'text/plain';
     options.name = options.name || 'StringClient';


### PR DESCRIPTION
I saw that the following code only used `if (this.gzip)` for condition, so should it be boolean but not object?
