### PR TITLE
Consider no_proxy env variable while setting proxy for clients

### DIFF
--- a/lib/clients/http_client.js
+++ b/lib/clients/http_client.js
@@ -252,6 +252,56 @@ function rawRequest(opts, cb) {
 } // end `rawRequest`
 
 
+//  Check if url is excluded by the no_proxy environment variable
+function isProxyForURL(address) {
+    var noProxy = process.env.NO_PROXY || process.env.no_proxy || null;
+
+    // wildcard
+    if (noProxy === '*') {
+        return (null);
+    }
+
+    // otherwise, parse the noProxy value to see if it applies to the URL
+    if (noProxy !== null) {
+        var noProxyItem, hostname, port, noProxyItemParts,
+            noProxyHost, noProxyPort, noProxyList;
+
+        // canonicalize the hostname
+        /* JSSTYLED */
+        hostname = address.hostname.replace(/^\.*/, '.').toLowerCase();
+        noProxyList = noProxy.split(',');
+
+        for (var i = 0, len = noProxyList.length; i < len; i++) {
+            noProxyItem = noProxyList[i].trim().toLowerCase();
+
+            // no_proxy can be granular at the port level
+            if (noProxyItem.indexOf(':') > -1) {
+                noProxyItemParts = noProxyItem.split(':', 2);
+                /* JSSTYLED */
+                noProxyHost = noProxyItemParts[0].replace(/^\.*/, '.');
+                noProxyPort = noProxyItemParts[1];
+                port = address.port ||
+                    (address.protocol === 'https:' ? '443' : '80');
+
+                // match - ports are same and host ends with no_proxy entry.
+                if (port === noProxyPort &&
+                    hostname.indexOf(noProxyHost) ===
+                    hostname.length - noProxyHost.length) {
+                    return (null);
+                }
+            } else {
+                /* JSSTYLED */
+                noProxyItem = noProxyItem.replace(/^\.*/, '.');
+                var isMatchedAt = hostname.indexOf(noProxyItem);
+                if (isMatchedAt > -1 &&
+                    isMatchedAt === hostname.length - noProxyItem.length) {
+                    return (null);
+                }
+            }
+        }
+    }
+    return (true);
+}
 ///--- API
 
 function HttpClient(options) {
@@ -289,6 +339,11 @@ function HttpClient(options) {
         this.rejectUnauthorized = true;
     }
 
+    this.retry = cloneRetryOptions(options.retry);
+    this.signRequest = options.signRequest || false;
+    this.socketPath = options.socketPath || false;
+    this.url = options.url ? url.parse(options.url) : {};
+
     if (process.env.https_proxy) {
         this.proxy = url.parse(process.env.https_proxy);
     } else if (process.env.http_proxy) {
@@ -299,11 +354,9 @@ function HttpClient(options) {
         this.proxy = false;
     }
 
-    this.retry = cloneRetryOptions(options.retry);
-    this.signRequest = options.signRequest || false;
-    this.socketPath = options.socketPath || false;
-    this.url = options.url ? url.parse(options.url) : {};
-
+    if (this.proxy && !isProxyForURL(self.url)) {
+        this.proxy = false;
+    }
     if (options.accept) {
         if (options.accept.indexOf('/') === -1)
             options.accept = mime.lookup(options.accept);

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -864,6 +864,11 @@ test('GH-738 respect NO_PROXY while setting proxy', function (t) {
     t.equal(false, clientWithoutProxy.proxy);
     t.done();
 
-    process.env.https_proxy = origProxy;
+    //Setting process.env.https_proxy to undefined, converts it to 'undefined'
+    if (typeof (origProxy) === 'undefined') {
+        delete process.env.https_proxy;
+    } else {
+        process.env.https_proxy = origProxy;
+    }
     process.env.NO_PROXY = origNoProxy;
 });


### PR DESCRIPTION
The policy is similar to what [request](https://github.com/request/request#proxies) uses.

no_proxy should contain a comma separated list of hosts to opt out of proxying.
It is also possible to opt of proxying when a particular destination port is used.
Finally, the variable may be set to * to opt out of the implicit proxy configuration of the other environment variables.

