### PR TITLE
pass maxFieldsSize parameter to formidable.

### DIFF
--- a/lib/plugins/multipart_parser.js
+++ b/lib/plugins/multipart_parser.js
@@ -39,6 +39,8 @@ function multipartBodyParser(options) {
         form.keepExtensions = options.keepExtensions ? true : false;
         if (options.uploadDir)
             form.uploadDir = options.uploadDir;
+        if (options.maxFieldsSize)
+            form.maxFieldsSize = options.maxFieldsSize;
 
         form.onPart = function onPart(part) {
             if (part.filename && options.multipartFileHandler)


### PR DESCRIPTION
Allow the default max parameter size for forms to be overridden.
