### PR TITLE
remove CORS

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -12,7 +12,6 @@ var LRU = require('lru-cache');
 var Negotiator = require('negotiator');
 var semver = require('semver');
 
-var cors = require('./plugins/cors');
 var utils = require('./utils');
 
 
@@ -502,8 +501,7 @@ Router.prototype.find = function find(req, res, callback) {
     // we indeed did find a matching route (method+url), but the version
     // field didn't line up, so we return bad version.  If no route and no
     // version, we now need to go walk the reverse map and look at whether
-    // we should return 405 or 404.  If it was an OPTIONS request, we need
-    // to handle this having been a preflight request.
+    // we should return 405 or 404.
     if (params && r) {
         cacheVal = {
             methods: reverse,
@@ -536,54 +534,6 @@ Router.prototype.find = function find(req, res, callback) {
         return;
     }
 
-    //Checks if header is in cors.ALLOWED_HEADERS
-    function inAllowedHeaders(header) {
-        header = header.toLowerCase();
-        return (cors.ALLOW_HEADERS.indexOf(header) !== -1);
-    }
-
-    // This is a very generic preflight handler - it does
-    // not handle requiring authentication, nor does it do
-    // any special checking for extra user headers. The
-    // user will need to defined their own .opts handler to
-    // do that
-    function preflight(methods) {
-        var headers = req.headers['access-control-request-headers'];
-        var method = req.headers['access-control-request-method'];
-        var origin = req.headers.origin;
-
-        if (req.method !== 'OPTIONS' || !origin || !method ||
-            methods.indexOf(method) === -1) {
-            return (false);
-        }
-
-        // Last, check request-headers
-        var ok = !headers || headers.split(/\s*,\s*/).every(inAllowedHeaders);
-
-        if (!ok) {
-            return (false);
-        }
-
-        // Verify the incoming origin against the whitelist. Pass the origin
-        // through if there is a match.
-        if (cors.matchOrigin(req, cors.origins)) {
-            res.setHeader('Access-Control-Allow-Origin', origin);
-
-            if (cors.credentials) {
-                res.setHeader('Access-Control-Allow-Credentials', 'true');
-            }
-        } else {
-            res.setHeader('Access-Control-Allow-Origin', '*');
-        }
-        res.setHeader('Access-Control-Allow-Methods',
-            methods.join(', '));
-        res.setHeader('Access-Control-Allow-Headers',
-            cors.ALLOW_HEADERS.join(', '));
-        res.setHeader('Access-Control-Max-Age', 3600);
-
-        return (true);
-    }
-
     // Check for 405 instead of 404
     var j;
     var urls = Object.keys(this.reverse);
@@ -593,10 +543,6 @@ Router.prototype.find = function find(req, res, callback) {
             res.methods = this.reverse[urls[j]].slice();
             res.setHeader('Allow', res.methods.join(', '));
 
-            if (preflight(res.methods)) {
-                callback(null, {name: 'preflight'});
-                return;
-            }
             var err = new MethodNotAllowedError('%s is not allowed',
                 req.method);
             callback(err);

--- a/lib/server.js
+++ b/lib/server.js
@@ -717,6 +717,14 @@ Server.prototype._handle = function _handle(req, res) {
 
     if (this.before.length > 0) {
         this._run(req, res, null, this.before, function (err) {
+            // check for return false here - like with the regular handlers,
+            // if false is returned we already sent a response and should stop
+            // processing.
+            if (err === false) {
+                self.emit('after', req, res, err);
+                return;
+            }
+
             if (!err) {
                 routeAndRun();
             }
@@ -753,10 +761,6 @@ Server.prototype._route = function _route(req, res, name, cb) {
                 } else {
                     emitRouteError(self, req, res, err);
                 }
-            } else if (r === 'preflight') {
-                res.writeHead(200);
-                res.end();
-                self.emit('after', req, res, null);
             } else if (!r || !self.routes[r]) {
                 err = new ResourceNotFoundError(req.path());
                 emitRouteError(self, res, res, err);


### PR DESCRIPTION
This removes CORS from restify core.

It also adds support for `next(false)` in pre chains. This is a prerequisite for the new [CORS plugin PR](https://github.com/restify/plugins/pull/10).