### PR TITLE
Request

### DIFF
--- a/docs/index.restdown
+++ b/docs/index.restdown
@@ -1005,6 +1005,10 @@ This logger can be used normally, with [req.log](#Request-API).
 This plugin does _not_ log each individual request. Use the Audit Logging
 plugin or a custom middleware for that use.
 
+Options:
+  * `headers` - A list of headers to transfer from the request to top level
+    props on the log.
+
 ### GzipResponse
 
     server.use(restify.gzipResponse());

--- a/lib/plugins/bunyan.js
+++ b/lib/plugins/bunyan.js
@@ -27,7 +27,7 @@ function requestLogger(options) {
 
     var headersToCopy = options.headers || [];
 
-    function bunyan(req, res, next) {
+    return function bunyan(req, res, next) {
         if (!req.log && !options.log) {
             next();
             return;
@@ -36,7 +36,8 @@ function requestLogger(options) {
         var log = req.log || options.log;
 
         props.req_id = req.getId();
-        headersToCopy.forEach(function(k) {
+        headersToCopy.forEach(function (k) {
+
             if (req.headers[k]) {
                 props[k] = req.headers[k];
             }
@@ -49,8 +50,6 @@ function requestLogger(options) {
 
         next();
     };
-
-    return (bunyan);
 }
 
 

--- a/lib/plugins/bunyan.js
+++ b/lib/plugins/bunyan.js
@@ -25,6 +25,8 @@ function requestLogger(options) {
         props.serializers = options.serializers;
     }
 
+    var headersToCopy = options.headers || [];
+
     function bunyan(req, res, next) {
         if (!req.log && !options.log) {
             next();
@@ -34,6 +36,11 @@ function requestLogger(options) {
         var log = req.log || options.log;
 
         props.req_id = req.getId();
+        headersToCopy.forEach(function(k) {
+            if (req.headers[k]) {
+                props[k] = req.headers[k];
+            }
+        });
         req.log = log.child(props, props.serializers ? false : true);
 
         if (props.req_id) {
@@ -41,7 +48,7 @@ function requestLogger(options) {
         }
 
         next();
-    }
+    };
 
     return (bunyan);
 }

--- a/lib/response.js
+++ b/lib/response.js
@@ -33,7 +33,8 @@ Response.prototype.cache = function cache(type, options) {
         type += ', max-age=' + options.maxAge;
     }
 
-    return (this.header('Cache-Control', type)); };
+    return (this.header('Cache-Control', type));
+};
 
 Response.prototype.noCache = function noCache() {
     // HTTP 1.1

--- a/lib/response.js
+++ b/lib/response.js
@@ -33,9 +33,7 @@ Response.prototype.cache = function cache(type, options) {
         type += ', max-age=' + options.maxAge;
     }
 
-    return (this.header('Cache-Control', type));
-};
-
+    return (this.header('Cache-Control', type)); };
 
 Response.prototype.noCache = function noCache() {
     // HTTP 1.1

--- a/test/plugins.test.js
+++ b/test/plugins.test.js
@@ -1169,4 +1169,5 @@ function serveStaticTest(t, testDefault, tmpDir, regex) {
             });
         });
     });
+
 }

--- a/test/plugins.test.js
+++ b/test/plugins.test.js
@@ -1091,6 +1091,33 @@ test('request expiry testing to ensure that valid ' +
     });
 });
 
+test('tests the requestLoggers extra header properties', function (t) {
+    var key = 'x-request-uuid';
+    var badKey = 'x-foo-bar';
+    var getPath = '/requestLogger/extraHeaders';
+    var headers = [key, badKey];
+    SERVER.get(
+        getPath,
+        restify.requestLogger({headers: headers}),
+        function (req, res, next) {
+            t.equal(req.log.fields[key], 'foo-for-eva');
+            t.equal(req.log.fields.hasOwnProperty(badKey), false);
+            res.send();
+            next();
+        });
+
+    var obj = {
+        path: getPath,
+        headers: { }
+    };
+    obj.headers[key] = 'foo-for-eva';
+    CLIENT.get(obj, function (err, _, res) {
+        t.equal(res.statusCode, 200);
+        t.ifError(err);
+        t.end();
+    });
+});
+
 
 ///--- Privates
 function serveStaticTest(t, testDefault, tmpDir, regex) {


### PR DESCRIPTION
The purpose of this PR is to be able to specify a list of header keys to transfer from the request header to the props object of the request logger.  This will make the headers top level vars on the bunyan log.