### PR TITLE
Enable setting multiples true for formidable

### DIFF
--- a/lib/plugins/multipart_parser.js
+++ b/lib/plugins/multipart_parser.js
@@ -36,6 +36,8 @@ function multipartBodyParser(options) {
             return (next());
 
         var form = new formidable.IncomingForm();
+        //enable multiple files on a single upload field
+        form.multiples = options.multiples || false;
         form.keepExtensions = options.keepExtensions ? true : false;
         if (options.uploadDir)
             form.uploadDir = options.uploadDir;


### PR DESCRIPTION
This offers support for multiple files on a single input field if multiples has been set in the options. I think it resolves issue: #627
