### PR TITLE
updated index.restdown

### DIFF
--- a/docs/index.restdown
+++ b/docs/index.restdown
@@ -128,19 +128,20 @@ Creating a server is straightforward, as you simply invoke the
 below (and `listen()` takes the same arguments as node's
 [http.Server.listen](http://nodejs.org/docs/latest/api/http.html#http_server_listen_port_hostname_backlog_callback)):
 
-    var restify = require('restify');
+    var restify = require('restify'),
+    fs = require('fs');
 
     var server = restify.createServer({
-      certificate: ...,
-      key: ...,
+      certificate: fs.readFileSync('path/to/server/certificate'),
+      key: fs.readFileSync('path/to/server/key'),
       name: 'MyApp',
     });
 
     server.listen(8080);
 
 ||**Option**||**Type**||**Description**||
-||certificate||String||If you want to create an HTTPS server, pass in the PEM-encoded certificate and key||
-||key||String||If you want to create an HTTPS server, pass in the PEM-encoded certificate and key||
+||certificate||String||If you want to create an HTTPS server, pass in the path to PEM-encoded certificate and key||
+||key||String||If you want to create an HTTPS server, pass in the path to PEM-encoded certificate and key||
 ||formatters||Object||Custom response formatters for `res.send()`||
 ||log||Object||You can optionally pass in a [bunyan](https://github.com/trentm/node-bunyan) instance; not required||
 ||name||String||By default, this will be set in the `Server` response header, default is `restify` ||


### PR DESCRIPTION
added more (clearer) instructions for creating HTTPS server

`fs.readFileSync` to read the files as described on https://nodejs.org/api/https.html#https_https_createserver_options_requestlistener