### PR TITLE
GH-1086: reuse incoming request id headers to set request id

### DIFF
--- a/docs/index.restdown
+++ b/docs/index.restdown
@@ -150,6 +150,7 @@ below (and `listen()` takes the same arguments as node's
 ||version||String|Array||A default version to set for all routes||
 ||handleUpgrades||Boolean||Hook the `upgrade` event from the node HTTP server, pushing `Connection: Upgrade` requests through the regular request handling chain; defaults to `false`||
 ||httpsServerOptions||Object||Any options accepted by [node-https Server](http://nodejs.org/api/https.html#https_https). If provided the following restify server options will be ignored: spdy, ca, certificate, key, passphrase, rejectUnauthorized, requestCert and ciphers; however these can all be specified on httpsServerOptions.||
+||reqIdHeaders||Array||an optional array of request id header names that will be used to set the request id (i.e., the value for req.getId()) ||
 
 ## Common handlers: server.use()
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -222,9 +222,7 @@ Request.prototype.getId = function getId() {
         return (this._id);
     }
 
-    this._id = this.headers['request-id'] ||
-        this.headers['x-request-id'] ||
-        uuid.v4();
+    this._id = uuid.v4();
 
     return (this._id);
 };

--- a/lib/server.js
+++ b/lib/server.js
@@ -235,11 +235,14 @@ function optionsError(err, req, res) {
  * @public
  * @class
  * @param {Object} options an options object
+ * @param {Array} [options.reqIdHeaders] an array of request id headers to
+ * re-use from incoming requests
  */
 function Server(options) {
     assert.object(options, 'options');
     assert.object(options.log, 'options.log');
     assert.object(options.router, 'options.router');
+    assert.optionalArrayOfString(options.reqIdHeaders, 'options.reqIdHeaders');
 
     var self = this;
 
@@ -255,6 +258,11 @@ function Server(options) {
     this.secure = false;
     this.versions = options.versions || options.version || [];
     this.socketio = options.socketio || false;
+
+    var defaultReqIdHeaders = ['request-id', 'x-request-id'];
+    this.reqIdHeaders = (options.reqIdHeaders) ?
+                    options.reqIdHeaders.concat(defaultReqIdHeaders) :
+                    defaultReqIdHeaders;
 
     var fmt = mergeFormatters(options.formatters);
     this.acceptable = fmt.acceptable;
@@ -1038,4 +1046,17 @@ Server.prototype._setupRequest = function _setupRequest(req, res) {
     res.req = req;
     res.serverName = this.name;
     res.version = this.router.versions[this.router.versions.length - 1];
+
+    // GH-1086: set request id based on array of headers, lowest index
+    // is highest priority.
+    var i = 0;
+
+    for (i = 0; i < this.reqIdHeaders.length; i++) {
+        var idName = this.reqIdHeaders[i];
+
+        if (req.headers.hasOwnProperty(idName) && req.headers[idName]) {
+            req._id = req.headers[idName];
+            break;
+        }
+    }
 };

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "nsp": "^2.2.0",
     "restify-clients": "^1.2.1",
     "restify-plugins": "^1.0.2",
+    "validator": "^5.2.0",
     "watershed": "^0.3.0"
   },
   "license": "MIT",

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -13,6 +13,7 @@ var filed = require('filed');
 var plugins = require('restify-plugins');
 var restifyClients = require('restify-clients');
 var uuid = require('node-uuid');
+var validator = require('validator');
 
 var RestError = errors.RestError;
 var restify = require('../lib');
@@ -43,7 +44,8 @@ before(function (cb) {
             dtrace: helper.dtrace,
             handleUncaughtExceptions: true,
             log: helper.getLog('server'),
-            version: ['2.0.0', '0.5.4', '1.4.3']
+            version: ['2.0.0', '0.5.4', '1.4.3'],
+            reqIdHeaders: ['x-req-id-a', 'x-req-id-b']
         });
         SERVER.listen(PORT, '127.0.0.1', function () {
             PORT = SERVER.address().port;
@@ -2170,4 +2172,104 @@ test('calling next(false) should early exit from pre handlers', function (t) {
         t.end();
     });
 
+});
+
+
+test('GH-1086: should reuse request id when available', function (t) {
+
+    SERVER.get('/1', function (req, res, next) {
+        // the 12345 value is set when the client is created.
+        t.ok(req.headers.hasOwnProperty('x-req-id-a'));
+        t.equal(req.getId(), req.headers['x-req-id-a']);
+        res.send('hello world');
+        return next();
+    });
+
+    // create new client since we new specific headers
+    CLIENT = restifyClients.createJsonClient({
+        url: 'http://127.0.0.1:' + PORT,
+        headers:{
+            'x-req-id-a': 12345
+        }
+    });
+
+    CLIENT.get('/1', function (err, req, res, data) {
+        t.ifError(err);
+        t.equal(data, 'hello world');
+        t.end();
+    });
+});
+
+
+test('GH-1086: should use second request id when available', function (t) {
+
+    SERVER.get('/1', function (req, res, next) {
+        t.ok(req.headers.hasOwnProperty('x-req-id-b'));
+        t.equal(req.getId(), req.headers['x-req-id-b']);
+        res.send('hello world');
+        return next();
+    });
+
+    // create new client since we new specific headers
+    CLIENT = restifyClients.createJsonClient({
+        url: 'http://127.0.0.1:' + PORT,
+        headers:{
+            'x-req-id-b': 678910
+        }
+    });
+
+    CLIENT.get('/1', function (err, req, res, data) {
+        t.ifError(err);
+        t.equal(data, 'hello world');
+        t.end();
+    });
+});
+
+
+test('GH-1086: should use default uuid request id if none provided',
+function (t) {
+
+    SERVER.get('/1', function (req, res, next) {
+        t.ok(req.getId());
+        t.ok(validator.isUUID(req.getId()));
+        res.send('hello world');
+        return next();
+    });
+
+    // create new client since we new specific headers
+    CLIENT = restifyClients.createJsonClient({
+        url: 'http://127.0.0.1:' + PORT
+    });
+
+    CLIENT.get('/1', function (err, req, res, data) {
+        t.ifError(err);
+        t.equal(data, 'hello world');
+        t.end();
+    });
+});
+
+
+test('GH-1086: empty request id should be ignored', function (t) {
+
+    SERVER.get('/1', function (req, res, next) {
+        t.ok(req.headers.hasOwnProperty('x-req-id-b'));
+        t.equal(req.getId(), req.headers['x-req-id-b']);
+        res.send('hello world');
+        return next();
+    });
+
+    // create new client since we new specific headers
+    CLIENT = restifyClients.createJsonClient({
+        url: 'http://127.0.0.1:' + PORT,
+        headers:{
+            'x-req-id-a': '',
+            'x-req-id-b': 12345
+        }
+    });
+
+    CLIENT.get('/1', function (err, req, res, data) {
+        t.ifError(err);
+        t.equal(data, 'hello world');
+        t.end();
+    });
 });


### PR DESCRIPTION
Fixes #1086 