### PR TITLE
Update all links to the new github organization location

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # restify
 
-[![Build Status](https://travis-ci.org/mcavage/node-restify.svg)](https://travis-ci.org/mcavage/node-restify)
+[![Build Status](https://travis-ci.org/restify/node-restify.svg)](https://travis-ci.org/restify/node-restify)
 [![Gitter chat](https://badges.gitter.im/mcavage/node-restify.svg)](https://gitter.im/mcavage/node-restify)
-[![Dependency Status](https://david-dm.org/mcavage/node-restify.svg)](https://david-dm.org/mcavage/node-restify)
-[![devDependency Status](https://david-dm.org/mcavage/node-restify/dev-status.svg)](https://david-dm.org/mcavage/node-restify#info=devDependencies)
+[![Dependency Status](https://david-dm.org/restify/node-restify.svg)](https://david-dm.org/restify/node-restify)
+[![devDependency Status](https://david-dm.org/restify/node-restify/dev-status.svg)](https://david-dm.org/restify/node-restify#info=devDependencies)
 
 
-[restify](http://mcavage.github.com/node-restify) is a smallish framework,
+[restify](http://restifyjs.com) is a smallish framework,
 similar to [express](http://expressjs.com) for building REST APIs.  For full
 details, see http://restifyjs.com
 
@@ -82,7 +82,7 @@ SOFTWARE.
 
 ## Bugs
 
-See <https://github.com/mcavage/node-restify/issues>.
+See <https://github.com/restify/node-restify/issues>.
 
 ## Mailing list
 

--- a/docs/branding/header.html.in
+++ b/docs/branding/header.html.in
@@ -7,7 +7,7 @@
     <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
 </head>
 <body>
-  <a href="http://github.com/mcavage/node-restify">
+  <a href="http://github.com/restify/node-restify">
     <img style="position: absolute; top: 0; right: 0; border: 0; z-index: 3;"
          src="https://a248.e.akamai.net/assets.github.com/img/7afbc8b248c68eb468279e8c17986ad46549fb71/687474703a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67"
          alt="Fork me on GitHub"/ >

--- a/docs/index.restdown
+++ b/docs/index.restdown
@@ -44,7 +44,7 @@ Note this documentation refers to the 2.x version(s) of restify;
 these versions are not backwards-compatible with the 0.x and 1.x versions.
 
 If you're migrating from an earlier version of restify, see
-[1.4 to 2.0 Migration Tips](https://github.com/mcavage/node-restify/wiki/1.4-to-2.0-Migration-Tips)
+[1.4 to 2.0 Migration Tips](https://github.com/restify/node-restify/wiki/1.4-to-2.0-Migration-Tips)
 
 ## Conventions
 
@@ -793,7 +793,7 @@ a hook to change request headers and the like if you need to. Note that
     });
 
 You can also clean up URLs before routes are matched with the built in
-`restify.pre.sanitizePath`. This [re-implements v1.4 behaviour](https://github.com/mcavage/node-restify/wiki/1.4-to-2.0-Migration-Tips#trailing--characters)
+`restify.pre.sanitizePath`. This [re-implements v1.4 behaviour](https://github.com/restify/node-restify/wiki/1.4-to-2.0-Migration-Tips#trailing--characters)
 
     server.pre(restify.pre.sanitizePath());
 

--- a/examples/todoapp/package.json
+++ b/examples/todoapp/package.json
@@ -7,7 +7,7 @@
                 "assert-plus": "0.1.2",
                 "bunyan": "0.21.1",
                 "posix-getopt": "1.0.0",
-                "restify": "git://github.com/mcavage/node-restify.git#master"
+                "restify": "git://github.com/restify/node-restify.git#master"
         },
         "devDependencies": {
                 "nodeunit": "0.8.0"

--- a/package.json
+++ b/package.json
@@ -37,12 +37,12 @@
     "Yunong Xiao"
   ],
   "name": "restify",
-  "homepage": "http://mcavage.github.com/node-restify",
+  "homepage": "http://restifyjs.com",
   "description": "REST framework",
   "version": "3.0.3",
   "repository": {
     "type": "git",
-    "url": "git://github.com/mcavage/node-restify.git"
+    "url": "git://github.com/restify/node-restify.git"
   },
   "main": "lib/index.js",
   "directories": {


### PR DESCRIPTION
 - Update links from github.com/mcavage/node-restify/ to
   github.com/restify/node-restify
 - Update links for mcavage.github.com to restifyjs.com