### PR TITLE
Feature: Ability to find a route by a path

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -577,6 +577,16 @@ Router.prototype.find = function find(req, res, callback) {
     ));
 };
 
+/**
+ * Find a route by path. Scans the route list for a route with the same RegEx.
+ * i.e. /foo/:param1/:param2 would match an existing route with different
+ * parameter names /foo/:id/:name since the compiled RegExs match.
+ * @public
+ * @function findByPath
+ * @param    {String | RegExp}    path      a path to find a route for.
+ * @param    {Object}             options   an options object
+ * @returns  {Object}             returns the route if a match is found
+ */
 Router.prototype.findByPath = function findByPath(path, options) {
     assert.string(path, 'path');
     assert.object(options, 'options');

--- a/lib/router.js
+++ b/lib/router.js
@@ -577,6 +577,29 @@ Router.prototype.find = function find(req, res, callback) {
     ));
 };
 
+Router.prototype.findByPath = function findByPath(path, options) {
+    assert.string(path, 'path');
+    assert.object(options, 'options');
+    assert.string(options.method, 'options.method');
+
+    var route;
+    var routes = this.routes[options.method] || [];
+    var routeRegex = compileURL({
+        url: path,
+        flags: options.flags,
+        urlParamPattern: options.urlParamPattern,
+        strict: this.strict
+    });
+
+    for (var i = 0; i < routes.length; i++) {
+        if (routeRegex.toString() === routes[i].path.toString()) {
+            route = routes[i];
+            break;
+        }
+    }
+    return (route);
+};
+
 
 /**
  * toString() serialization.

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -220,3 +220,25 @@ test('Default non-strict routing ignores trailing slash(es)', function (t) {
 
     t.end();
 });
+
+test('Find existing route with path', function (t) {
+    var server = restify.createServer();
+    function noop () {}
+
+    var routePath = '/route/:withParam';
+    server.get(routePath, noop);
+
+    var foundRoute = server.router.findByPath(
+      '/route/:withADifferentParamName',
+      { method: 'GET' }
+    );
+    t.equal(foundRoute.spec.path, routePath);
+
+    var notFoundRoute = server.router.findByPath(
+      '/route/:withADifferentParamName([A-Z]{2,3})',
+      { method: 'GET' }
+    );
+    t.notOk(notFoundRoute);
+
+    t.end();
+});


### PR DESCRIPTION
I have a use case where I'm adding routes to the server dynamically after the server is up. I would like to be able to check if a route exists for a path before I add it, because if another route already has a similar path regex, the new route will not fire (the first route that matches the request is always the one returned from the router).

Example:

```javascript
// existing route
server.get('/users/:id', () => {});   // regex: /^\/+users\/+([^\/]*)[\/]*$/
// new route
server.get('/users/:myParamName', () => {});   // regex: /^\/+users\/+([^\/]*)[\/]*$/
```

In this case, I wouldn't want to add the new route because the existing route has the same regex even though the parameter names are different. I would like to throw an error that says a route at that path already exists on the server, and then output the details of that route.

I didn't see another way to do this since the `compileUrl` method in router.js method isn't exported and that's what translates a path with parameter names to a RegEx. So rather than copy that method, I created this new method to translate a path to a RegEx and compare it against the route collection. I made it a `findByPath` method so that it can return the route that had the same path.

The other way I thought about doing it was to do my own parsing of the path and then set that as the route name (the `mount` method in the router will return `false` for routes that have the same name). But, I thought it might be good to still be able to name my routes differently from the path.

Anyway, TLDR; let me know if you have any feedback! Thanks! 👍 