### PR TITLE
Emit 'after' event even if next is not called.

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -700,6 +700,7 @@ Server.prototype.toString = function toString() {
  */
 Server.prototype._handle = function _handle(req, res) {
     var self = this;
+    var afterCalled = false;
 
     function routeAndRun() {
         self._route(req, res, function (route, context) {
@@ -709,8 +710,15 @@ Server.prototype._handle = function _handle(req, res) {
             var r = route ? route.name : null;
             var chain = self.routes[r];
 
+            res.on('finish', function () {
+                if (!afterCalled) {
+                    self.emit('after', req, res, route, null);
+                }
+            });
+
             self._run(req, res, route, chain, function done(e) {
                 self.emit('after', req, res, route, e);
+                afterCalled = true;
             });
         });
     }

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -26,6 +26,7 @@ var test = helper.test;
 var PORT = process.env.UNIT_TEST_PORT || 0;
 var CLIENT;
 var SERVER;
+var TIMEOUT = 500;
 
 
 ///--- Tests
@@ -1925,4 +1926,40 @@ test('GH-877 content-type should be case insensitive', function (t) {
         t.end();
     });
     client.end();
+});
+
+test('always call after', function (t) {
+    var complete = false;
+    var r = SERVER.get('/foo/:id', function echoId(req, res, next) {
+        t.ok(req.params);
+        t.equal(req.params.id, 'bar');
+        t.equal(req.isUpload(), false);
+        res.send();
+    });
+
+    var iv = setTimeout(function () {
+        if (complete) {
+            return;
+        }
+
+        complete = true;
+        t.ok(false, 'timeout after ' + TIMEOUT + 'ms');
+        t.done();
+    }, TIMEOUT);
+
+    SERVER.once('after', function (req, res, route) {
+        complete = true;
+        t.ok(req);
+        t.ok(res);
+        t.equal(r, route.name);
+
+        clearTimeout(iv);
+
+        t.end();
+    });
+
+    CLIENT.get('/foo/bar', function (err, _, res) {
+        t.ifError(err);
+        t.equal(res.statusCode, 200);
+    });
 });


### PR DESCRIPTION
I would like the audit logger to log all requests, even if a particular handler doesn't call next for some reason. I see that the general consensus seems to be just make sure that you call next, but I wonder if you'd accept a patch that ensures that the after event is emitted even if the handler doesn't call next.

To accomplish that, I added code to handle the ServerResponse finish event.

I have opened another PR with the same fix for 5.x: https://github.com/restify/node-restify/pull/998

Edit: The failed check seems unrelated, I see previous PRs with the same issue.