### PR TITLE
Capitalize the location header field for redirect

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -561,7 +561,7 @@ Response.prototype.redirect = function redirect(arg1, arg2, arg3) {
 
     // now we're done constructing url, send the res
     self.send(statusCode, null, {
-        location: redirectLocation
+        Location: redirectLocation
     });
 
     // tell server to stop processing the handler stack.


### PR DESCRIPTION
The http header fields are case sensitive according to the
RFC 2616 and 7230. This changes the 302 header field "location"
into "Location".