### PR TITLE
feat(response): redirect, set & docs enhancements

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -311,7 +311,7 @@ Response.prototype.send = function send(code, body, headers) {
         // know at this point what format to send the error as. Additionally,
         // the current 'after' event is emitted _before_ we send the response,
         // so there's no way to re-emit the error here. TODO: clean up 'after'
-        // even emitter so we pick up the error here.
+        // event emitter so we pick up the error here.
         if (err) {
             self._data = null;
             self.statusCode = 500;
@@ -358,12 +358,13 @@ Response.prototype.set = function set(name, val) {
     var self = this;
 
     if (arguments.length === 2) {
-        assert.string(name, 'name');
+        assert.string(name, 'res.set(name, val) requires name to be a string');
         this.header(name, val);
     } else {
-        assert.object(name, 'object');
+        assert.object(name,
+            'res.set(headers) requires headers to be an object');
         Object.keys(name).forEach(function (k) {
-            self.header(k, name[k]);
+            self.set(k, name[k]);
         });
     }
 
@@ -417,6 +418,7 @@ if (!Response.prototype.hasOwnProperty('_writeHead')) {
  * pass through to native response.writeHead()
  * @public
  * @function writeHead
+ * @emits    header
  * @returns  {undefined}
  */
 Response.prototype.writeHead = function restifyWriteHead() {
@@ -443,6 +445,7 @@ Response.prototype.writeHead = function restifyWriteHead() {
  * @param    {Number | String}   arg1 the status code or url to direct to
  * @param    {String | Function} arg2 the url to redirect to, or `next` fn
  * @param    {Function}          arg3 `next` fn
+ * @emits    redirect
  * @function redirect
  * @return   {undefined}
  */
@@ -451,6 +454,7 @@ Response.prototype.redirect = function redirect(arg1, arg2, arg3) {
     var self = this;
     var statusCode = 302;
     var finalUri;
+    var redirectLocation;
     var next;
 
     // 1) this is signature 1, where an explicit status code is passed in.
@@ -539,9 +543,13 @@ Response.prototype.redirect = function redirect(arg1, arg2, arg3) {
         return (next(new InternalServerError('could not construct url')));
     }
 
+    redirectLocation = url.format(finalUri);
+
+    self.emit('redirect', redirectLocation);
+
     // now we're done constructing url, send the res
     self.send(statusCode, null, {
-        location: url.format(finalUri)
+        location: redirectLocation
     });
 
     // tell server to stop processing the handler stack.

--- a/lib/server.js
+++ b/lib/server.js
@@ -794,6 +794,7 @@ Server.prototype._route = function _route(req, res, name, cb) {
  * @param    {Object}    route the route object
  * @param    {Array}     chain array of handler functions
  * @param    {Function}  cb    callback function
+ * @emits    redirect
  * @returns  {undefined}
  */
 Server.prototype._run = function _run(req, res, route, chain, cb) {
@@ -827,6 +828,11 @@ Server.prototype._run = function _run(req, res, route, chain, cb) {
         req.clientClosed = true;
     }
     req.once('close', _requestClose);
+
+    // attach a listener for the response's 'redirect' event
+    res.on('redirect', function (redirectLocation) {
+        self.emit('redirect', redirectLocation);
+    });
 
     function next(arg) {
         var done = false;

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "Guillaume Chauvet",
     "Isaac Schlueter",
     "Jacob Quatier",
+    "James Womack",
     "Jonathan Dahan",
     "Josh Clulow",
     "Matt Smillie",
@@ -58,27 +59,23 @@
     "node": ">=0.10"
   },
   "dependencies": {
-    "assert-plus": "^0.1.5",
-    "backoff": "^2.4.0",
+    "assert-plus": "0.1.5",
     "bunyan": "^1.4.0",
     "csv": "^0.4.0",
     "escape-regexp-component": "^1.0.2",
     "formidable": "^1.0.14",
     "http-signature": "^0.11.0",
-    "keep-alive-agent": "^0.0.1",
     "lru-cache": "^2.5.0",
     "mime": "^1.2.11",
     "negotiator": "^0.5.1",
     "node-uuid": "^1.4.1",
     "once": "^1.3.0",
+    "qs": "^5.0.0",
     "restify-clients": "1.1.0",
     "restify-errors": "3.0.0",
-    "qs": "^5.0.0",
     "semver": "^5.0.1",
     "spdy": "^2.0.5",
-    "tunnel-agent": "^0.4.0",
-    "vasync": "1.6.3",
-    "verror": "^1.4.0"
+    "vasync": "1.6.3"
   },
   "optionalDependencies": {
     "dtrace-provider": "^0.6.0"

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -984,6 +984,24 @@ test('emitting error from a handler (with domains)', function (t) {
 });
 
 
+test('re-emitting redirect from a response', function (t) {
+    var redirectLocation;
+
+    SERVER.on('redirect', function (payload) {
+        redirectLocation = payload;
+    });
+
+    SERVER.get('/', function (req, res, next) {
+        res.redirect('/10', next);
+    });
+
+    CLIENT.get('/', function (err, _, res) {
+        t.equal(redirectLocation, '/10');
+        t.end();
+    });
+});
+
+
 test('throwing error from a handler (with domains)', function (t) {
     SERVER.get('/', function (req, res, next) {
         process.nextTick(function () {


### PR DESCRIPTION
# James' Response changes & fixes for Restify 5

:star: :star2: :facepunch:

* Make `set` behave in a dev-friendly way whether it's called with a key-val pair or with a collection of key-val pairs
* Make `redirect` emit a `redirect` event with the `redirectLocation`
* Human-friendly assertion strings in `set`, more inline with recent assertions such as that in `redirect`
* Improve Restify install time and eventual readability by removing unused dependencies **keep-alive-agent, backoff, verror** & **tunnel-agent**
* Document that `writeHead` emits `header`
* Test that `writeHead` emits `header`
* Grammar correction for a comment