### PR TITLE
Formatters cleanup

### DIFF
--- a/lib/formatters/binary.js
+++ b/lib/formatters/binary.js
@@ -15,9 +15,6 @@
  * @returns  {Buffer}
  */
 function formatBinary(req, res, body, cb) {
-    if (body instanceof Error) {
-        res.statusCode = body.statusCode || 500;
-    }
 
     if (!Buffer.isBuffer(body)) {
         body = new Buffer(body.toString());

--- a/lib/formatters/json.js
+++ b/lib/formatters/json.js
@@ -5,8 +5,8 @@
 ///--- Exports
 
 /**
- * JSON formatter. Will look for a toJson() method on the body. If one does not exist
- * then a JSON.stringify will be attempted.
+ * JSON formatter. Will look for a toJson() method on the body. If one does not
+ * exist then a JSON.stringify will be attempted.
  * @public
  * @function formatJSON
  * @param    {Object} req  the request object (not used)
@@ -18,7 +18,8 @@
 function formatJSON(req, res, body, cb) {
 
     var data = body.toJSON ? body.toJSON() : JSON.stringify(body);
-    // Setting the content-length header is not a formatting feature and should be separated into another module
+    // Setting the content-length header is not a formatting feature and should
+    // be separated into another module
     res.setHeader('Content-Length', Buffer.byteLength(data));
 
     return cb(null, data);

--- a/lib/formatters/json.js
+++ b/lib/formatters/json.js
@@ -17,7 +17,7 @@
  */
 function formatJSON(req, res, body, cb) {
 
-    var data = body.toJSON ? body.toJSON() : JSON.stringify(body);
+    var data = (body) ? JSON.stringify(body) : 'null';
     // Setting the content-length header is not a formatting feature and should
     // be separated into another module
     res.setHeader('Content-Length', Buffer.byteLength(data));

--- a/lib/formatters/json.js
+++ b/lib/formatters/json.js
@@ -5,33 +5,20 @@
 ///--- Exports
 
 /**
- * JSON formatter.
+ * JSON formatter. Will look for a toJson() method on the body. If one does not exist
+ * then a JSON.stringify will be attempted.
  * @public
  * @function formatJSON
- * @param    {Object} req  the request object
+ * @param    {Object} req  the request object (not used)
  * @param    {Object} res  the response object
  * @param    {Object} body response body
  * @param    {Function} cb cb
  * @returns  {String}
  */
 function formatJSON(req, res, body, cb) {
-    if (body instanceof Error) {
-        // snoop for RestError or HttpError, but don't rely on
-        // instanceof
-        res.statusCode = body.statusCode || 500;
 
-        if (body.body) {
-            body = body.body;
-        } else {
-            body = {
-                message: body.message
-            };
-        }
-    } else if (Buffer.isBuffer(body)) {
-        body = body.toString('base64');
-    }
-
-    var data = JSON.stringify(body);
+    var data = body.toJSON ? body.toJSON() : JSON.stringify(body);
+    // Setting the content-length header is not a formatting feature and should be separated into another module
     res.setHeader('Content-Length', Buffer.byteLength(data));
 
     return cb(null, data);

--- a/lib/formatters/jsonp.js
+++ b/lib/formatters/jsonp.js
@@ -20,16 +20,6 @@ function formatJSONP(req, res, body, cb) {
         return (null);
     }
 
-    if (body instanceof Error) {
-        if ((body.restCode || body.httpCode) && body.body) {
-            body = body.body;
-        } else {
-            body = {
-                message: body.message
-            };
-        }
-    }
-
     if (Buffer.isBuffer(body)) {
         body = body.toString('base64');
     }

--- a/lib/formatters/text.js
+++ b/lib/formatters/text.js
@@ -5,27 +5,21 @@
 ///--- Exports
 
 /**
- * JSONP formatter. like JSON, but with a callback invocation.
+ * Formats the body to 'text' by invoking a toString() on the body if it exists. If it doesn't, then the 
+ * response is a zero-length string
  * @public
- * @function formatJSONP
- * @param    {Object} req  the request object
+ * @function formatText
+ * @param    {Object} req  the request object (not used)
  * @param    {Object} res  the response object
- * @param    {Object} body response body
+ * @param    {Object} body response body. If it has a toString() method this will be used to make the string representation
  * @param    {Function} cb cb
  * @returns  {String}
  */
 function formatText(req, res, body, cb) {
-    if (body instanceof Error) {
-        res.statusCode = body.statusCode || 500;
-        body = body.message;
-    } else if (typeof (body) === 'object') {
-        body = JSON.stringify(body);
-    } else {
-        body = body.toString();
-    }
-
-    res.setHeader('Content-Length', Buffer.byteLength(body));
-    return cb(null, body);
+    var data =  body.toString && body.toString() || '';
+    // Setting the content-length header is not a formatting feature and should be separated into another module
+    res.setHeader('Content-Length', Buffer.byteLength(data));
+    return cb(null, data);
 }
 
 module.exports = formatText;

--- a/lib/formatters/text.js
+++ b/lib/formatters/text.js
@@ -5,19 +5,21 @@
 ///--- Exports
 
 /**
- * Formats the body to 'text' by invoking a toString() on the body if it exists. If it doesn't, then the 
- * response is a zero-length string
+ * Formats the body to 'text' by invoking a toString() on the body if it
+ * exists. If it doesn't, then the response is a zero-length string
  * @public
  * @function formatText
  * @param    {Object} req  the request object (not used)
  * @param    {Object} res  the response object
- * @param    {Object} body response body. If it has a toString() method this will be used to make the string representation
+ * @param    {Object} body response body. If it has a toString() method this
+ * will be used to make the string representation
  * @param    {Function} cb cb
  * @returns  {String}
  */
 function formatText(req, res, body, cb) {
     var data =  body.toString && body.toString() || '';
-    // Setting the content-length header is not a formatting feature and should be separated into another module
+    // Setting the content-length header is not a formatting feature and should
+    // be separated into another module
     res.setHeader('Content-Length', Buffer.byteLength(data));
     return cb(null, data);
 }

--- a/lib/formatters/text.js
+++ b/lib/formatters/text.js
@@ -2,6 +2,8 @@
 
 'use strict';
 
+var errs = require('restify-errors');
+
 ///--- Exports
 
 /**
@@ -17,7 +19,22 @@
  * @returns  {String}
  */
 function formatText(req, res, body, cb) {
-    var data =  body.toString && body.toString() || '';
+
+    // if body is null, default to empty string
+    var data = '';
+
+    if (body && typeof body.toString === 'function') {
+        data = body.toString();
+    } else {
+        // if no toString, or toString isn't a function, this is almost
+        // certainly an error. even though we pass back this error, formatter
+        // errors won't get sent to the client. this error will get logged on
+        // server side, but client gets empty 500 when we have formatter errors
+        return cb(new errs.InternalServerError(
+            'no toString() method defined, unable to format response'
+        ));
+    }
+
     // Setting the content-length header is not a formatting feature and should
     // be separated into another module
     res.setHeader('Content-Length', Buffer.byteLength(data));

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,7 +36,7 @@ function createServer(options) {
                 return (false);
             }
 
-            res.send(new InternalError(e, e.message || 'unexpected error'));
+            res.send(new InternalError(e.message || 'unexpected error'));
             return (true);
         });
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,7 +36,7 @@ function createServer(options) {
                 return (false);
             }
 
-            res.send(new InternalError(e.message || 'unexpected error'));
+            res.send(new InternalError(e, e.message || 'unexpected error'));
             return (true);
         });
     }

--- a/lib/response.js
+++ b/lib/response.js
@@ -285,12 +285,12 @@ Response.prototype.send = function send(code, body, headers) {
     var self = this;
 
     if (code === undefined) {
-        this.statusCode = 200;
+        self.statusCode = 200;
     } else if (typeof code === 'number') {
-        this.statusCode = code;
+        self.statusCode = code;
 
         if (body instanceof Error) {
-            body.statusCode = this.statusCode;
+            body.statusCode = self.statusCode;
         }
     } else {
         headers = body;
@@ -314,7 +314,7 @@ Response.prototype.send = function send(code, body, headers) {
         log.trace(_props, 'response::send entered');
     }
 
-    this._body = body;
+    self._body = body;
 
     function _cb(err, _body) {
         // the problem here is that if the formatter throws an error, we can't
@@ -331,9 +331,14 @@ Response.prototype.send = function send(code, body, headers) {
         } else {
             self._data = _body;
         }
+
         Object.keys(headers).forEach(function (k) {
             self.setHeader(k, headers[k]);
         });
+
+        if (body instanceof Error) {
+            self.statusCode = body.statusCode || 500;
+        }
 
         self.writeHead(self.statusCode);
 
@@ -349,12 +354,12 @@ Response.prototype.send = function send(code, body, headers) {
     }
 
     if (body !== undefined) {
-        this.format(body, _cb);
+        self.format(body, _cb);
     } else {
         _cb(null, null);
     }
 
-    return (this);
+    return (self);
 };
 
 

--- a/lib/response.js
+++ b/lib/response.js
@@ -157,9 +157,6 @@ Response.prototype.format = function format(body, cb) {
 
     this.setHeader('Content-Type', type);
 
-    if (body instanceof Error && body.statusCode !== undefined) {
-        this.statusCode = body.statusCode;
-    }
     return (formatter.call(this, this.req, this, body, cb));
 };
 
@@ -274,28 +271,35 @@ Response.prototype.link = function link(l, rel) {
  *     writeHead(), write(), end()
  * @public
  * @function send
- * @param    {Number} code                      http status code
- * @param    {Object | Buffer | Error} body     the content to send
- * @param    {Object}                  headers  any add'l headers to set
- * @returns  {Object}                           self, the response object
+ * @param    {Number} [code]                     http status code
+ * @param    {Object | Buffer | Error} body      the content to send
+ * @param    {Object}                  [headers] any add'l headers to set
+ * @returns  {Object}                            self, the response object
  */
 Response.prototype.send = function send(code, body, headers) {
     var isHead = (this.req.method === 'HEAD');
     var log = this.log;
     var self = this;
 
+    // normalize variadic args. if nothing passed in, set 200 and go
     if (code === undefined) {
         self.statusCode = 200;
     } else if (typeof code === 'number') {
+        // set status code if explicitly set, the defined signature in jsdoc
+        // is the one we use. set status code now.
         self.statusCode = code;
-
-        if (body instanceof Error) {
-            body.statusCode = self.statusCode;
-        }
     } else {
+        // otherwise, no status code set, only body and maybe headers.
+        // status code defaults to 200 in any case.
         headers = body;
         body = code;
         code = null;
+    }
+
+    // if an error object is being sent and a status code isn't explicitly set,
+    // infer one from the error object itself.
+    if (!code && body instanceof Error) {
+        self.statusCode = body.statusCode || 500;
     }
 
     headers = headers || {};
@@ -335,10 +339,6 @@ Response.prototype.send = function send(code, body, headers) {
         Object.keys(headers).forEach(function (k) {
             self.setHeader(k, headers[k]);
         });
-
-        if (body instanceof Error) {
-            self.statusCode = body.statusCode || 500;
-        }
 
         self.writeHead(self.statusCode);
 

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "node-uuid": "^1.4.7",
     "once": "^1.3.0",
     "qs": "^5.0.0",
-    "restify-errors": "^4.2.2",
+    "restify-errors": "^4.2.3",
     "semver": "^5.0.1",
     "spdy": "^3.2.0",
     "vasync": "1.6.4"

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "node-uuid": "^1.4.7",
     "once": "^1.3.0",
     "qs": "^5.0.0",
-    "restify-errors": "^3.1.0",
+    "restify-errors": "^4.2.2",
     "semver": "^5.0.1",
     "spdy": "^3.2.0",
     "vasync": "1.6.4"
@@ -87,7 +87,7 @@
     "jscs": "^3.0.0",
     "nodeunit": "^0.9.1",
     "nsp": "^2.2.0",
-    "restify-clients": "^1.1.1",
+    "restify-clients": "^1.2.1",
     "restify-plugins": "^1.0.2",
     "watershed": "^0.3.0"
   },

--- a/test/response.test.js
+++ b/test/response.test.js
@@ -2,6 +2,7 @@
 
 var url = require('url');
 var restifyClients = require('restify-clients');
+var errs = require('restify-errors');
 var plugins = require('restify-plugins');
 
 var restify = require('../lib');
@@ -433,6 +434,24 @@ test('should not fail to send null as body without status code', function (t) {
     CLIENT.get(join(LOCALHOST, '/13'), function (err, _, res) {
         t.ifError(err);
         t.equal(res.statusCode, 200);
+        t.end();
+    });
+});
+
+
+test('should prefer explicit status code over error status code', function (t) {
+
+    SERVER.get('/14', function handle (req, res, next) {
+        res.send(200, new errs.InternalServerError('boom'));
+        return next();
+    });
+
+    CLIENT.get(join(LOCALHOST, '/14'), function (err, _, res, body) {
+        t.ifError(err);
+        t.equal(res.statusCode, 200);
+        // ensure error body was still sent
+        t.equal(body.code, 'InternalServer');
+        t.equal(body.message, 'boom');
         t.end();
     });
 });

--- a/test/response.test.js
+++ b/test/response.test.js
@@ -287,12 +287,11 @@ test('redirect should cause InternalError when invoked without next', function (
         res.redirect();
     });
 
-    CLIENT.get(join(LOCALHOST, '/9'), function (err, _, res) {
+    CLIENT.get(join(LOCALHOST, '/9'), function (err, _, res, body) {
         t.equal(res.statusCode, 500);
 
         // json parse the response
-        var msg = JSON.parse(res.body);
-        t.equal(msg.body.code, 'Internal');
+        t.equal(body.code, 'Internal');
         t.end();
     });
 });

--- a/test/response.test.js
+++ b/test/response.test.js
@@ -292,7 +292,7 @@ test('redirect should cause InternalError when invoked without next', function (
 
         // json parse the response
         var msg = JSON.parse(res.body);
-        t.equal(msg.code, 'Internal');
+        t.equal(msg.body.code, 'Internal');
         t.end();
     });
 });

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1006,8 +1006,6 @@ test('next.ifError', function (t) {
 
     SERVER.get('/foo/:id', function tester(req, res, next) {
         process.nextTick(function () {
-            // this object fails to become JSON because it's picking up the
-            // arguments of the call stack which includes itself
             var e = new RestError({
                 statusCode: 400,
                 restCode: 'Foo',
@@ -1022,7 +1020,6 @@ test('next.ifError', function (t) {
 
     CLIENT.get('/foo/bar', function (err) {
         t.ok(err);
-        t.equal(err.statusCode, 400);
         t.equal(err.body.message, 'screw you client');
         t.end();
     });
@@ -2185,6 +2182,24 @@ test('GH-999 Custom 404 handler does not send response', function (t) {
         }));
         t.end();
     });
+});
 
 
+test('GH-1084 missing toString() causes formatter to error', function (t) {
+
+    SERVER.get('/foo', function (req, res, next) {
+        res.header('content-type', 'text/plain');
+        var obj = {
+            message: 'foo',
+            toString: null
+        };
+        res.send(200, obj);
+        return next();
+    });
+
+    CLIENT.get('/foo', function (err, req, res, body) {
+        t.ok(err);
+        t.equal(err.message, '');
+        t.end();
+    });
 });


### PR DESCRIPTION
Clones #1074, thanks @chb0github!

text and json formatters now do only that.

1. text/plain formatter will now invoke a toString() on the body if it exists. Otherwise the body will be empty
2. application/json formatter will attempt to find a toJson() method on the body and invoke it. If that isn't found then it will invoke JSON.stringify on the body.