### PR TITLE
jsonp() compatibility with res.json()

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -230,7 +230,9 @@ Response.prototype.header = function header(name, value) {
  * @returns  {Object}
  */
 Response.prototype.json = function json(code, object, headers) {
-    if (!/application\/json/.test(this.header('content-type'))) {
+    var type = /application\/j[son|avascript]/;
+
+    if (!type.test(this.header('content-type'))) {
         this.header('Content-Type', 'application/json');
     }
 

--- a/lib/response.js
+++ b/lib/response.js
@@ -230,10 +230,8 @@ Response.prototype.header = function header(name, value) {
  * @returns  {Object}
  */
 Response.prototype.json = function json(code, object, headers) {
-    var type = /application\/j[son|avascript]/;
-
-    if (!type.test(this.header('content-type'))) {
-        this.header('Content-Type', 'application/json');
+    if (!/application\/json/.test(this.header('content-type'))) {
+        this.setHeader('Content-Type', 'application/json');
     }
 
     return (this.send(code, object, headers));

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "Paul Bouzakis",
     "Pedro Palazón",
     "Richardo Stuven",
+    "Sean Wragg",
     "Shaun Berryman",
     "Steve Mason",
     "Trent Mick",

--- a/test/plugins.test.js
+++ b/test/plugins.test.js
@@ -45,6 +45,7 @@ before(function (callback) {
         SERVER.use(restify.authorizationParser());
         SERVER.use(restify.dateParser());
         SERVER.use(restify.queryParser());
+        SERVER.use(restify.jsonp());
 
         SERVER.get('/foo/:id', function respond(req, res, next) {
             res.send();
@@ -1340,6 +1341,20 @@ test('tests the requestLoggers extra header properties', function (t) {
     CLIENT.get(obj, function (err, _, res) {
         t.equal(res.statusCode, 200);
         t.ifError(err);
+        t.end();
+    });
+});
+
+
+test('jsonp plugin with res.json()', function (t) {
+    SERVER.get('/jsonp', function (req, res, next) {
+        res.json({x: 'w00t!'});
+    });
+
+    CLIENT.get('/jsonp?callback=c._0', function (err, _, res) {
+        t.equal(res.statusCode, 200);
+        var body = 'typeof c._0 === \'function\' && c._0({"x":"w00t!"});';
+        t.equal(res.body, body);
         t.end();
     });
 });

--- a/test/plugins.test.js
+++ b/test/plugins.test.js
@@ -1353,8 +1353,8 @@ test('jsonp plugin with res.json()', function (t) {
 
     CLIENT.get('/jsonp?callback=c._0', function (err, _, res) {
         t.equal(res.statusCode, 200);
-        var body = 'typeof c._0 === \'function\' && c._0({"x":"w00t!"});';
-        t.equal(res.body, body);
+        t.equal(res.headers['content-type'], 'application/json');
+        t.equal(res.body, '{"x":"w00t!"}');
         t.end();
     });
 });


### PR DESCRIPTION
This allows `res.json()` to continue functioning when used with the `restify.jsonp()` plugin/middleware.

###### Proposal
With this change, if the `application/javascipt` Content-Type is already added (as through the jsonp plugin), we don't add the `application/json` type when `res.json` is invoked.

###### Advantages
Basically, if you're exposing an API that can be hit through JSONP _and/or_ JSON, you can still use `res.json()`. The following example currently breaks prior to this change:

```js
// server
server.use(restify.queryParser());
server.use(restify.jsonp());

server.get('/endpoint', function (req, res, next) {
  res.json({x: 'meow'})
});

// client
request.get('/endpoint?callback=angular.callback._0', function  (err, res, body) {
  // server app fails due to typeof error
  // lib/response.js (line 117): TypeError [].split()
});
```