### PR TITLE
Add iojs to travis config for builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
-   - 0.10
-   - 0.12
+   - "0.10"
+   - "0.12"
+   - "iojs"
 notifications:
   webhooks:
     urls:


### PR DESCRIPTION
With the re-unification of Node and IOjs on the horizon, it makes sense to add iojs as a build option in the travis yaml configuration.

I've also quoted both the 0.10 and 0.12 parameters, so they showed up properly in Travis.

