### PR TITLE
fix #1024: disable uncaughtException handler by default, added server option to enable it again

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 # restify Changelog
 
 ## Current
+ - #1024 **BREAKING** Disabled the uncaughtException handler by default, added
+   server option 'handleUncaughtExceptions' to allow enabling of it again
+   (restify 4.x and before used to handle exceptions by default), Todd Whiteman
  - #944 Support generic event listener, Alex Liu
  - #943 Fix typos in documentation, azollyx
  - #939 Fix issue where missing content-type header would hang response, Alex

--- a/docs/index.restdown
+++ b/docs/index.restdown
@@ -143,6 +143,7 @@ below (and `listen()` takes the same arguments as node's
 ||certificate||String||If you want to create an HTTPS server, pass in the path to PEM-encoded certificate and key||
 ||key||String||If you want to create an HTTPS server, pass in the path to PEM-encoded certificate and key||
 ||formatters||Object||Custom response formatters for `res.send()`||
+||handleUncaughtExceptions||Boolean||When true (default is false) restify will use a domain to catch and respond to any uncaught exceptions that occur in it's handler stack||
 ||log||Object||You can optionally pass in a [bunyan](https://github.com/trentm/node-bunyan) instance; not required||
 ||name||String||By default, this will be set in the `Server` response header, default is `restify` ||
 ||spdy||Object||Any options accepted by [node-spdy](https://github.com/indutny/node-spdy)||
@@ -802,10 +803,11 @@ them.
 
 `function (request, response, route, error) {}`
 
-Emitted when some handler throws an uncaughtException somewhere in the chain.
-The default behavior is to just call `res.send(error)`, and let the built-ins
-in restify handle transforming, but you can override to whatever you want
-here.
+Emitted when some handler throws an uncaughtException somewhere in the chain and
+only when 'handleUncaughtExceptions' is set to true on the restify server. The
+restify server has a default handler for this event - which is to just call
+`res.send(error)`, and lets the built-ins in restify handle transforming, but
+you can override the default handler to do whatever you want.
 
 
 ### Properties

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,15 +28,18 @@ function createServer(options) {
     opts.router = opts.router || new Router(opts);
 
     server = new Server(opts);
-    server.on('uncaughtException', function (req, res, route, e) {
-        if (this.listeners('uncaughtException').length > 1 ||
-            res.headersSent) {
-            return (false);
-        }
 
-        res.send(new InternalError(e, e.message || 'unexpected error'));
-        return (true);
-    });
+    if (opts.handleUncaughtExceptions) {
+        server.on('uncaughtException', function (req, res, route, e) {
+            if (this.listeners('uncaughtException').length > 1 ||
+                res.headersSent) {
+                return (false);
+            }
+
+            res.send(new InternalError(e, e.message || 'unexpected error'));
+            return (true);
+        });
+    }
 
     return (server);
 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -248,6 +248,7 @@ function Server(options) {
     this.chain = [];
     this.log = options.log;
     this.name = options.name || 'restify';
+    this.handleUncaughtExceptions = options.handleUncaughtExceptions || false;
     this.router = options.router;
     this.routes = {};
     this.secure = false;
@@ -991,6 +992,14 @@ Server.prototype._run = function _run(req, res, route, chain, cb) {
         ]);
     });
 
+    req.timers = [];
+
+    if (!self.handleUncaughtExceptions) {
+        n1();
+        return;
+    }
+
+    // Add the uncaughtException error handler.
     d = domain.create();
     d.add(req);
     d.add(res);

--- a/test/lib/server-withDisableUncaughtException.js
+++ b/test/lib/server-withDisableUncaughtException.js
@@ -1,0 +1,31 @@
+// A simple node process that will start a restify server with the
+// uncaughtException handler disabled. Responds to a 'serverPortRequest' message
+// and sends back the server's bound port number.
+
+'use strict';
+
+var restify = require('../../lib');
+
+function main() {
+    var port = process.env.UNIT_TEST_PORT || 0;
+    var server = restify.createServer({ handleUncaughtExceptions: false });
+    server.get('/', function (req, res, next) {
+        throw new Error('Catch me!');
+    });
+    server.listen(0, function () {
+        port = server.address().port;
+        console.log('port: ', port);
+
+        process.on('message', function (msg) {
+            if (msg.task !== 'serverPortRequest') {
+                process.send({error: 'Unexpected message: ' + msg});
+                return;
+            }
+            process.send({task: 'serverPortResponse', port: port});
+        });
+    });
+}
+
+if (require.main === module) {
+    main();
+}

--- a/test/response.test.js
+++ b/test/response.test.js
@@ -30,6 +30,7 @@ before(function (cb) {
     try {
         SERVER = restify.createServer({
             dtrace: helper.dtrace,
+            handleUncaughtExceptions: true,
             log: helper.getLog('server'),
             version: ['2.0.0', '0.5.4', '1.4.3']
         });


### PR DESCRIPTION
New server option: 'handleUncaughtExceptions' (default is false) to enable uncaughtExceptions on the server instance.

* added out-of-process tests (as now the node server instance will abort when there is an exception).
* updated some existing tests to set 'handleUncaughtExceptions' to true
