### PR TITLE
Isolated, host-based routes in a single Restify server

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -520,7 +520,7 @@ Router.prototype.find = function find(req, res, callback) {
     var host = req.headers['host'] || '*';
     var urls = Object.keys(this.reverse['*']);
     if (this.reverse[host]) {
-        urls.concat(Object.keys(this.reverse['*']));
+        urls = urls.concat(Object.keys(this.reverse[host]));
     }
     for (i = 0; i < urls.length; i++) {
         if (matchURL(new RegExp(urls[i]), req)) {

--- a/test/router-host.test.js
+++ b/test/router-host.test.js
@@ -88,6 +88,24 @@ test('request for /hello in subdomain 1', function(t) {
     });
 });
 
+test('request for /hello in subdomain 2', function(t) {
+    CLIENT.headers['Host'] = 'subdomain2.example.com';
+    CLIENT.get('/hello', function(err, req, res, data) {
+        t.ifError(err);
+        t.equal('hello from subdomain 2', data);
+        t.end();
+    });
+});
+
+test('request for /hello in subdomain 1 (cache bust)', function(t) {
+    CLIENT.headers['Host'] = 'subdomain1.example.com';
+    CLIENT.get('/hello', function(err, req, res, data) {
+        t.ifError(err);
+        t.equal('hello from subdomain 1', data);
+        t.end();
+    });
+});
+
 test('request for /bar in subdomain 1', function(t) {
     CLIENT.headers['Host'] = 'subdomain1.example.com';
     CLIENT.get('/bar', function(err, req, res, data) {
@@ -102,15 +120,6 @@ test('request for /bar in subdomain 2', function(t) {
     CLIENT.get('/bar', function(err, req, res, data) {
         t.ifError(err);
         t.equal('bar from subdomain 2', data);
-        t.end();
-    });
-});
-
-test('request for /hello in subdomain 2', function(t) {
-    CLIENT.headers['Host'] = 'subdomain2.example.com';
-    CLIENT.get('/hello', function(err, req, res, data) {
-        t.ifError(err);
-        t.equal('hello from subdomain 2', data);
         t.end();
     });
 });


### PR DESCRIPTION
The idea is to allow a single Restify server to serve multiple "sites", each with their separate set of routes, based on the `Host` header of the incoming web request. The problem with building something like that with Restify as of its current version is that all routes are, by default, shared by all the "sites" served from the same server.

These changes provide a way by which you can opt-in to Host-based routing in a Restify app. To do this, you need to tag your routes with the host that it belongs to:

``` javascript
server.get({ path: '/one', host: 'one.example.com' }, function(req, res, next) {
  res.end('One!');
  next();
});
server.get({ path: '/two', host: 'two.example.com' }, function(req, res, next) {
  res.end('Two!');
  next();
});
```

So, if you request `http://one.example.com/two`, or `http://two.example.com/one`, you'll get a `404`.

To implement this change, I have:
- changed the cache key only for the routes for which the host has been specified
- changed the schema of `reverse` from `reverse[route-source][http-method]` to `reverse[host][route-source][http-method]`. The default host is `*`.
- added a new test suite.

These changes shouldn't affect sites that don't opt-in in any way.
