### PR TITLE
Fix "too few args to sprintf" for errors in static plugin

### DIFF
--- a/lib/plugins/static.js
+++ b/lib/plugins/static.js
@@ -44,8 +44,7 @@ function serveStatic(opts) {
 
     function serveFileFromStats(file, err, stats, isGzip, req, res, next) {
         if (err) {
-            next(new ResourceNotFoundError(err,
-                req.path()));
+            next(new ResourceNotFoundError(err, '%s', req.path()));
             return;
         } else if (!stats.isFile()) {
             next(new ResourceNotFoundError('%s does not exist', req.path()));
@@ -125,12 +124,12 @@ function serveStatic(opts) {
         }
 
         if (!re.test(file.replace(/\\/g, '/'))) {
-            next(new NotAuthorizedError(req.path()));
+            next(new NotAuthorizedError('%s', req.path()));
             return;
         }
 
         if (opts.match && !opts.match.test(file)) {
-            next(new NotAuthorizedError(req.path()));
+            next(new NotAuthorizedError('%s', req.path()));
             return;
         }
 


### PR DESCRIPTION
Hello,

just a minor fix: If you use the serveStatic plugin and have urls like:
`http://localhost/public/dir%2Ffile.jpg` or even double escaped `http://localhost/public/dir%252Ffile.jpg` restify will return an internal error with the message above.

I think adding a `%s` as first parameter is the easiest way of fixing this.

Regards,
Ben