### PR TITLE
Allow responses to skip formatters. was (Add support for pre-gzipped application/json)

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -254,7 +254,6 @@ Response.prototype.link = function link(l, rel) {
     return (this.header('Link', _link));
 };
 
-
 /**
  * sends the response object. convenience method that handles:
  *     writeHead(), write(), end()
@@ -266,6 +265,24 @@ Response.prototype.link = function link(l, rel) {
  * @returns  {Object}                           self, the response object
  */
 Response.prototype.send = function send(code, body, headers) {
+    return this._send(code, body, headers, true);
+};
+
+/**
+ * sends the response object as-is without formatting. convenience method that
+ *     handles: writeHead(), write(), end()
+ * @public
+ * @function send
+ * @param    {Number} code                      http status code
+ * @param    {Object | Buffer | Error} body     the content to send
+ * @param    {Object}                  headers  any add'l headers to set
+ * @returns  {Object}                           self, the response object
+ */
+Response.prototype.sendRaw = function sendRaw(code, body, headers) {
+    return this._send(code, body, headers, false);
+};
+
+Response.prototype._send = function _send(code, body, headers, format) {
     var isHead = (this.req.method === 'HEAD');
     var log = this.log;
     var self = this;
@@ -334,15 +351,16 @@ Response.prototype.send = function send(code, body, headers) {
         }
     }
 
-    if (body !== undefined) {
+    if (body === undefined) {
+        _cb(null, null);
+    } else if (format) {
         this.format(body, _cb);
     } else {
-        _cb(null, null);
+        _cb(null, body);
     }
 
     return (this);
 };
-
 
 /**
  * sets a header on the response.


### PR DESCRIPTION
If a valid `Content-Encoding` is already set on an `application/json` response, do not convert `body` to a string and instead return it as is. The use case is sending the response JSON that has already been gzipped rather than going through the gzip plug-in and wanting to provide the correct `application/json` `Content-Type`.

I apologize if there is a reason this isn't already supported (perhaps I'm doing something wrong on my side).  I wanted to add a test case, bit couldn't find where the existing json formatter tests lived, if you can point me to them, I'll be happy to add one.

Here's an example of what I am talking about, this causes the gzipped data to be incorrectly turned into a string in `4.0.3` but is fixed in my branch.  In my specific use case, I'm not gzipping on the fly and instead have a in-memory buffer of already gzipped JSON data.

```
function preGzip(req, res, next) {
    zlib.gzip(JSON.stringify(result), function (err, data) {
        if (err) {
            return next(err);
        }
        res.setHeader('Content-Type', 'application/json');
        res.setHeader('Content-Encoding', 'gzip');
        res.setHeader('Content-Length', data.length);
        res.send(data);
        next();
    });
};
```