### PR TITLE
Make sure signRequest is called before send

### DIFF
--- a/lib/clients/http_client.js
+++ b/lib/clients/http_client.js
@@ -213,6 +213,10 @@ function rawRequest(opts, cb) {
         req.emit('upgradeResult', (err || null), res, socket, _head);
     });
 
+    if (opts.signRequest) {
+        opts.signRequest(req);
+    }
+
     req.once('socket', function onSocket(socket) {
         var _socket = socket;
 
@@ -257,10 +261,6 @@ function rawRequest(opts, cb) {
             cb(null, req);
         });
     });
-
-    if (opts.signRequest) {
-        opts.signRequest(req);
-    }
 
     if (log.trace()) {
         log.trace({client_req: opts}, 'request sent');


### PR DESCRIPTION
If the socket connected very quickly (e.g. to localhost), the signRequest
callback was never called.