### PR TITLE
Necessary changes to make the SPDY example work

### DIFF
--- a/examples/spdy/spdy.js
+++ b/examples/spdy/spdy.js
@@ -1,6 +1,7 @@
 var fs = require('fs');
 var bunyan = require('bunyan');
 var restify = require('../../lib');
+var restifyPlugins = require('restify-plugins');
 
 var srv = restify.createServer({
     spdy: {
@@ -15,7 +16,7 @@ srv.get('/', function (req, res, next) {
     next();
 });
 
-srv.on('after', restify.auditLogger({
+srv.on('after', restifyPlugins.auditLogger({
     body: true,
     log: bunyan.createLogger({
         name: 'audit',


### PR DESCRIPTION
It looks like this example was not updated when auditLogger was moved to restify-plugins.  These changes are enough to make the example work again, assuming the user has already installed `restify-plugins` (`npm install restify-plugins`).