### PR TITLE
JSDoc fix: net code and headers optional as they are. fixes #1113

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -235,9 +235,9 @@ Response.prototype.header = function header(name, value) {
  *     res.send({hello: 'world'});
  * @public
  * @function json
- * @param    {Number} code    http status code
- * @param    {Object} object  value to json.stringify
- * @param    {Object} headers headers to set on the response
+ * @param    {Number} [code]    http status code
+ * @param    {Object} object    value to json.stringify
+ * @param    {Object} [headers] headers to set on the response
  * @returns  {Object}
  */
 Response.prototype.json = function json(code, object, headers) {


### PR DESCRIPTION
I just found out that the jsdoc is not correct for `Response.prototype.json`. My IDE notes that the function expects exactly 3 parameters what is wrong.