### PR TITLE
add nsp support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,10 @@
 #
 ESLINT		:= ./node_modules/.bin/eslint
 JSCS		:= ./node_modules/.bin/jscs
+NSP         := ./node_modules/.bin/nsp
 NODEUNIT	:= ./node_modules/.bin/nodeunit
 NODECOVER	:= ./node_modules/.bin/cover
+NSP_BADGE   := ./tools/nspBadge.js
 NPM		:= npm
 
 #
@@ -58,6 +60,12 @@ CLEAN_FILES += $(TAP) ./node_modules/nodeunit
 .PHONY: test
 test: $(NODEUNIT)
 	$(NODEUNIT) test/*.test.js
+
+.PHONY: nsp
+nsp: node_modules $(NSP)
+	@$(NPM) shrinkwrap --dev
+	@($(NSP) check || echo 1) | $(NSP_BADGE)
+	@rm $(SHRINKWRAP)
 
 include ./tools/mk/Makefile.deps
 include ./tools/mk/Makefile.targ

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Dependency Status](https://david-dm.org/restify/node-restify.svg)](https://david-dm.org/restify/node-restify)
 [![devDependency Status](https://david-dm.org/restify/node-restify/dev-status.svg)](https://david-dm.org/restify/node-restify#info=devDependencies)
 [![bitHound Score](https://www.bithound.io/github/restify/node-restify/badges/score.svg)](https://www.bithound.io/github/restify/node-restify/master)
+[![NSP Status](https://img.shields.io/badge/NSP%20status-vulnerabilities%20found-red.svg)](https://travis-ci.org/restify/node-restify)
 
 [restify](http://restify.com) is a smallish framework,
 similar to [express](http://expressjs.com) for building REST APIs.  For full

--- a/package.json
+++ b/package.json
@@ -85,7 +85,8 @@
     "eslint": "^1.10.3",
     "filed": "^0.1.0",
     "jscs": "^2.7.0",
-    "nodeunit": "^0.9.0",
+    "nodeunit": "^0.9.1",
+    "nsp": "^2.1.0",
     "watershed": "^0.3.0"
   },
   "license": "MIT",

--- a/tools/mk/Makefile.targ
+++ b/tools/mk/Makefile.targ
@@ -236,4 +236,4 @@ $(DOC_MEDIA_DIRS_BUILD):
 test:
 
 .PHONY: prepush
-prepush: check test
+prepush: check test nsp

--- a/tools/nspBadge.js
+++ b/tools/nspBadge.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+
+var README_PATH = path.join(__dirname, '../README.md');
+/* jscs:disable maximumLineLength */
+var FAIL_BADGE = 'vulnerabilities%20found-red';
+var SUCCESS_BADGE = 'no%20vulnerabilities-green';
+var NSP_LINE_ID = '[NSP Status]';
+/* jscs:enable maximumLineLength */
+
+process.stdin.on('data', function (exitCodeBuf) {
+
+    var nspExitCode = parseInt(exitCodeBuf.toString(), 10);
+
+    if (isNaN(nspExitCode)) {
+        nspExitCode = 0;
+    }
+
+    var readmeStr = fs.readFileSync(README_PATH).toString();
+
+    var out = processLines(nspExitCode, readmeStr);
+
+    // now write it back out
+    fs.writeFileSync(README_PATH, out);
+});
+
+function processLines(exitCode, readmeStr) {
+    var lines = readmeStr.toString().split('\n');
+    var outLines = '';
+
+    lines.forEach(function (line) {
+        if (line.indexOf(NSP_LINE_ID) > -1) {
+            if (exitCode === 0) {
+                outLines += line.replace(FAIL_BADGE, SUCCESS_BADGE) + '\n';
+            } else {
+                outLines += line.replace(SUCCESS_BADGE, FAIL_BADGE) + '\n';
+            }
+        } else {
+            outLines += line + '\n';
+        }
+    });
+
+    // chop off last newline
+    return outLines.slice(0, -1);
+}


### PR DESCRIPTION
- due to npm3, cannot generate shrinkwrap for non devDeps. so we will
  get vulnerabilities even in dev deps, which may be misleading.