### PR TITLE
throw error on node failure to access a server's address

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -360,7 +360,7 @@ function Server(options) {
             str += ':';
             str += addr.port;
         } else {
-            str += '169.254.0.1:0000';
+            throw new Error("Restify couldn't find a valid address to bind to.");
         }
 
         return (str);


### PR DESCRIPTION
I just happened to peek over the source code and this line seemed pretty weird.

Git blame goes to @mcavage. Why did you choice `169.254.0.1` and not any other IP or localhost?

https://github.com/restify/node-restify/commit/19ddb2c288ad158a0fbe025c7e6fc8525ea13b34 
