### PR TITLE
Initial attempt to add cache clearing for a removed route.

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -346,6 +346,13 @@ Router.prototype.unmount = function unmount(name) {
         delete this.reverse[route.path.source];
     }
 
+    var cached = this.cache.values().filter(function (c) {
+      return (c.name === name);
+    })
+    if (cached) {
+      this.cache.del(cached.key);
+    }
+
     delete this.mounts[name];
 
     return (name);


### PR DESCRIPTION
Hi there,

I had a little time today to work on this. It's my first time contributing code here so bare with me.

As described here: restify/conductor#32, when removing a route through `server.rm` the cache is not cleared for the removed route and an error is thrown under some circumstances when the router attempts to process a removed route. In my case this happens specifically when the audit logger is on though it is possible it can occur under other circumstances.

I've added the fix below based on what I did within my own project but I have a few notes/questions:

1. The tests don't pass for me on a fresh clone. I get some linting errors (see below).
2. I am using slightly different code on my project. The main difference is that here I wanted to use your pattern using `[].filter(fun(){...}` as opposed to a `forEach`. Since I wasn't able to test, I wanted to ask you if this is acceptable before I go down the test rabbit hole.
3. I do not see a granular unit test for mounting or unmounting a route on the router. I know it's indirectly tested through the server.rm test but, in this specific case I'd need to add the audit logger to be sure the issue is fixed in the patch. Would it be appropriate if I added a completely new test using a new server instead of the `SERVER` instance in test/server.test.js`?

Output from `npm test` on a fresh clone (see note 1 above):
```bash
Projects/node-restify - [5.x] » npm test

> restify@4.0.3 test /Users/lgomez/Projects/node-restify
> make prepush

not found: gawk
not found: nawk
./node_modules/.bin/eslint '.'

/Users/lgomez/Projects/node-restify/lib/router.js
  348:5   error  "server" is not defined  no-undef
  349:26  error  "change" is not defined  no-undef
  352:7   error  "log" is not defined     no-undef

/Users/lgomez/Projects/node-restify/test/formatter.test.js
  109:9  warning  Unexpected "todo" comment  no-warning-comments

✖ 4 problems (3 errors, 1 warning)

make: *** [check-eslint] Error 1
npm ERR! Test failed.  See above for more details.
```

Thank you.