### PR TITLE
Removing replace logic for route name

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -225,8 +225,7 @@ Router.prototype.render = function render(routeName, params, query) {
         return (encodeURIComponent(key) + '=' + encodeURIComponent(query[key]));
     }
 
-    var routeKey = routeName.replace(/\W/g, '').toLowerCase();
-    var route = this.mounts[routeKey];
+    var route = this.mounts[routeName];
 
     if (!route) {
         return (null);
@@ -367,10 +366,8 @@ Router.prototype.get = function get(name, req, cb) {
     var route = false;
     var routes = this.routes[req.method] || [];
 
-    var routeName = name.replace(/\W/g, '').toLowerCase();
-
     for (var i = 0; i < routes.length; i++) {
-        if (routes[i].name === routeName) {
+        if (routes[i].name === name) {
             route = routes[i];
 
             try {

--- a/lib/server.js
+++ b/lib/server.js
@@ -490,10 +490,7 @@ Server.prototype.close = function close(callback) {
                 if (this.router.mounts[opts.name]) { // GH-401
                     opts.name += uuid.v4().substr(0, 7);
                 }
-            } else {
-                opts.name = opts.name.replace(/\W/g, '').toLowerCase();
             }
-
 
             if (!(route = this.router.mount(opts))) {
                 return (false);

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "name": "restify",
   "homepage": "http://restifyjs.com",
   "description": "REST framework",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "repository": {
     "type": "git",
     "url": "git://github.com/restify/node-restify.git"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "name": "restify",
   "homepage": "http://restifyjs.com",
   "description": "REST framework",
-  "version": "4.1.0",
+  "version": "4.0.0",
   "repository": {
     "type": "git",
     "url": "git://github.com/restify/node-restify.git"

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1927,3 +1927,18 @@ test('GH-877 content-type should be case insensitive', function (t) {
     });
     client.end();
 });
+
+test('GH-882: route name is same as specified', function (t) {
+    SERVER.get({
+        name: 'my-r$-%-x',
+        path: '/m1'
+    }, function (req, res, next) {
+        res.send({name: req.route.name});
+    });
+
+    CLIENT.get('/m1', function (err, _, res) {
+        t.ifError(err);
+        t.equal(res.body, '{"name":"my-r$-%-x"}');
+        t.end();
+    });
+});


### PR DESCRIPTION
GH Issue #882

This PR ensures that a given route name is returned the same as specified by removing the (seemingly unnecessary) replace logic. As it stands, route names provided will be stored with any `/[^\w]/g` characters removed. This effectively makes them useless as a reference outside of the `router.render()` usage.

```js
app.get({
  name: 'my-awesome-route',
  path: '/my-awesome-route'
}, ...)
```

Currently provides the following `req.route` object

```js
route: { 
  name: 'myawesomeroute',
  path: '/my-awesome-route',
  method: 'GET'
}
```

The change here proposes that the `name` property should instead be, `my-awesome-route`