### PR TITLE
update dependencies, fix usage of assert.AssertionError

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "node": ">=0.10"
   },
   "dependencies": {
-    "assert-plus": "0.1.5",
+    "assert-plus": "^0.2.0",
     "bunyan": "^1.4.0",
     "csv": "^0.4.0",
     "escape-regexp-component": "^1.0.2",
@@ -82,9 +82,9 @@
   },
   "devDependencies": {
     "cover": "^0.2.9",
-    "eslint": "^1.3.1",
+    "eslint": "^1.10.3",
     "filed": "^0.1.0",
-    "jscs": "^2.1.1",
+    "jscs": "^2.7.0",
     "nodeunit": "^0.9.0",
     "watershed": "^0.3.0"
   },

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -202,15 +202,16 @@ test('rm', function (t) {
 
 
 test('use - throws TypeError on non function as argument', function (t) {
-    var err = assert.AssertionError('handler (function) is required');
+
+    var errMsg = 'handler (function) is required';
 
     t.throws(function () {
         SERVER.use('/nonfn');
-    }, err);
+    }, assert.AssertionError, errMsg);
 
     t.throws(function () {
         SERVER.use({an: 'object'});
-    }, err);
+    }, assert.AssertionError, errMsg);
 
     t.throws(function () {
         SERVER.use(
@@ -221,7 +222,7 @@ test('use - throws TypeError on non function as argument', function (t) {
             {
                 really: 'bad'
             });
-    }, err);
+    }, assert.AssertionError, errMsg);
 
     t.end();
 });


### PR DESCRIPTION
Fixes #966, as well as the issue @jameswomack ran into when upgrading assert-plus.

Not sure how it ever worked in the first place, as assert.AssertionError is a constructor and should be called with `new`. I suspect something in core changed, since the tests run with no issue on 0.12.x. 