### PR TITLE
Allow objects for errors when calling next()

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -842,7 +842,7 @@ Server.prototype._run = function _run(req, res, route, chain, cb) {
                 done = true;
             } else if ( typeof arg === 'object' ) {
                 log.trace({err: arg, errName: 'Unknown'}, 'next(err=Unknown)');
-                res.send(arg, arg.statusCode || 500 );
+                res.send(arg.statusCode || 500, arg);
                 done = true;
             } else if (typeof (arg) === 'string') { // GH-193, allow redirect
                 if (req._rstfy_chained_route) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -840,6 +840,10 @@ Server.prototype._run = function _run(req, res, route, chain, cb) {
                     res.send(arg);
                 }
                 done = true;
+            } else if ( typeof arg === 'object' ) {
+                log.trace({err: arg, errName: 'Unknown'}, 'next(err=Unknown)');
+                res.send(arg);
+                done = true;
             } else if (typeof (arg) === 'string') { // GH-193, allow redirect
                 if (req._rstfy_chained_route) {
                     var _e = new errors.InternalError();

--- a/lib/server.js
+++ b/lib/server.js
@@ -842,7 +842,7 @@ Server.prototype._run = function _run(req, res, route, chain, cb) {
                 done = true;
             } else if ( typeof arg === 'object' ) {
                 log.trace({err: arg, errName: 'Unknown'}, 'next(err=Unknown)');
-                res.send(arg);
+                res.send(arg, arg.statusCode || 500 );
                 done = true;
             } else if (typeof (arg) === 'string') { // GH-193, allow redirect
                 if (req._rstfy_chained_route) {


### PR DESCRIPTION
I was surprised when I tried the following code and it allowed the handler chain to proceed:

```javascript
function someMiddleware( request, response, next ) {
    // ...
    next( {
        error: 'permission denied',
        message: 'You do not have permission.',
        statusCode: 403
    } );
}
```

This change allows passing an object to next() that will be sent as an error.