### PR TITLE
don't include (large) coverage files in published packages

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,9 @@
+.coverage_data
 .dir-locals.el
 .gitmodules
 .travis.yml
 Makefile
+cover_html
 deps
 docs
 examples


### PR DESCRIPTION
E.g. in restify@3.0.3 these are:

    $ du -sh ...
    1.3M cover_html
    1.8M .coverage_data

Details:

```
$ npm install restify@3.0.3
...
$ du -sh * .??*
 16K	CHANGES.md
4.0K	LICENSE
4.0K	README.md
8.0K	bin
1.3M	cover_html
268K	lib
4.0M	node_modules
8.0K	package.json
1.8M	.coverage_data
4.0K	.npmignore
```