### PR TITLE
fix #1024: add server option: 'ignoreUncaughtExceptions'

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # restify Changelog
 ## Current
+ - #1024 Added server option: 'ignoreUncaughtExceptions' to allow disabling
+         of the uncaughtException error handling
  - #903 Update docs to reflect new error handling, Jacob Quatier
  - #889 Bump dependencies to latest, Micah Ransdell
  - #887 Bump dtrace-provider to 0.6.0 for Node 4 support, Corbin Uselton

--- a/docs/index.restdown
+++ b/docs/index.restdown
@@ -143,6 +143,7 @@ below (and `listen()` takes the same arguments as node's
 ||certificate||String||If you want to create an HTTPS server, pass in the path to PEM-encoded certificate and key||
 ||key||String||If you want to create an HTTPS server, pass in the path to PEM-encoded certificate and key||
 ||formatters||Object||Custom response formatters for `res.send()`||
+||ignoreUncaughtExceptions||Boolean||When true (default is false), turns off restify's uncaughtException handler||
 ||log||Object||You can optionally pass in a [bunyan](https://github.com/trentm/node-bunyan) instance; not required||
 ||name||String||By default, this will be set in the `Server` response header, default is `restify` ||
 ||spdy||Object||Any options accepted by [node-spdy](https://github.com/indutny/node-spdy)||

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,15 +28,18 @@ function createServer(options) {
     opts.router = opts.router || new Router(opts);
 
     server = new Server(opts);
-    server.on('uncaughtException', function (req, res, route, e) {
-        if (this.listeners('uncaughtException').length > 1 ||
-            res.headersSent) {
-            return (false);
-        }
 
-        res.send(new InternalError(e, e.message || 'unexpected error'));
-        return (true);
-    });
+    if (!opts.ignoreUncaughtExceptions) {
+        server.on('uncaughtException', function (req, res, route, e) {
+            if (this.listeners('uncaughtException').length > 1 ||
+                res.headersSent) {
+                return (false);
+            }
+
+            res.send(new InternalError(e, e.message || 'unexpected error'));
+            return (true);
+        });
+    }
 
     return (server);
 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -247,6 +247,7 @@ function Server(options) {
     this.chain = [];
     this.log = options.log;
     this.name = options.name || 'restify';
+    this.ignoreUncaughtExceptions = options.ignoreUncaughtExceptions || false;
     this.router = options.router;
     this.routes = {};
     this.secure = false;
@@ -955,6 +956,14 @@ Server.prototype._run = function _run(req, res, route, chain, cb) {
         ]);
     });
 
+    req.timers = [];
+
+    if (self.ignoreUncaughtExceptions) {
+        n1();
+        return;
+    }
+
+    // Add the uncaughtException error handler.
     d = domain.create();
     d.add(req);
     d.add(res);

--- a/test/lib/server-withDisableUncaughtException.js
+++ b/test/lib/server-withDisableUncaughtException.js
@@ -1,0 +1,31 @@
+// A simple node process that will start a restify server with the
+// uncaughtException handler disabled. Responds to a 'serverPortRequest' message
+// and sends back the server's bound port number.
+
+'use strict';
+
+var restify = require('../../lib');
+
+function main() {
+    var port = process.env.UNIT_TEST_PORT || 0;
+    var server = restify.createServer({ ignoreUncaughtExceptions: true });
+    server.get('/', function (req, res, next) {
+        throw new Error('Catch me!');
+    });
+    server.listen(0, function () {
+        port = server.address().port;
+        console.log('port: ', port);
+
+        process.on('message', function (msg) {
+            if (msg.task !== 'serverPortRequest') {
+                process.send({error: 'Unexpected message: ' + msg});
+                return;
+            }
+            process.send({task: 'serverPortResponse', port: port});
+        });
+    });
+}
+
+if (require.main === module) {
+    main();
+}

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -4,6 +4,7 @@
 
 var assert = require('assert-plus');
 var bunyan = require('bunyan');
+var childprocess = require('child_process');
 var http = require('http');
 
 var filed = require('filed');
@@ -2044,3 +2045,48 @@ test('GH-733 if request closed early, stop processing. ensure only ' +
     });
 });
 
+test('GH-1024 uncaughtException disabling', function (t) {
+    // With uncaughtException handling disabled, the node process will abort,
+    // so testing of this feature must occur in a separate node process.
+
+    var allStderr = '';
+    var serverPath = __dirname + '/lib/server-withDisableUncaughtException.js';
+    var serverProc = childprocess.fork(serverPath, {silent: true});
+
+    // Record stderr, to check for the correct exception stack.
+    serverProc.stderr.on('data', function (data) {
+        allStderr += String(data);
+    });
+
+    // Handle serverPortResponse and then make the client request - the request
+    // should receive a connection closed error (because the server aborts).
+    serverProc.on('message', function (msg) {
+        if (msg.task !== 'serverPortResponse') {
+            serverProc.kill();
+            t.end();
+            return;
+        }
+
+        var port = msg.port;
+        var client = restifyClients.createJsonClient({
+            url: 'http://127.0.0.1:' + port,
+            dtrace: helper.dtrace,
+            retry: false
+        });
+
+        client.get('/', function (err, _, res) {
+            // Should get a connection closed error, but no response object.
+            t.ok(err);
+            t.equal(err.code, 'ECONNRESET');
+            t.equal(res, undefined);
+
+            serverProc.kill(); // Ensure it's dead.
+
+            t.ok(allStderr.indexOf('Error: Catch me!') > 0);
+
+            t.end();
+        });
+    });
+
+    serverProc.send({task: 'serverPortRequest'});
+});


### PR DESCRIPTION
Allows the user to disable the uncaughtException error handler by setting *ignoreUncaughtExceptions* when creating the restify server. The default behaviour is unchanged (i.e. uncaught exceptions are still enabled when this option is not supplied).

Note: I added tests for this, but it felt a little awkward as it had to use a separate process to run the restify server - this is because disabling the uncaught exception handler will cause node to abort the process when an uncaught error occurs.
