### PR TITLE
req.getQuery() always returns a string

### DIFF
--- a/docs/index.restdown
+++ b/docs/index.restdown
@@ -1339,6 +1339,12 @@ instance that is a child component of the one restify has:
 
     var log = req.getLogger('MyFoo');
 
+### getQuery()
+
+Returns the raw query string. Returns empty string if no query string is found.
+To get the parsed query object, use the `queryParser` plugin. More info can
+be found about the plugin in the [bundled plugins](#bundled-plugins) section.
+
 ### time()
 
 The time when this request arrived (ms since epoch)

--- a/lib/request.js
+++ b/lib/request.js
@@ -167,9 +167,16 @@ Request.prototype.getPath = function getPath() {
 };
 Request.prototype.path = Request.prototype.getPath;
 
-
+/**
+ * returns the raw query string
+ * @public
+ * @return {String}
+ */
 Request.prototype.getQuery = function getQuery() {
-    return (this.getUrl().query || {});
+    // always return a string, because this is the raw query string.
+    // if the queryParser plugin is used, req.query will provide an empty
+    // object fallback.
+    return (this.getUrl().query || '');
 };
 Request.prototype.query = Request.prototype.getQuery;
 

--- a/test/plugins.test.js
+++ b/test/plugins.test.js
@@ -166,8 +166,7 @@ test('query ok', function (t) {
 
 test('GH-124 query ok no query string', function (t) {
     SERVER.get('/query/:id', function (req, res, next) {
-        t.ok(req.getQuery());
-        t.equal(typeof (req.getQuery()), 'object');
+        t.equal(req.getQuery(), '');
         res.send();
         next();
     });

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -1,0 +1,91 @@
+'use strict';
+
+
+var restify = require('../lib');
+
+if (require.cache[__dirname + '/lib/helper.js']) {
+    delete require.cache[__dirname + '/lib/helper.js'];
+}
+var helper = require('./lib/helper.js');
+
+
+///--- Globals
+
+var after = helper.after;
+var before = helper.before;
+var test = helper.test;
+
+var PORT = process.env.UNIT_TEST_PORT || 0;
+var CLIENT;
+var SERVER;
+
+
+before(function (cb) {
+    try {
+        SERVER = restify.createServer({
+            dtrace: helper.dtrace,
+            log: helper.getLog('server')
+        });
+        SERVER.listen(PORT, '127.0.0.1', function () {
+            PORT = SERVER.address().port;
+            CLIENT = restify.createJsonClient({
+                url: 'http://127.0.0.1:' + PORT,
+                dtrace: helper.dtrace,
+                retry: false
+            });
+
+            cb();
+        });
+    } catch (e) {
+        console.error(e.stack);
+        process.exit(1);
+    }
+});
+
+
+after(function (cb) {
+    try {
+        CLIENT.close();
+        SERVER.close(function () {
+            CLIENT = null;
+            SERVER = null;
+            cb();
+        });
+    } catch (e) {
+        console.error(e.stack);
+        process.exit(1);
+    }
+});
+
+
+test('query should return empty string', function (t) {
+    SERVER.get('/emptyQs', function (req, res, next) {
+        t.equal(req.query(), '');
+        t.equal(req.getQuery(), '');
+        res.send();
+        next();
+    });
+
+    CLIENT.get('/emptyQs', function (err, _, res) {
+        t.ifError(err);
+        t.equal(res.statusCode, 200);
+        t.end();
+    });
+});
+
+
+test('query should return raw query string string', function (t) {
+    SERVER.get('/qs', function (req, res, next) {
+        t.equal(req.query(), 'a=1&b=2');
+        t.equal(req.getQuery(), 'a=1&b=2');
+        res.send();
+        next();
+    });
+
+    CLIENT.get('/qs?a=1&b=2', function (err, _, res) {
+        t.ifError(err);
+        t.equal(res.statusCode, 200);
+        t.end();
+    });
+});
+


### PR DESCRIPTION
Fixes #374, but also changes the default behavior of req.getQuery(). There was some blurring of behavior between the default behavior, and the behavior expected from using the queryParser plugin.

Previously, if you were not using the queryParser plugin, you'd get an empty object, which is consistent with behavior from the queryParser plugin, but __inconsistent__ with the behavior of req.getQuery().

```
/foo 
req.getQuery(); // => {}
req.query; // => {}

/foo?a=1
req.getQuery(); // => 'a=1'
req.query; // => {a: 1}
```

With this pull request, the behavior is now:

```
/foo 
req.getQuery(); // => ''
req.query; // => {}
```

If you're using the plugin, you'll always get objects returned using `req.query`, but now `req.getQuery()` will consistently return a string even if you don't use the queryParser plugin.