### PR TITLE
Rev restify-errors so it uses the same version of assert-plus

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "once": "^1.3.0",
     "qs": "^5.0.0",
     "restify-clients": "1.1.0",
-    "restify-errors": "3.0.0",
+    "restify-errors": "^3.1.0",
     "semver": "^5.0.1",
     "spdy": "^2.0.5",
     "vasync": "1.6.3"


### PR DESCRIPTION
Update restify-errors to the latest version to assert-plus lines up.

Companion to #969 
Completes the fix for #966