### PR TITLE
Bump dtrace provider for iojs 3.x and future node support

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "verror": "^1.4.0"
   },
   "optionalDependencies": {
-    "dtrace-provider": "^0.5.0"
+    "dtrace-provider": "^0.6.0"
   },
   "devDependencies": {
     "cover": "^0.2.9",


### PR DESCRIPTION
Dtrace 0.6 has been upgraded to Nan 2 for future node support.