### PR TITLE
fixed #982 -- allow null to be passed to res.send()

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -274,7 +274,7 @@ Response.prototype.send = function send(code, body, headers) {
 
     if (code === undefined) {
         this.statusCode = 200;
-    } else if (code.constructor.name === 'Number') {
+    } else if (typeof code === 'number') {
         this.statusCode = code;
 
         if (body instanceof Error) {

--- a/test/response.test.js
+++ b/test/response.test.js
@@ -420,3 +420,18 @@ test('should not fail to send null as body', function (t) {
         t.end();
     });
 });
+
+
+test('should not fail to send null as body without status code', function (t) {
+
+    SERVER.get('/13', function handle(req, res, next) {
+        res.send(null);
+        return next();
+    });
+
+    CLIENT.get(join(LOCALHOST, '/13'), function (err, _, res) {
+        t.ifError(err);
+        t.equal(res.statusCode, 200);
+        t.end();
+    });
+});


### PR DESCRIPTION
Implements technique already being used at `/lib/upgrade.js:275` to check for the same thing. This allows for `null` and other possible edge values to be passed into `res.send()`.
