### PR TITLE
Copied fix from #694 and added test to verify

### DIFF
--- a/docs/index.restdown
+++ b/docs/index.restdown
@@ -948,6 +948,7 @@ supported.
         keepExtensions: false,
         uploadDir: os.tmpdir(),
         multiples: true
+        hash: 'sha1'
      }));
 
 Options:
@@ -984,6 +985,7 @@ Options:
     before the contents is mapped into `req.params`. Does nothing
     if `multipartFileHandler` is defined.
   * `multiples` - if you want to support html5 multiple attribute in upload fields.
+  * `hash` - If you want checksums calculated for incoming files, set this to either `sha1` or `md5`.
 
 ### RequestLogger
 

--- a/lib/plugins/multipart_parser.js
+++ b/lib/plugins/multipart_parser.js
@@ -54,6 +54,10 @@ function multipartBodyParser(options) {
             form.maxFieldsSize = options.maxFieldsSize;
         }
 
+        if (options.hash) {
+            form.hash = options.hash;
+        }
+
         form.onPart = function onPart(part) {
             if (part.filename && options.multipartFileHandler) {
                 options.multipartFileHandler(part, req);

--- a/test/plugins.test.js
+++ b/test/plugins.test.js
@@ -359,6 +359,46 @@ test('body multipart ok custom handling', function (t) {
     client.end();
 });
 
+test('GH-694 pass hash option through to Formidable', function (t) {
+    var content = 'Hello World!';
+    var hash = '2ef7bde608ce5404e97d5f042f95f89f1c232871';
+    SERVER.post('/multipart',
+        restify.bodyParser({hash: 'sha1'}),
+        function (req, res, next) {
+            t.equal(req.files.details.hash, hash);
+            res.send();
+            next();
+        });
+
+    var opts = {
+        hostname: '127.0.0.1',
+        port: PORT,
+        path: '/multipart',
+        agent: false,
+        method: 'POST',
+        headers: {
+            'Content-Type': 'multipart/form-data; boundary=huff'
+        }
+    };
+
+    var client = http.request(opts, function (res) {
+        t.equal(res.statusCode, 200);
+        t.end();
+    });
+
+    client.write('--huff\r\n');
+
+    // jscs:disable maximumLineLength
+    client.write('Content-Disposition: form-data; name="details"; filename="mood_details.txt"\r\n');
+
+    // jscs:enable maximumLineLength
+    client.write('Content-Type: text/plain\r\n\r\n');
+    client.write(content + '\r\n');
+    client.write('--huff--');
+
+    client.end();
+});
+
 test('body json ok', function (t) {
     SERVER.post('/body/:id',
         restify.bodyParser(),


### PR DESCRIPTION
Took up where PR #694 left off to add support passing the hash option to Formidable for multipart file uploads.