### PR TITLE
Update static.js to allow for serving static files that do not use the route as a path

### DIFF
--- a/lib/plugins/static.js
+++ b/lib/plugins/static.js
@@ -25,6 +25,7 @@ function serveStatic(opts) {
     assert.optionalNumber(opts.maxAge, 'options.maxAge');
     assert.optionalObject(opts.match, 'options.match');
     assert.optionalString(opts.charSet, 'options.charSet');
+    assert.optionalString(opts.file, 'options.file');
 
     var p = path.normalize(opts.directory).replace(/\\/g, '/');
     var re = new RegExp('^' + escapeRE(p) + '/?.*');
@@ -93,8 +94,18 @@ function serveStatic(opts) {
     }
 
     function serve(req, res, next) {
-        var file = path.join(opts.directory,
-            decodeURIComponent(req.path()));
+       var file;
+        if(opts.file)
+        {
+            //serves a direct file
+            file = path.join(opts.directory,
+            decodeURIComponent(opts.file))
+        }
+        else
+        {
+            file = path.join(opts.directory,
+            decodeURIComponent(req.path()));  
+        }
 
         if (req.method !== 'GET' && req.method !== 'HEAD') {
             next(new MethodNotAllowedError(req.method));


### PR DESCRIPTION
When using restify moving from express, I found sending a static file of which I knew the direct path to difficult when I was trying to map a route to it which did not contain the filename in it.

For example in express:

app.get('/cool', function (req, res) {
  res.sendFile("../public/coolindex.html");
}

the proposed change:
By sending a "file" option now with the serveStatic call you can serve a file which does not have its' filename present in the req.path there by mapping routes to static files.

Example usage:
app.get('/logins',
    restify.serveStatic({
      directory: './public',
      file: 'login.html'
    })
  );