### PR TITLE
Update docs for request-api

### DIFF
--- a/docs/index.restdown
+++ b/docs/index.restdown
@@ -1054,7 +1054,7 @@ current request id filled in, along with any other parameters you define.
 You can pass in no options to this, in which case only the request id will be
 appended, and no serializers appended (this is also the most performant); the
 logger created at server creation time will be used as the parent logger.
-This logger can be used normally, with [req.log](#Request-API).
+This logger can be used normally, with [req.log](#request-api).
 
 This plugin does _not_ log each individual request. Use the Audit Logging
 plugin or a custom middleware for that use.
@@ -1394,8 +1394,8 @@ Check if the incoming request is kept alive.
 
 ### log
 
-Note that you can piggyback on the restify logging framework, by just using
-`req.log`.  I.e.,:
+If you are using the [RequestLogger](#bundled-plugins) plugin, the child logger
+will be available on `req.log`:
 
     function myHandler(req, res, next) {
       var log = req.log;
@@ -1403,17 +1403,10 @@ Note that you can piggyback on the restify logging framework, by just using
       log.debug({params: req.params}, 'Hello there %s', 'foo');
     }
 
-The advantage to doing this is that each restify `req` instance has a new
-[bunyan](https://github.com/trentm/node-bunyan) instance `log` on it where
-the request id is automatically injected in, so you can easily correlate
-your high-throughput logs together.
-
-### getLogger(component)
-
-Shorthand to grab a new  [bunyan](https://github.com/trentm/node-bunyan)
-instance that is a child component of the one restify has:
-
-    var log = req.getLogger('MyFoo');
+The child logger will inject the request's UUID in the `req._id` attribute of
+each log statement. Since the logger lasts for the life of the request, you can
+use this to correlate statements for an individual request across any number of
+separate handlers.
 
 ### getQuery()
 


### PR DESCRIPTION
- Remove deprecated Request.getLogger() reference and add info to
  Request.log
- Fix link in Plugins.requestLogger

fixes #1011