### PR TITLE
GH-667: support generic error listener

### DIFF
--- a/docs/index.restdown
+++ b/docs/index.restdown
@@ -502,10 +502,12 @@ Alternatively, restify 2.1 supports a `next.ifError` API:
 
 Sometimes, for all requests, you may want to handle an error condition the same
 way. As an example, you may want to serve a 500 page on all
-`InternalServerErrors`. In this case, you can add a listener for the `InternalServer` error event that
-is always fired when this Error is encountered by Restify as part of a
-`next(error)` statement. This gives you a way to handle all errors of the same
-class identically across the server.
+`InternalServerErrors`. In this case, you can add a listener for the
+`InternalServer` error event that is always fired when this Error is
+encountered by Restify as part of a `next(error)` statement. This gives you a
+way to handle all errors of the same class identically across the server. You
+can also use a generic `restifyError` event which will catch errors of all types.
+
 
     server.get('/hello/:name', function(req, res, next) {
       // some internal unrecoverable error
@@ -513,10 +515,26 @@ class identically across the server.
       return next(err);
     });
 
+    server.get('/hello/:foo', function(req, res, next) {
+      // resource not found error
+      var err = new restify.errors.NotFoundError('oh noes!');
+      return next(err);
+    });
+
     server.on('InternalServer', function (req, res, err, cb) {
       err.body = 'something is wrong!';
       return cb();
     });
+
+    server.on('restifyError', function (req, res, err, cb) {
+        // this listener will fire on both above scenarios!
+    });
+
+    server.on('NotFound', function (req, res, err, cb) {
+        // can return another error in place of the error you got
+        return cb(new restify.errors.ImATeapot('black!'));
+    });
+
 
 ### HttpError
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -14,6 +14,7 @@ var mime = require('mime');
 var once = require('once');
 var spdy = require('spdy');
 var uuid = require('node-uuid');
+var vasync = require('vasync');
 
 var dtrace = require('./dtrace');
 var formatters = require('./formatters');
@@ -843,24 +844,29 @@ Server.prototype._run = function _run(req, res, route, chain, cb) {
                 // possible. fall back on generic 'error' listener if we can't
                 // find one for the error we got.
                 var hasErrListeners = false;
-                var errEvtName;
+                var errEvtNames = [];
 
                 // if we have listeners for the specific error
                 if (self.listeners(errName).length > 0) {
                     hasErrListeners = true;
-                    errEvtName = errName;
+                    errEvtNames.push(errName);
                 }
                 // or if we have a generic error listener
-                else if (self.listeners('error').length > 0) {
+                if (self.listeners('restifyError').length > 0) {
                     hasErrListeners = true;
-                    errEvtName = 'error';
+                    errEvtNames.push('restifyError');
                 }
 
                 if (hasErrListeners) {
-                    self.emit(errEvtName, req, res, arg, once(function () {
-                        res.send(arg);
-                        return (cb ? cb(arg) : true);
-                    }));
+                    vasync.forEachPipeline({
+                        func: function emitError(errEvtName, vasyncCb) {
+                            self.emit(errEvtName, req, res, arg, vasyncCb);
+                        },
+                        inputs: errEvtNames
+                    }, function (err, results) {
+                        res.send(err || arg);
+                        return (cb ? cb(err || arg) : true);
+                    });
                     emittedError = true;
                 } else {
                     res.send(arg);

--- a/lib/server.js
+++ b/lib/server.js
@@ -811,7 +811,6 @@ Server.prototype._run = function _run(req, res, route, chain, cb) {
     var log = this.log;
     var self = this;
     var handlerName = null;
-    var errName;
     var emittedError = false;
     var reqClosed = false;
 
@@ -833,12 +832,32 @@ Server.prototype._run = function _run(req, res, route, chain, cb) {
 
         if (arg) {
             if (arg instanceof Error) {
-                errName = arg.name.replace(/Error$/, '');
-                log.trace({err: arg, errName: errName}, 'next(err=%s)',
-                    (arg.name || 'Error'));
 
+                var errName = arg.name.replace(/Error$/, '');
+                log.trace({
+                    err: arg,
+                    errName: errName
+                }, 'next(err=%s)', (arg.name || 'Error'));
+
+                // always attempt to use the most specific error listener
+                // possible. fall back on generic 'error' listener if we can't
+                // find one for the error we got.
+                var hasErrListeners = false;
+                var errEvtName;
+
+                // if we have listeners for the specific error
                 if (self.listeners(errName).length > 0) {
-                    self.emit(errName, req, res, arg, once(function () {
+                    hasErrListeners = true;
+                    errEvtName = errName;
+                }
+                // or if we have a generic error listener
+                else if (self.listeners('error').length > 0) {
+                    hasErrListeners = true;
+                    errEvtName = 'error';
+                }
+
+                if (hasErrListeners) {
+                    self.emit(errEvtName, req, res, arg, once(function () {
                         res.send(arg);
                         return (cb ? cb(arg) : true);
                     }));

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -2047,7 +2047,8 @@ test('GH-733 if request closed early, stop processing. ensure only ' +
 
 test('GH-667 emit error event for generic Errors', function (t) {
 
-    var count = 0;
+    var restifyError = 0;
+    var notFoundFired = false;
 
     SERVER.get('/1', function (req, res, next) {
         return next(new Error('foobar'));
@@ -2059,25 +2060,53 @@ test('GH-667 emit error event for generic Errors', function (t) {
 
     SERVER.get('/3', function (req, res, next) {
         SERVER.on('NotFound', function (req2, res2, err, cb) {
+            notFoundFired = true;
             t.ok(err);
             t.equal(err instanceof errors.NotFoundError, true);
-            t.equal(count, 2);
+            t.equal(restifyError, 2);
             t.end();
             return cb();
         });
         return next(new errors.NotFoundError('foobar'));
     });
 
-    SERVER.on('error', function (req, res, err, cb) {
-        count++;
+    SERVER.on('restifyError', function (req, res, err, cb) {
+        restifyError++;
         t.ok(err);
         t.equal(err instanceof Error, true);
         return cb();
     });
 
-    function noop() {}
-    CLIENT.get('/1', noop);
-    CLIENT.get('/2', noop);
-    CLIENT.get('/3', noop);
+    CLIENT.get('/1', function (err, req, res, data) {
+        // should get regular error
+        t.ok(err);
+    });
+    CLIENT.get('/2', function (err, req, res, data) {
+        // should get not found error
+        t.ok(err);
+    });
+    CLIENT.get('/3', function (err, req, res, data) {
+        // should get notfounderror
+        t.ok(err);
+        t.equal(notFoundFired, true);
+    });
+});
+
+
+test('GH-667 error handler to return another error', function (t) {
+
+    SERVER.on('ImATeapot', function (req, res, err, cb) {
+        return cb(new errors.LockedError('oh noes'));
+    });
+
+    SERVER.get('/1', function (req, res, next) {
+        return next(new errors.ImATeapotError('foobar'));
+    });
+
+    CLIENT.get('/1', function (err, req, res, data) {
+        t.ok(err);
+        t.equal(err.name, 'LockedError');
+        t.end();
+    });
 });
 


### PR DESCRIPTION
Fixes #667 and #888. Emit to a generic error event when typed error event listeners are not registered.