### PR TITLE
Add support for strict routing

### DIFF
--- a/docs/index.restdown
+++ b/docs/index.restdown
@@ -151,6 +151,8 @@ below (and `listen()` takes the same arguments as node's
 ||handleUpgrades||Boolean||Hook the `upgrade` event from the node HTTP server, pushing `Connection: Upgrade` requests through the regular request handling chain; defaults to `false`||
 ||httpsServerOptions||Object||Any options accepted by [node-https Server](http://nodejs.org/api/https.html#https_https). If provided the following restify server options will be ignored: spdy, ca, certificate, key, passphrase, rejectUnauthorized, requestCert and ciphers; however these can all be specified on httpsServerOptions.||
 ||reqIdHeaders||Array||an optional array of request id header names that will be used to set the request id (i.e., the value for req.getId()) ||
+||strict||Boolean||(Default=`false`). If set, Restify will treat "/foo" and "/foo/" as different paths.||
+
 
 ## Common handlers: server.use()
 

--- a/docs/index.restdown
+++ b/docs/index.restdown
@@ -151,7 +151,7 @@ below (and `listen()` takes the same arguments as node's
 ||handleUpgrades||Boolean||Hook the `upgrade` event from the node HTTP server, pushing `Connection: Upgrade` requests through the regular request handling chain; defaults to `false`||
 ||httpsServerOptions||Object||Any options accepted by [node-https Server](http://nodejs.org/api/https.html#https_https). If provided the following restify server options will be ignored: spdy, ca, certificate, key, passphrase, rejectUnauthorized, requestCert and ciphers; however these can all be specified on httpsServerOptions.||
 ||reqIdHeaders||Array||an optional array of request id header names that will be used to set the request id (i.e., the value for req.getId()) ||
-||strict||Boolean||(Default=`false`). If set, Restify will treat "/foo" and "/foo/" as different paths.||
+||strictRouting||Boolean||(Default=`false`). If set, Restify will treat "/foo" and "/foo/" as different paths.||
 
 
 ## Common handlers: server.use()

--- a/lib/router.js
+++ b/lib/router.js
@@ -171,7 +171,7 @@ function Router(options) {
     }
     assert.arrayOfString(this.contentType, 'options.contentType');
 
-    this.strict = Boolean(options.strict);
+    this.strict = Boolean(options.strictRouting);
     this.log = options.log;
     this.mounts = {};
     this.name = 'RestifyRouter';

--- a/lib/router.js
+++ b/lib/router.js
@@ -126,9 +126,20 @@ function compileURL(options) {
         return (true);
     });
 
+    if (options.strict
+        && pattern !== '^'
+        && _url.slice(-1) === '/') {
+        pattern += '\\/';
+    }
+
+    if (!options.strict) {
+        pattern += '[\\/]?';
+    }
+
     if (pattern === '^') {
         pattern += '\\/';
     }
+
     pattern += '$';
 
     re = new RegExp(pattern, options.flags);
@@ -161,6 +172,7 @@ function Router(options) {
     }
     assert.arrayOfString(this.contentType, 'options.contentType');
 
+    this.strict = Boolean(options.strict);
     this.log = options.log;
     this.mounts = {};
     this.name = 'RestifyRouter';
@@ -288,7 +300,8 @@ Router.prototype.mount = function mount(options) {
         path: compileURL({
             url: options.path || options.url,
             flags: options.flags,
-            urlParamPattern: options.urlParamPattern
+            urlParamPattern: options.urlParamPattern,
+            strict: self.strict
         }),
         spec: options,
         types: type,

--- a/lib/router.js
+++ b/lib/router.js
@@ -132,7 +132,7 @@ function compileURL(options) {
     }
 
     if (!options.strict) {
-        pattern += '[\\/]?';
+        pattern += '[\\/]*';
     }
 
     if (pattern === '^') {

--- a/lib/router.js
+++ b/lib/router.js
@@ -127,7 +127,6 @@ function compileURL(options) {
     });
 
     if (options.strict
-        && pattern !== '^'
         && _url.slice(-1) === '/') {
         pattern += '\\/';
     }

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -170,3 +170,51 @@ test('clean up xss for 404', function (t) {
         });
     });
 });
+
+test('Strict routing handles root path', function (t) {
+    var server = restify.createServer({strict: true});
+    function noop () {}
+    server.get('/', noop);
+
+    var root = server.router.routes.GET[0];
+    t.ok(root.path.test('/'));
+
+    t.end();
+});
+
+test('Strict routing distinguishes trailing slash', function (t) {
+    var server = restify.createServer({strict: true});
+    function noop () {}
+
+    server.get('/trailing/', noop);
+    server.get('/no-trailing', noop);
+
+
+    var trailing = server.router.routes.GET[0];
+    t.ok(trailing.path.test('/trailing/'));
+    t.notOk(trailing.path.test('/trailing'));
+
+    var noTrailing = server.router.routes.GET[1];
+    t.ok(noTrailing.path.test('/no-trailing'));
+    t.notOk(noTrailing.path.test('/no-trailing/'));
+
+    t.end();
+});
+
+test('Default non-strict routing ignores trailing slash', function (t) {
+    var server = restify.createServer();
+    function noop () {}
+
+    server.get('/trailing/', noop);
+    server.get('/no-trailing', noop);
+
+    var trailing = server.router.routes.GET[0];
+    t.ok(trailing.path.test('/trailing/'));
+    t.ok(trailing.path.test('/trailing'));
+
+    var noTrailing = server.router.routes.GET[1];
+    t.ok(noTrailing.path.test('/no-trailing'));
+    t.ok(noTrailing.path.test('/no-trailing/'));
+
+    t.end();
+});

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -172,7 +172,7 @@ test('clean up xss for 404', function (t) {
 });
 
 test('Strict routing handles root path', function (t) {
-    var server = restify.createServer({strict: true});
+    var server = restify.createServer({strictRouting: true});
     function noop () {}
     server.get('/', noop);
 
@@ -183,7 +183,7 @@ test('Strict routing handles root path', function (t) {
 });
 
 test('Strict routing distinguishes trailing slash', function (t) {
-    var server = restify.createServer({strict: true});
+    var server = restify.createServer({strictRouting: true});
     function noop () {}
 
     server.get('/trailing/', noop);

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -201,7 +201,7 @@ test('Strict routing distinguishes trailing slash', function (t) {
     t.end();
 });
 
-test('Default non-strict routing ignores trailing slash', function (t) {
+test('Default non-strict routing ignores trailing slash(es)', function (t) {
     var server = restify.createServer();
     function noop () {}
 
@@ -210,10 +210,12 @@ test('Default non-strict routing ignores trailing slash', function (t) {
 
     var trailing = server.router.routes.GET[0];
     t.ok(trailing.path.test('/trailing/'));
+    t.ok(trailing.path.test('//trailing//'));
     t.ok(trailing.path.test('/trailing'));
 
     var noTrailing = server.router.routes.GET[1];
     t.ok(noTrailing.path.test('/no-trailing'));
+    t.ok(noTrailing.path.test('//no-trailing//'));
     t.ok(noTrailing.path.test('/no-trailing/'));
 
     t.end();


### PR DESCRIPTION
Not sure if the idea was to have it opt-in, but that's what I've done here, since the original issue asked for an Express-like API – but I think that is the opposite of current behavior. Is that ok?

- Adds a new boolean parameter for createServer (`strict`)
- Compiles and matches paths using non-strict mode by default

Cf. #692