### PR TITLE
Add Response.sendRaw for sending without formatting.

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -268,7 +268,6 @@ Response.prototype.link = function link(l, rel) {
     return (this.header('Link', _link));
 };
 
-
 /**
  * sends the response object. convenience method that handles:
  *     writeHead(), write(), end()
@@ -280,6 +279,24 @@ Response.prototype.link = function link(l, rel) {
  * @returns  {Object}                           self, the response object
  */
 Response.prototype.send = function send(code, body, headers) {
+    return this.__send(code, body, headers, true);
+};
+
+/**
+ * sends the response object as-is without formatting. convenience method that
+ *     handles: writeHead(), write(), end()
+ * @public
+ * @function send
+ * @param    {Number} code                      http status code
+ * @param    {Object | Buffer | Error} body     the content to send
+ * @param    {Object}                  headers  any add'l headers to set
+ * @returns  {Object}                           self, the response object
+ */
+Response.prototype.sendRaw = function sendRaw(code, body, headers) {
+    return this.__send(code, body, headers, false);
+};
+
+Response.prototype.__send = function __send(code, body, headers, format) {
     var isHead = (this.req.method === 'HEAD');
     var log = this.log;
     var self = this;
@@ -348,15 +365,16 @@ Response.prototype.send = function send(code, body, headers) {
         }
     }
 
-    if (body !== undefined) {
+    if (body === undefined) {
+        _cb(null, null);
+    } else if (format) {
         this.format(body, _cb);
     } else {
-        _cb(null, null);
+        _cb(null, body);
     }
 
     return (this);
 };
-
 
 /**
  * sets a header on the response.


### PR DESCRIPTION
This is a continuation of #951 but PR'd into the `5.x` branch as requested.  See that discussion for details.

Factor out `Response.send` into a private function, `Response.__send`, that is  called by both `Response.send` and `Response.sendRaw`