### PR TITLE
Test sending of null body

### DIFF
--- a/test/response.test.js
+++ b/test/response.test.js
@@ -346,3 +346,18 @@ test('should fail to set header due to missing formatter', function (t) {
         t.end();
     });
 });
+
+
+test('should not fail to send null as body', function (t) {
+
+    SERVER.get('/12', function handle(req, res, next) {
+        res.send(200, null);
+        return next();
+    });
+
+    CLIENT.get(join(LOCALHOST, '/12'), function (err, _, res) {
+        t.ifError(err);
+        t.equal(res.statusCode, 200);
+        t.end();
+    });
+});


### PR DESCRIPTION
This tests if sending `null` from the response—mentioned in #941 and #942—is handled properly. I do not see the issue filed by @lukebrdn. If the error is still occurring, please provide more context, so I can try to reproduce it.