### PR TITLE
update spdy to 3.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "qs": "^5.0.0",
     "restify-errors": "^3.1.0",
     "semver": "^5.0.1",
-    "spdy": "^2.0.5",
+    "spdy": "^3.2.0",
     "vasync": "1.6.3"
   },
   "optionalDependencies": {


### PR DESCRIPTION
Since restify 5.0 which integrates spdy 2.0.5 hasn't released yet, suggest updating spdy to latest 3.2.0.