### PR TITLE
stop processing requests on which the close event has been fired

### DIFF
--- a/lib/plugins/audit.js
+++ b/lib/plugins/audit.js
@@ -59,7 +59,8 @@ function auditLogger(options) {
                     version: req.version(),
                     body: options.body === true ?
                         req.body : undefined,
-                    timers: timers
+                    timers: timers,
+                    clientClosed: req.clientClosed
                 });
             },
             res: function auditResponseSerializer(res) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -824,7 +824,7 @@ Server.prototype._run = function _run(req, res, route, chain, cb) {
     // (or we lose the connection).
     function _requestClose() {
         reqClosed = true;
-        req.earlyClose = true;
+        req.clientClosed = true;
     }
     req.once('close', _requestClose);
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -824,6 +824,7 @@ Server.prototype._run = function _run(req, res, route, chain, cb) {
     // (or we lose the connection).
     function _requestClose() {
         reqClosed = true;
+        req.earlyClose = true;
     }
     req.once('close', _requestClose);
 
@@ -882,7 +883,7 @@ Server.prototype._run = function _run(req, res, route, chain, cb) {
             }
         }
 
-        if (arg === false || reqClosed === true) {
+        if (arg === false) {
             done = true;
         }
 
@@ -892,7 +893,7 @@ Server.prototype._run = function _run(req, res, route, chain, cb) {
         }
 
         // Run the next handler up
-        if (!done && chain[++i]) {
+        if (!done && chain[++i] && !reqClosed) {
             if (chain[i]._skip) {
                 return (next());
             }

--- a/lib/server.js
+++ b/lib/server.js
@@ -813,10 +813,19 @@ Server.prototype._run = function _run(req, res, route, chain, cb) {
     var handlerName = null;
     var errName;
     var emittedError = false;
+    var reqClosed = false;
 
     if (cb) {
         cb = once(cb);
     }
+
+    // attach a listener for 'close' event, this will let us set a flag so that
+    // we can stop processing the request if the client closes the connection
+    // (or we lose the connection).
+    function _requestClose() {
+        reqClosed = true;
+    }
+    req.once('close', _requestClose);
 
     function next(arg) {
         var done = false;
@@ -873,7 +882,7 @@ Server.prototype._run = function _run(req, res, route, chain, cb) {
             }
         }
 
-        if (arg === false) {
+        if (arg === false || reqClosed === true) {
             done = true;
         }
 
@@ -916,6 +925,7 @@ Server.prototype._run = function _run(req, res, route, chain, cb) {
         if (route === null) {
             self.emit('preDone', req, res);
         } else {
+            req.removeListener('close', _requestClose);
             self.emit('done', req, res, route);
         }
 

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -3,6 +3,7 @@
 'use strict';
 
 var assert = require('assert-plus');
+var bunyan = require('bunyan');
 var http = require('http');
 
 var filed = require('filed');
@@ -51,7 +52,7 @@ before(function (cb) {
                 url: 'http://127.0.0.1:' + PORT,
                 dtrace: helper.dtrace,
                 retry: false,
-                requestTimeout: 10
+                requestTimeout: 500
             });
 
             cb();
@@ -69,6 +70,7 @@ after(function (cb) {
         FAST_CLIENT.close();
         SERVER.close(function () {
             CLIENT = null;
+            FAST_CLIENT = null;
             SERVER = null;
             cb();
         });
@@ -1955,36 +1957,88 @@ test('GH-882: route name is same as specified', function (t) {
 });
 
 
-test('GH-733 if request is closed early, stop processing', function (t) {
-
+test('GH-733 if request closed early, stop processing. ensure only ' +
+     'relevant audit logs output.', function (t) {
+    // Dirty hack to capture the log record using a ring buffer.
     var numCount = 0;
 
-    SERVER.get('/', [
-        function delay (req, res, next) {
+    // FAST_CLIENT times out at 500ms, should capture two records then close
+    // the request.
+    SERVER.get('/audit', [
+        function first(req, res, next) {
+            req.startHandlerTimer('first');
             setTimeout(function () {
-                next();
-            }, 50);
+                numCount++;
+                req.endHandlerTimer('first');
+                return next();
+            }, 300);
         },
-        function send(req, res, next) {
+        function second(req, res, next) {
+            req.startHandlerTimer('second');
+            setTimeout(function () {
+                numCount++;
+                req.endHandlerTimer('second');
+                return next();
+            }, 300);
+        },
+        function third(req, res, next) {
+            req.endHandlerTimer('third');
             numCount++;
             res.send({ hello: 'world'});
-            next();
+            return next();
         }
     ]);
 
-    CLIENT.get('/', function (err, req, res, data) {
+
+    CLIENT.get('/audit', function (err, req, res, data) {
         t.ifError(err);
         t.deepEqual(data, { hello: 'world' });
+        t.equal(numCount, 3);
 
-        FAST_CLIENT.get('/', function (err2, req2, res2, data2) {
-            t.ok(err2);
-            t.equal(err2.name, 'RequestTimeoutError');
-            t.deepEqual(data2, {});
-            // fast client short circuits, should never run second handler
+        // reset numCount
+        numCount = 0;
+
+        // set up audit logs
+        var ringbuffer = new bunyan.RingBuffer({ limit: 1 });
+        SERVER.once('after', restify.auditLogger({
+            log: bunyan.createLogger({
+                name: 'audit',
+                streams:[ {
+                    level: 'info',
+                    type: 'raw',
+                    stream: ringbuffer
+                }]
+            })
+        }));
+
+
+        FAST_CLIENT.get('/audit', function (err2, req2, res2, data2) {
             setTimeout(function () {
-                t.equal(numCount, 1);
+                // should request timeout error
+                t.ok(err2);
+                t.equal(err2.name, 'RequestTimeoutError');
+                t.deepEqual(data2, {});
+
+                // check records
+                t.ok(ringbuffer.records[0], 'no log records');
+                t.equal(ringbuffer.records.length, 1,
+                        'should only have 1 log record');
+
+                // check timers
+                var handlers = Object.keys(ringbuffer.records[0].req.timers);
+                t.equal(handlers.length, 2,
+                        'should only have 2 req timers');
+                t.equal(handlers[0], 'first',
+                        'first handler timer not in order');
+                t.equal(handlers[handlers.length - 1], 'second',
+                        'second handler not last');
                 t.end();
+
+                // ensure third handler never ran
+                t.equal(numCount, 2);
             }, 500);
+            // don't start tests until a little after the request times out so
+            // that server can start the audit logs.
         });
     });
 });

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -2023,6 +2023,7 @@ test('GH-733 if request closed early, stop processing. ensure only ' +
                 t.ok(ringbuffer.records[0], 'no log records');
                 t.equal(ringbuffer.records.length, 1,
                         'should only have 1 log record');
+                t.equal(ringbuffer.records[0].req.clientClosed, true);
 
                 // check timers
                 var handlers = Object.keys(ringbuffer.records[0].req.timers);


### PR DESCRIPTION
Fixes #733.

Not sure if this is too naive, as I'm using the same place we check for `next(false)` to determine if the request should be stopped. I believe from a resource management perspective we should be okay, but would be good to get second pair of eyes on it.

