### PR TITLE
GH-1129: always invoke res.send callback if provided

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -457,7 +457,11 @@ function __send(maybeCode, maybeBody, maybeHeaders, maybeCallback, format) {
         }
         // for sync formatters, invoke formatter and send response body.
         else {
-            return _flush(formatter.call(self, self.req, self, body), body);
+            _flush(formatter.call(self, self.req, self, body), body);
+            // users can always opt to pass in next, even when formatter is not
+            // async. invoke callback in that case. return null when no
+            // callback because eslint wants consistent-return.
+            return (callback) ? callback() : null;
         }
     });
 

--- a/test/formatter.test.js
+++ b/test/formatter.test.js
@@ -221,6 +221,26 @@ test('GH-845: async formatter error should emit FormatterError', function (t) {
 });
 
 
+test('GH-1129: sync formatter should invoke res.send callback', function (t) {
+
+    SERVER.on('after', function () {
+        // only end the test when server considers request complete
+        t.end();
+    });
+
+    CLIENT.get({
+        path: '/async',
+        headers: {
+            accept: 'text/sync'
+        }
+    }, function (err, req, res, data) {
+        t.ifError(err);
+        t.equal(res.statusCode, 200);
+        t.equal(data, 'sync fmt');
+    });
+});
+
+
 test('GH-845: should blow up when using async formatter ' +
      'without res.send callback', function (t) {
 


### PR DESCRIPTION
Fixes #1129 