### PR TITLE
Support URLs that have a path component

### DIFF
--- a/lib/clients/http_client.js
+++ b/lib/clients/http_client.js
@@ -630,14 +630,15 @@ HttpClient.prototype._options = function (method, options) {
 
     // url[http://localhost:3000/something] + get[/foo] -> http://localhost:3000/something/foo
     if (opts.path) {
-        if (this.url.path[this.url.path.length-1] == '/' && opts.path[0] == '/') {
+        if ( this.url.path[this.url.path.length - 1] === '/' &&
+            opts.path[0] === '/' ) {
+
             opts.path = this.url.path + opts.path.substr(1);
-        }
-        else {
+        } else {
             opts.path = this.url.path + opts.path;
         }
     }
-    
+
     Object.keys(this.url).forEach(function (k) {
         if (!opts[k]) {
             opts[k] = self.url[k];

--- a/lib/clients/http_client.js
+++ b/lib/clients/http_client.js
@@ -628,6 +628,11 @@ HttpClient.prototype._options = function (method, options) {
         opts.socketPath = this.socketPath;
     }
 
+    // url[http://localhost:3000/something] + get[/foo] -> http://localhost:3000/something/foo
+    if (opts.path) {
+        opts.path = this.url.path + opts.path;
+    }
+    
     Object.keys(this.url).forEach(function (k) {
         if (!opts[k]) {
             opts[k] = self.url[k];

--- a/lib/clients/http_client.js
+++ b/lib/clients/http_client.js
@@ -630,7 +630,12 @@ HttpClient.prototype._options = function (method, options) {
 
     // url[http://localhost:3000/something] + get[/foo] -> http://localhost:3000/something/foo
     if (opts.path) {
-        opts.path = this.url.path + opts.path;
+        if (this.url.path[this.url.path.length-1] == '/' && opts.path[0] == '/') {
+            opts.path = this.url.path + opts.path.substr(1);
+        }
+        else {
+            opts.path = this.url.path + opts.path;
+        }
     }
     
     Object.keys(this.url).forEach(function (k) {

--- a/lib/clients/http_client.js
+++ b/lib/clients/http_client.js
@@ -21,6 +21,7 @@ var tunnelAgent = require('tunnel-agent');
 var dtrace = require('../dtrace');
 var errors = require('../errors');
 var bunyan = require('../bunyan_helper');
+var utils = require('../utils');
 
 // Use native KeepAlive in Node as of 0.11.6
 var semver = require('semver');
@@ -628,15 +629,13 @@ HttpClient.prototype._options = function (method, options) {
         opts.socketPath = this.socketPath;
     }
 
-    // url[http://localhost:3000/something] + get[/foo] -> http://localhost:3000/something/foo
-    if (opts.path) {
-        if ( this.url.path[this.url.path.length - 1] === '/' &&
-            opts.path[0] === '/' ) {
-
-            opts.path = this.url.path + opts.path.substr(1);
-        } else {
-            opts.path = this.url.path + opts.path;
-        }
+    // Add the request path to the base path of the client
+    // Don't combine the request url and client path if they both
+    // have a slash
+    if (opts.path && this.url.path &&
+        opts.path !== '/' && this.url.path !== '/') {
+        // clean up the url path, stripping the last /
+        opts.path = utils.sanitizePath([this.url.path, opts.path].join('/'));
     }
 
     Object.keys(this.url).forEach(function (k) {

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -972,3 +972,54 @@ test('GH-738 respect NO_PROXY while setting proxy', function (t) {
     }
     process.env.NO_PROXY = origNoProxy;
 });
+
+
+test('GH-628 create JSON client with a path prefix \
+     and trailing slash', function (t) {
+    var client = restify.createJsonClient({
+        url: 'http://127.0.0.1:' + PORT + '/json/'
+    });
+    client.agent = false;
+
+    client.get('/mcavage', function (err, req, res, obj) {
+        t.deepEqual(obj, {hello: 'mcavage'});
+        t.end();
+    });
+});
+
+
+test('GH-628 create JSON client with a path prefix', function (t) {
+    var client = restify.createJsonClient({
+        url: 'http://127.0.0.1:' + PORT + '/json'
+    });
+    client.agent = false;
+
+    client.get('/mcavage', function (err, req, res, obj) {
+        t.deepEqual(obj, {hello: 'mcavage'});
+        t.end();
+    });
+});
+
+
+test('GH-628 create base client with a path prefix', function (t) {
+    var client = restify.createClient({
+        url: 'http://127.0.0.1:' + PORT + '/str'
+    });
+    client.agent = false;
+
+    client.get('/mcavage', function (err, req, res, data) {
+        req.on('result', function (error, response) {
+            t.ifError(error);
+            response.body = '';
+            response.setEncoding('utf8');
+            response.on('data', function (chunk) {
+                response.body += chunk;
+            });
+
+            response.on('end', function () {
+                t.equal(response.body, '"hello mcavage"');
+                t.end();
+            });
+        });
+    });
+});


### PR DESCRIPTION
Combine both PRs #633 and #628 

Pull the logic from #633 and clean it up a bit
Pull the tests from #628

Thanks to both @nakosung and @calebbrown for their contributions.

The goal of this PR is to use the path from both the Client options and the requested url.

For example, when a user creates a client for a non-root url, any subsequent requests should use that as part of the request path.

```javascript
var client = restify.createClient({
    url: 'http://127.0.0.1/str'
});

client.get('/foo', function (err, req, res, data){});
```

The resulting request should go to `http://127.0.0.1/str/foo`.
