### PR TITLE
Fix highlighting in sidebar by using a more specific title.

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
     <li><div><a href="#content-negotiation">Content Negotiation</a></div></li>
     <li><div><a href="#error-handling">Error handling</a></div></li>
     <li><div><a href="#socketio">Socket.IO</a></div></li>
-    <li><div><a href="#server-api-2">Server API</a></div></li>
+    <li><div><a href="#node-server-api">Node Server API</a></div></li>
     <li><div><a href="#bundled-plugins">Bundled Plugins</a></div></li>
     <li><div><a href="#request-api">Request API</a></div></li>
     <li><div><a href="#response-api">Response API</a></div></li>
@@ -799,7 +799,7 @@ server.listen(8080, function () {
 });
 </code></pre>
 
-<h2 id="server-api-2">Server API</h2>
+<h2 id="node-server-api">Node Server API</h2>
 
 <h3 id="events">Events</h3>
 


### PR DESCRIPTION
The wrong list item was highlighting in the sidebar when a user scrolls to the second Server API heading or clicks on the link from the sidebar. This was fixed by changing the title to a more appropriate one, Node Server API.