### PR TITLE
next(err) does not call res.send on a finished res

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -877,11 +877,13 @@ Server.prototype._run = function _run(req, res, route, chain, cb) {
                         },
                         inputs: errEvtNames
                     }, function (err, results) {
-                        res.send(err || arg);
+                        if (!res.finished) {
+                            res.send(err || arg);
+                        }
                         return (cb ? cb(err || arg) : true);
                     });
                     emittedError = true;
-                } else {
+                } else if (!res.finished) {
                     res.send(arg);
                 }
                 done = true;

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -2070,3 +2070,47 @@ function (t) {
         t.end();
     });
 });
+
+test('GH-1019 next(err) should only call res.send once ever', function (t) {
+    SERVER.get('/1',
+               function hOne (req, res, next) {
+                   res.send(200);
+                   return next();
+               },
+               function hTwo (req, res, next) {
+                   var err = new errors.InternalServerError('No Listener');
+                   return next(err);
+               });
+
+    SERVER.get('/2',
+               function hOne (req, res, next) {
+                   res.send(200);
+                   return next();
+               },
+               function hTwo (req, res, next) {
+                   var err = new errors.ImATeapotError('Has Listener');
+                   return next(err);
+               });
+
+    SERVER.on('ImATeapot', function (req, res, err, cb) {
+        t.ok(err);
+        return cb(err);
+    });
+
+    SERVER.on('uncaughtException', function (req, res, route, err) {
+        // Technically, we mean only
+        // notOk(/Can't set headers/.test(err.message)),
+        // but we keep it here in case that message ever changes.
+        t.notOk(err);
+        t.end();
+    });
+
+    CLIENT.get('/1', function (err, req, res, data) {
+        t.notOk(err);
+    });
+
+    CLIENT.get('/2', function (err, req, res, data) {
+        t.notOk(err);
+        t.end();
+    });
+});


### PR DESCRIPTION
If an upstream handler closes the response successfully (or not), and
a downstream handler passes an unrelated error to `next`, an uncaught
exception will be thrown for trying to set headers that have already been
sent.

This commit alters the behavior of `next` such that its error-handling
path only calls `res.send` if the response is not finished yet.

closes #1019