### PR TITLE
Removed doc for deprecated feature - setting default res headers

### DIFF
--- a/docs/index.restdown
+++ b/docs/index.restdown
@@ -1557,22 +1557,6 @@ Short-hand for:
 ||headers||Object||response headers||
 ||id||String||A unique request id (x-request-id)||
 
-### Setting the default headers
-
-You can change what headers restify sends by default by setting the
-top-level property `defaultResponseHeaders`.  This should be a
-function that takes one argument `data`, which is the already
-serialized response body.  `data` can be either a String or Buffer (or
-null).  The `this` object will be the response itself.
-
-    var restify = require('restify');
-
-    restify.defaultResponseHeaders = function(data) {
-      this.header('Server', 'helloworld');
-    };
-
-    restify.defaultResponseHeaders = false; // disable altogether
-
 ## DTrace
 
 One of the coolest features of restify is that it automatically


### PR DESCRIPTION
This feature appears to have been removed back in 2012 —[c323034](https://github.com/restify/node-restify/commit/c323034c73308561f3d8920e0e76f333063bb0aa#diff-6d186b954a58d5bb740f73d84fe39073L155) — but the docs don't reflect that yet.

Fixes restify/node-restify#1006