### PR TITLE
CORS partial wildcards and protocol

### DIFF
--- a/lib/plugins/cors.js
+++ b/lib/plugins/cors.js
@@ -93,10 +93,10 @@ function cors(opts) {
     assert.optionalArrayOfString(opts.headers, 'options.headers');
 
     if (opts.origins) {
-        assert.ok(Array.isArray(opts.origins), 'options.credentials');
+        assert.ok(Array.isArray(opts.origins), 'options.origins');
         opts.origins.forEach(function (origin, index) {
             assert.ok(typeof origin === 'string' || origin instanceof RegExp,
-              'options.credentials[' + index + ']');
+              'options.origins[' + index + ']');
         });
     }
 

--- a/lib/plugins/cors.js
+++ b/lib/plugins/cors.js
@@ -35,16 +35,24 @@ var AC_EXPOSE_HEADERS = 'Access-Control-Expose-Headers';
 
 ///--- Internal Functions
 
+function toRegExp(str) {
+    if (str instanceof RegExp) {
+        return str;
+    }
+    var regexStr = str
+      // escape all the special characters, except *
+      .replace(/[\-\[\]\/\{\}\(\)\+\?\.\\\^\$\|]/g, '\\$&')
+      // replace all instances of * with a proper regex wildcard
+      .replace(/\*/g, '.*');
+
+    return new RegExp('^(https?://)?' + regexStr + '$', 'i');
+}
+
 function matchOrigin(req, origins) {
     var origin = req.headers.origin;
 
     function belongs(o) {
-        if (origin === o || o === '*') {
-            origin = o;
-            return (true);
-        }
-
-        return (false);
+        return o.test(origin);
     }
 
     return ((origin && origins.some(belongs)) ? origin : false);
@@ -88,7 +96,7 @@ function cors(opts) {
     cors.origins = opts.origins || ['*'];
 
     var headers = (opts.headers || []).slice(0);
-    var origins = opts.origins || ['*'];
+    cors.originPatterns = cors.origins.map(toRegExp);
 
     EXPOSE_HEADERS.forEach(function (h) {
         if (headers.indexOf(h) === -1) {
@@ -100,7 +108,7 @@ function cors(opts) {
     function restifyCORSSimple(req, res, next) {
         var origin;
 
-        if (!(origin = matchOrigin(req, origins))) {
+        if (!(origin = matchOrigin(req, cors.originPatterns))) {
             next();
             return;
         }
@@ -135,4 +143,11 @@ cors.ALLOW_HEADERS = ALLOW_HEADERS;
 cors.EXPOSE_HEADERS = EXPOSE_HEADERS;
 cors.credentials = false;
 cors.origins = [];
-cors.matchOrigin = matchOrigin;
+cors.matchOrigin = function (req, origins) {
+    return matchOrigin(
+        req,
+        // if the `origins` parameter is the original config value
+        // then there is no need to regenerate the regexes
+        origins === cors.origins ? cors.originPatterns : origins.map(toRegExp)
+    );
+};

--- a/lib/plugins/cors.js
+++ b/lib/plugins/cors.js
@@ -89,9 +89,16 @@ function matchOrigin(req, origins) {
 function cors(opts) {
     assert.optionalObject(opts, 'options');
     opts = opts || {};
-    assert.optionalArrayOfString(opts.origins, 'options.origins');
     assert.optionalBool(opts.credentials, 'options.credentials');
     assert.optionalArrayOfString(opts.headers, 'options.headers');
+
+    if (opts.origins) {
+        assert.ok(Array.isArray(opts.origins), 'options.credentials');
+        opts.origins.forEach(function (origin, index) {
+            assert.ok(typeof origin === 'string' || origin instanceof RegExp,
+              'options.credentials[' + index + ']');
+        });
+    }
 
     cors.credentials = opts.credentials;
     cors.origins = opts.origins || ['*'];

--- a/lib/plugins/cors.js
+++ b/lib/plugins/cors.js
@@ -35,6 +35,7 @@ var AC_EXPOSE_HEADERS = 'Access-Control-Expose-Headers';
 
 ///--- Internal Functions
 
+// turn a string defining an allowed domain into a regex
 function toRegExp(str) {
     if (str instanceof RegExp) {
         return str;
@@ -144,6 +145,8 @@ cors.EXPOSE_HEADERS = EXPOSE_HEADERS;
 cors.credentials = false;
 cors.origins = [];
 cors.matchOrigin = function (req, origins) {
+    // we need to pass an array of regexes to `matchOrigin`,
+    // so do the conversion
     return matchOrigin(
         req,
         // if the `origins` parameter is the original config value

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -447,6 +447,118 @@ test('CORS Preflight - any origin', function (t) {
     }).end();
 });
 
+test('CORS Preflight - any protocol', function (t) {
+    SERVER.use(restify.CORS({
+        credentials: true,
+        origins: [ 'somesite.local' ]
+    }));
+    SERVER.post('/foo/:id', function tester(req, res, next) {});
+
+    var opts = {
+        hostname: '127.0.0.1',
+        port: PORT,
+        path: '/foo/bar',
+        method: 'OPTIONS',
+        agent: false,
+        headers: {
+            'Access-Control-Request-Headers': 'accept, content-type',
+            'Access-Control-Request-Method': 'POST',
+            Origin: 'http://somesite.local'
+        }
+    };
+    http.request(opts, function (res) {
+        t.equal(res.headers['access-control-allow-origin'],
+            'http://somesite.local');
+        t.equal(res.headers['access-control-allow-credentials'], 'true');
+        t.equal(res.statusCode, 200);
+        t.end();
+    }).end();
+});
+
+test('CORS Preflight - any subdomain', function (t) {
+    SERVER.use(restify.CORS({
+        credentials: true,
+        origins: [ 'http://*.somesite.local' ]
+    }));
+    SERVER.post('/foo/:id', function tester(req, res, next) {});
+
+    var opts = {
+        hostname: '127.0.0.1',
+        port: PORT,
+        path: '/foo/bar',
+        method: 'OPTIONS',
+        agent: false,
+        headers: {
+            'Access-Control-Request-Headers': 'accept, content-type',
+            'Access-Control-Request-Method': 'POST',
+            Origin: 'http://test.somesite.local'
+        }
+    };
+    http.request(opts, function (res) {
+        t.equal(res.headers['access-control-allow-origin'],
+            'http://test.somesite.local');
+        t.equal(res.headers['access-control-allow-credentials'], 'true');
+        t.equal(res.statusCode, 200);
+        t.end();
+    }).end();
+});
+
+test('CORS Preflight - any subdomain, any protocol', function (t) {
+    SERVER.use(restify.CORS({
+        credentials: true,
+        origins: [ '*.somesite.local' ]
+    }));
+    SERVER.post('/foo/:id', function tester(req, res, next) {});
+
+    var opts = {
+        hostname: '127.0.0.1',
+        port: PORT,
+        path: '/foo/bar',
+        method: 'OPTIONS',
+        agent: false,
+        headers: {
+            'Access-Control-Request-Headers': 'accept, content-type',
+            'Access-Control-Request-Method': 'POST',
+            Origin: 'https://test.somesite.local'
+        }
+    };
+    http.request(opts, function (res) {
+        t.equal(res.headers['access-control-allow-origin'],
+            'https://test.somesite.local');
+        t.equal(res.headers['access-control-allow-credentials'], 'true');
+        t.equal(res.statusCode, 200);
+        t.end();
+    }).end();
+});
+
+test('CORS Preflight - regular expression', function (t) {
+    SERVER.use(restify.CORS({
+        credentials: true,
+        origins: [ /^https?:\/\/test[0-9]+\.somesite\.local$/ ]
+    }));
+    SERVER.post('/foo/:id', function tester(req, res, next) {});
+
+    var opts = {
+        hostname: '127.0.0.1',
+        port: PORT,
+        path: '/foo/bar',
+        method: 'OPTIONS',
+        agent: false,
+        headers: {
+            'Access-Control-Request-Headers': 'accept, content-type',
+            'Access-Control-Request-Method': 'POST',
+            Origin: 'https://test1.somesite.local'
+        }
+    };
+    http.request(opts, function (res) {
+        t.equal(res.headers['access-control-allow-origin'],
+            'https://test1.somesite.local');
+        t.equal(res.headers['access-control-allow-credentials'], 'true');
+        t.equal(res.statusCode, 200);
+        t.end();
+    }).end();
+});
+
 test('RegExp ok', function (t) {
     SERVER.get(/\/foo/, function tester(req, res, next) {
         res.send('hi there');
@@ -2043,4 +2155,3 @@ test('GH-733 if request closed early, stop processing. ensure only ' +
         });
     });
 });
-


### PR DESCRIPTION
Hi, this PR adds some flexibility to the CORS configuration for allowed origins.

Currently, the cors middleware only allows two ways of defining an allowed origin:
* a "global" wildcard `*`
* a scheme + domain name string - e.g. `http://foo.bar`

With this additional logic, the following definitions are supported:
* a "partial" wildcard, useful for whitelisting subdomains - e.g. `http://*.foo.bar`
* a domain name without the protocol, in which case both the http and https versions will be allowed - e.g. `foo.bar` or `*.foo.bar`
* a regular expression, to allow for total control over the format of the allowed domains - e.g. `/foo[0-9]?\.bar/i`