### PR TITLE
should fail to set content-type header when formatter is missing

### DIFF
--- a/test/response.test.js
+++ b/test/response.test.js
@@ -325,3 +325,23 @@ test('redirect should call next with false to stop ' +
         t.end();
     });
 });
+
+
+test('should fail to set header due to missing formatter', function (t) {
+
+    // when a formatter is not set up for a specific content-type, restify will
+    // default to octet-stream.
+
+    SERVER.get('/11', function handle(req, res, next) {
+        res.header('content-type', 'application/hal+json');
+        res.send(200, JSON.stringify({ hello: 'world' }));
+        return next();
+    });
+
+    CLIENT.get(join(LOCALHOST, '/11'), function (err, _, res) {
+        t.ifError(err);
+        t.equal(res.statusCode, 200);
+        t.equal(res.headers['content-type'], 'application/octet-stream');
+        t.end();
+    });
+});


### PR DESCRIPTION
Adding a test to verify behavior per #910