### PR TITLE
GH-951: res.sendRaw() skips formatters

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -265,7 +265,6 @@ Response.prototype.link = function link(l, rel) {
     return (this.header('Link', _link));
 };
 
-
 /**
  * sends the response object. convenience method that handles:
  *     writeHead(), write(), end()
@@ -277,6 +276,24 @@ Response.prototype.link = function link(l, rel) {
  * @returns  {Object}                            self, the response object
  */
 Response.prototype.send = function send(code, body, headers) {
+    return this.__send(code, body, headers, true);
+};
+
+/**
+ * sends the response object as-is without formatting. convenience method that
+ *     handles: writeHead(), write(), end()
+ * @public
+ * @function send
+ * @param    {Number} code                      http status code
+ * @param    {Object | Buffer | Error} body     the content to send
+ * @param    {Object}                  headers  any add'l headers to set
+ * @returns  {Object}                           self, the response object
+ */
+Response.prototype.sendRaw = function sendRaw(code, body, headers) {
+    return this.__send(code, body, headers, false);
+};
+
+Response.prototype.__send = function __send(code, body, headers, format) {
     var isHead = (this.req.method === 'HEAD');
     var log = this.log;
     var self = this;
@@ -353,7 +370,9 @@ Response.prototype.send = function send(code, body, headers) {
         }
     }
 
-    if (body !== undefined) {
+    if (format === false) {
+        _cb(null, body);
+    } else if (body !== undefined) {
         self.format(body, _cb);
     } else {
         _cb(null, null);
@@ -361,7 +380,6 @@ Response.prototype.send = function send(code, body, headers) {
 
     return (self);
 };
-
 
 /**
  * sets a header on the response.

--- a/lib/response.js
+++ b/lib/response.js
@@ -265,9 +265,10 @@ Response.prototype.link = function link(l, rel) {
     return (this.header('Link', _link));
 };
 
+
 /**
- * sends the response object. convenience method that handles:
- *     writeHead(), write(), end()
+ * sends the response object. pass through to internal __send that uses a
+ * formatter based on the content-type header.
  * @public
  * @function send
  * @param    {Number} [code]                     http status code
@@ -276,27 +277,43 @@ Response.prototype.link = function link(l, rel) {
  * @returns  {Object}                            self, the response object
  */
 Response.prototype.send = function send(code, body, headers) {
-    return this.__send(code, body, headers, true);
+    var self = this;
+    return self.__send(code, body, headers, true);
 };
 
+
 /**
- * sends the response object as-is without formatting. convenience method that
- *     handles: writeHead(), write(), end()
+ * sends the response object. pass through to internal __send that skips
+ * formatters entirely and sends the content as is.
  * @public
- * @function send
+ * @function sendRaw
  * @param    {Number} code                      http status code
  * @param    {Object | Buffer | Error} body     the content to send
  * @param    {Object}                  headers  any add'l headers to set
  * @returns  {Object}                           self, the response object
  */
 Response.prototype.sendRaw = function sendRaw(code, body, headers) {
-    return this.__send(code, body, headers, false);
+    var self = this;
+    return self.__send(code, body, headers, false);
 };
 
+
+/**
+ * internal implementation of send. convenience method that handles:
+ * writeHead(), write(), end().
+ * @private
+ * @param    {Number} code                      http status code
+ * @param    {Object | Buffer | Error} body     the content to send
+ * @param    {Object} headers  any add'l headers to set
+ * @param    {Boolean} format   if true, use a corresponding
+ * formatter for the specified content-type
+ * @returns  {Object}                           self, the response object
+ */
 Response.prototype.__send = function __send(code, body, headers, format) {
-    var isHead = (this.req.method === 'HEAD');
-    var log = this.log;
+
     var self = this;
+    var isHead = (self.req.method === 'HEAD');
+    var log = self.log;
 
     // normalize variadic args. if nothing passed in, set 200 and go
     if (code === undefined) {
@@ -371,6 +388,10 @@ Response.prototype.__send = function __send(code, body, headers, format) {
     }
 
     if (format === false) {
+        // if no formatting, assert that the value to be written is a string
+        // or a buffer.
+        assert.ok(typeof body === 'string' || Buffer.isBuffer(body),
+                  'res.sendRaw() accepts only strings or buffers');
         _cb(null, body);
     } else if (body !== undefined) {
         self.format(body, _cb);
@@ -380,6 +401,7 @@ Response.prototype.__send = function __send(code, body, headers, format) {
 
     return (self);
 };
+
 
 /**
  * sets a header on the response.

--- a/test/response.test.js
+++ b/test/response.test.js
@@ -21,6 +21,7 @@ var test = helper.test;
 
 var PORT = process.env.UNIT_TEST_PORT || 0;
 var CLIENT;
+var STRING_CLIENT;
 var SERVER;
 
 var LOCALHOST;
@@ -43,6 +44,11 @@ before(function (cb) {
                 dtrace: helper.dtrace,
                 retry: false
             });
+            STRING_CLIENT = restifyClients.createStringClient({
+                url: 'http://127.0.0.1:' + PORT,
+                dtrace: helper.dtrace,
+                retry: false
+            });
             LOCALHOST = 'http://' + '127.0.0.1:' + PORT;
             SLOCALHOST = 'https://' + '127.0.0.1:' + PORT;
 
@@ -58,6 +64,7 @@ before(function (cb) {
 after(function (cb) {
     try {
         CLIENT.close();
+        STRING_CLIENT.close();
         SERVER.close(function () {
             CLIENT = null;
             SERVER = null;
@@ -339,7 +346,6 @@ test('redirect should emit a redirect event', function (t) {
             wasEmitted = true;
             redirectLocation = payload;
         });
-        console.log('about to call next');
         next();
     }
     function redirect(req, res, next) {
@@ -454,4 +460,46 @@ test('should prefer explicit status code over error status code', function (t) {
         t.equal(body.message, 'boom');
         t.end();
     });
+});
+
+
+test('GH-951: should send without formatting', function (t) {
+
+    SERVER.get('/15', function handle (req, res, next) {
+        res.header('content-type', 'application/json');
+        res.sendRaw(200, JSON.stringify({
+            hello: 'world'
+        }));
+        return next();
+    });
+
+    STRING_CLIENT.get(join(LOCALHOST, '/15'), function (err, _, res, body) {
+        t.ifError(err);
+        t.equal(body, JSON.stringify({
+            hello: 'world'
+        }));
+        t.end();
+    });
+});
+
+
+test('GH-951: sendRaw accepts only strings or buffers', function (t) {
+
+    SERVER.on('uncaughtException', function (req, res, route, err) {
+        t.ok(err);
+        t.equal(err.name, 'AssertionError');
+        t.equal(err.message, 'res.sendRaw() accepts only strings or buffers');
+        t.end();
+    });
+
+    SERVER.get('/16', function handle (req, res, next) {
+        res.header('content-type', 'application/json');
+        res.sendRaw(200, {
+            hello: 'world'
+        });
+        return next();
+    });
+
+    // throw away response, we don't need it.
+    STRING_CLIENT.get(join(LOCALHOST, '/16'));
 });


### PR DESCRIPTION
This builds on top of #1025 and adds unit tests. @mramato, I hope you don't mind, I've pulled down your branch and added the unit tests. Let me know if this look ok. 

As usual, PTAL @yunong @micahr. 