### PR TITLE
Add `all` to server API

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -44,6 +44,17 @@ var PROXY_EVENTS = [
 ];
 
 
+var VERBS = [
+    'del',
+    'get',
+    'head',
+    'opts',
+    'post',
+    'put',
+    'patch'
+];
+
+
 ///--- Helpers
 
 /**
@@ -430,15 +441,7 @@ Server.prototype.close = function close(callback) {
  *                                 if options, the URL to handle, at minimum.
  * @returns {Route}                the newly created route.
  */
-[
-    'del',
-    'get',
-    'head',
-    'opts',
-    'post',
-    'put',
-    'patch'
-].forEach(function (method) {
+VERBS.forEach(function (method) {
         Server.prototype[method] = function (opts) {
             if (opts instanceof RegExp || typeof (opts) === 'string') {
                 opts = {
@@ -506,6 +509,35 @@ Server.prototype.close = function close(callback) {
             return (route);
         };
     });
+
+/**
+ * Minimal port of the functionality offered by Express.js
+ * @link http://expressjs.com/guide/routing.html
+ *
+ * This basically piggy-backs on the `server[verb]` methods.
+ *
+ * Exposes an API:
+ *   server.all("/foo", function (req, res, next) {
+ *     // Your handler logic here
+ *   });
+ *
+ * @public
+ * @function all
+ * @param   {String | Object} opts if string, the URL to handle.
+ *                                 if options, the URL to handle, at minimum.
+ * @returns {Object}               A map of the newly created routes.
+ */
+Server.prototype.all = function all() {
+    var self = this;
+    var args = Array.prototype.slice.call(arguments, 0);
+
+    return VERBS.reduce(function addHandlerForVerb(routeMap, verb) {
+        routeMap[verb] = self[verb].apply(self, args);
+        return routeMap;
+    }, { });
+};
+
+
 
 
 /**

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -249,6 +249,64 @@ test('PUT ok', function (t) {
 });
 
 
+[
+  'DELETE',
+  'GET',
+  'HEAD',
+  'PATCH',
+  'POST',
+  'PUT'
+].forEach(function testForVerb(VERB) {
+    test('all "' + VERB + '" ok', function (t) {
+        SERVER.all('/foo/:id', function tester(req, res, next) {
+            t.ok(req.params);
+            t.equal(req.params.id, 'bar');
+            res.send();
+            next();
+        });
+
+        var opts = {
+            hostname: '127.0.0.1',
+            port: PORT,
+            path: '/foo/bar',
+            method: VERB,
+            agent: false
+        };
+        http.request(opts, function (res) {
+            t.equal(res.statusCode, 200);
+            res.on('end', function () {
+                t.end();
+            });
+            res.resume();
+        }).end();
+    });
+});
+
+test('all returns a Route map', function (t) {
+    var routeMap = SERVER.all('/foo/:id', function noop () { });
+
+    var keys = Object.keys(routeMap);
+
+    t.deepEqual(keys, [
+        'del',
+        'get',
+        'head',
+        'opts',
+        'post',
+        'put',
+        'patch'
+    ]);
+
+    t.ok(keys.map(function mapToRoute(key) {
+        return routeMap[key];
+    }).every(function isString(route) {
+        return typeof route === 'string';
+    }));
+
+    t.end();
+});
+
+
 test('PATCH ok', function (t) {
     SERVER.patch('/foo/:id', function tester(req, res, next) {
         t.ok(req.params);


### PR DESCRIPTION
Added a `server.all` method, which is primarily a sugar method, but makes migrating from Express easier and makes leveraging Express knowledge for Restify easier.