### PR TITLE
Provide explicit error message for route not found

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -382,7 +382,7 @@ Router.prototype.get = function get(name, req, cb) {
     if (route) {
         cb(null, route, params || {});
     } else {
-        cb(new InternalError());
+        cb(new InternalError('Route not found: ' + name));
     }
 };
 


### PR DESCRIPTION
When testify does not find a matching route it just returns an InternalServerError. However, that could be anything and it is not clear it was caused by a non-matching route.

Provide a message to the error to make it easier to find these mistakes.
