### PR TITLE
Fixes GH-916 by falling back to the old HTTP 413 Error Code if not present

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,7 +15,7 @@
         "no-dupe-keys": [ 2 ],
         "no-duplicate-case": [ 2 ],
         "no-empty": [ 2 ],
-        "no-empty-class": [ 2 ],
+        "no-empty-character-class": [ 2 ],
         "no-ex-assign": [ 2 ],
         "no-extra-boolean-cast": [ 2 ],
         "no-extra-semi": [ 2 ],

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: node_js
 node_js:
    - "0.10"
    - "0.12"
+   - "4.0.0"
 notifications:
   webhooks:
     urls:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ language: node_js
 node_js:
    - "0.10"
    - "0.12"
-   - "4.0.0"
+   - "4"
+   - "stable"
 notifications:
   webhooks:
     urls:

--- a/lib/plugins/body_reader.js
+++ b/lib/plugins/body_reader.js
@@ -14,6 +14,7 @@ var errors = require('../errors');
 
 var BadDigestError = errors.BadDigestError;
 var RequestEntityTooLargeError = errors.RequestEntityTooLargeError;
+var PayloadTooLargeError = errors.PayloadTooLargeError;
 
 var MD5_MSG = 'Content-MD5 \'%s\' didn\'t match \'%s\'';
 
@@ -56,7 +57,7 @@ function createBodyWriter(req) {
  * reads the body of the request.
  * @public
  * @function bodyReader
- * @throws   {BadDigestError | RequestEntityTooLargeError}
+ * @throws   {BadDigestError | PayloadTooLargeError}
  * @param    {Object} options an options object
  * @returns  {Function}
  */
@@ -86,12 +87,23 @@ function bodyReader(options) {
         }
 
         function done() {
+            var errorMessage;
             bodyWriter.end();
 
             if (maxBodySize && bytesReceived > maxBodySize) {
                 var msg = 'Request body size exceeds ' +
                     maxBodySize;
-                next(new RequestEntityTooLargeError(msg));
+
+                // Between Node 0.12 and 4 http status code messages changed
+                // RequestEntityTooLarge was changed to PayloadTooLarge
+                // this check is to maintain backwards compatibility
+                if (PayloadTooLargeError !== undefined) {
+                    errorMessage = new PayloadTooLargeError(msg);
+                } else {
+                    errorMessage = new RequestEntityTooLargeError(msg);
+                }
+
+                next(errorMessage);
                 return;
             }
 
@@ -101,7 +113,8 @@ function bodyReader(options) {
             }
 
             if (hash && md5 !== (digest = hash.digest('base64'))) {
-                next(new BadDigestError(MD5_MSG, md5, digest));
+                errorMessage = new BadDigestError(MD5_MSG, md5, digest);
+                next(errorMessage);
                 return;
             }
 


### PR DESCRIPTION
Add compatibility with Node 4 for Http Status Codes

Moving between Node 0.12 and 4 introduces different http status code
messages for the request body size is too large error (413). This should
normalize between the two, picking the one that is not undefined.

Fixes #916