### PR TITLE
restify version bump so that a tag can be cut.

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "name": "restify",
   "homepage": "http://restifyjs.com",
   "description": "REST framework",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "repository": {
     "type": "git",
     "url": "git://github.com/restify/node-restify.git"


### PR DESCRIPTION
I need access to the `requestExpiry` plugin.  So i need to get a new tag published.  @yunong could you cut a tag / publish npm when you can?