### PR TITLE
GH-959: fixes issue where cached routes were not setting maxVersion on the req

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -416,6 +416,7 @@ Router.prototype.find = function find(req, res, callback) {
 
     if ((cacheVal = this.cache.get(cacheKey))) {
         res.methods = cacheVal.methods.slice();
+        req._matchedVersion = cacheVal.matchedVersion;
         callback(null, cacheVal, shallowCopy(cacheVal.params));
         return;
     }
@@ -516,6 +517,7 @@ Router.prototype.find = function find(req, res, callback) {
 
         if (versioned) {
             req._matchedVersion = maxV;
+            cacheVal.matchedVersion = maxV;
         }
 
         this.cache.set(cacheKey, cacheVal);

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1195,6 +1195,37 @@ test('versioned route matching should prefer \
 });
 
 
+test('GH-959 matchedVersion() should return on cached routes', function (t) {
+
+    SERVER.get({
+        path: '/test',
+        version: '0.5.0'
+    }, function (req, res, next) {
+        console.log('req.version()', req.version());
+        console.log('req.matchedVersion()', req.matchedVersion());
+        res.send({
+            version: req.version(),
+            matchedVersion: req.matchedVersion()
+        });
+        return next();
+    });
+
+
+    CLIENT.get('/test', function (err, _, res, body) {
+        t.ifError(err);
+        t.equal(body.version, '*');
+        t.equal(body.matchedVersion, '0.5.0');
+
+        CLIENT.get('/test', function (err2, _2, res2, body2) {
+            t.ifError(err2);
+            t.equal(body.version, '*');
+            t.equal(body.matchedVersion, '0.5.0');
+            t.end();
+        });
+    });
+});
+
+
 test('gh-329 wrong values in res.methods', function (t) {
     function route(req, res, next) {
         res.send(200);


### PR DESCRIPTION
Here is the fix for #959 cherry-picked onto the 4.x branch. Please let me know if it needs and additional work -- I noticed there were a couple of `console.log` statements in this test.