### PR TITLE
Emit 'after' event even if next is not called.

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -699,6 +699,7 @@ Server.prototype.toString = function toString() {
  */
 Server.prototype._handle = function _handle(req, res) {
     var self = this;
+    var afterCalled = false;
 
     function routeAndRun() {
         self._route(req, res, function (route, context) {
@@ -708,8 +709,15 @@ Server.prototype._handle = function _handle(req, res) {
             var r = route ? route.name : null;
             var chain = self.routes[r];
 
+            res.once('finish', function () {
+                if (!afterCalled) {
+                    self.emit('after', req, res, route, null);
+                }
+            });
+
             self._run(req, res, route, chain, function done(e) {
                 self.emit('after', req, res, route, e);
+                afterCalled = true;
             });
         });
     }


### PR DESCRIPTION
I would like the audit logger to log all requests, even if a particular handler doesn't call next for some reason. I see that the general consensus seems to be just make sure that you call next, but I wonder if you'd accept a patch that ensures that the after event is emitted even if the handler doesn't call next.

To accomplish that, I added code to handle the ServerResponse finish event.

This is a replacement for https://github.com/restify/node-restify/pull/998 which leaked event emitters.

@Jokero I fixed the error that I mentioned.