### PR TITLE
Send 500 status if async formatter sends error

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -302,9 +302,12 @@ Response.prototype.send = function send(code, body, headers) {
 
     this._body = body;
 
-    // TODO: restify doesn't ship with any async formatters, but
-    // presumably if an async formatter blows up, we should return a 500.
-    function _cb(err, _body) { // eslint-disable-line handle-callback-err
+    function _cb(err, _body) {
+        // If an async formatter blows up, we should return a 500.
+        if (Error.prototype.isPrototypeOf(err)) {
+            self.statusCode = 500;
+        }
+
         self._data = _body;
         Object.keys(headers).forEach(function (k) {
             self.setHeader(k, headers[k]);

--- a/test/formatter.test.js
+++ b/test/formatter.test.js
@@ -21,6 +21,7 @@ var CLIENT;
 var SERVER;
 
 var isFirstRequest = true;
+var isSecondRequest = true;
 
 
 ///--- Tests
@@ -34,6 +35,14 @@ before(function (callback) {
                         process.nextTick(function () {
                             isFirstRequest = false;
                             cb(null, 'async fmt');
+                        });
+                        return (this);
+                    }
+
+                    if (isSecondRequest) {
+                        process.nextTick(function () {
+                            isSecondRequest = false;
+                            cb(new Error('async fmt failed'), null);
                         });
                         return (this);
                     }
@@ -87,6 +96,17 @@ test('async formatter', function (t) {
         t.ok(req);
         t.ok(res);
         t.equal(data, 'async fmt');
+        t.end();
+    });
+});
+
+
+test('async formatter blow up', function (t) {
+    CLIENT.get('/tmp', function (err, req, res, data) {
+        t.ok(err);
+        t.ok(req);
+        t.ok(res);
+        t.equal(res.statusCode, 500);
         t.end();
     });
 });


### PR DESCRIPTION
# Async Formatter Handling Errors

**lib/response.js** contained a TODO and ESLint override related to the async formatter handler not dealing with errors being passed back. This TODO caused a warning in the lint task which led to me trying to tackle this in the lightest manner possible.