### PR TITLE
Improve request handler name handling

### DIFF
--- a/docs/index.restdown
+++ b/docs/index.restdown
@@ -244,6 +244,28 @@ Note that `foo` only gets run once in that example.  A few caveats:
   routing chain once (this is a limitation of the way routes are stored
   internally, and may be revisited someday).
 
+### Naming Handlers
+
+It's possible to name a handler. This name will be used for logging purpose mainly.
+
+If handler is a named function, this function name will be used.
+
+If the handler is anonymous function (or binded function), or if you want to
+override the function's name, just add a string "handlerName" property to the handler function.
+
+    function myHandler(req, res, next) {
+        res.send(200);
+        return next();
+    }
+
+    myHandler.handlerName = 'myRenamedHandler';
+
+    server.get(
+        '/foo',
+        myHandler
+    );
+
+
 ### Chaining Handlers
 
 Routes can also accept more than one handler function. For instance:

--- a/lib/server.js
+++ b/lib/server.js
@@ -891,13 +891,15 @@ Server.prototype._run = function _run(req, res, route, chain, cb) {
                 return (next());
             }
 
+            handlerName = (chain[i].handlerName ||
+                           chain[i].name ||
+                           ('handler-' + req._anonFuncCount++));
+
             if (log.trace()) {
-                log.trace('running %s', chain[i].name || '?');
+                log.trace('running %s', handlerName);
             }
 
             req._currentRoute = (route !== null ? route.name : 'pre');
-            handlerName = (chain[i].name ||
-                           ('handler-' + req._anonFuncCount++));
             req._currentHandler = handlerName;
             req.startHandlerTimer(handlerName);
 


### PR DESCRIPTION
This change allow request handler dev to force a name for a request handler and see this name in bunyan logs instead of a meaningless "?"