### PR TITLE
Request.absoluteUri updated to use correct protocol.

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -59,7 +59,7 @@ function negotiator(req) {
 Request.prototype.absoluteUri = function absoluteUri(path) {
     assert.string(path, 'path');
 
-    var protocol = this.secure ? 'https://' : 'http://';
+    var protocol = this.isSecure() ? 'https://' : 'http://';
     var hostname = this.headers.host;
     return (url.resolve(protocol + hostname + this.path() + '/', path));
 };


### PR DESCRIPTION
Request.absoluteUri used this.secure to determine if the protocol should be https or http, but this.secure doesn't exist anymore.
Switched to calling this.isSecure() to check if the connection is secure.