### PR TITLE
note that this is the breaking change in 4.x

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,7 +20,7 @@
 ## 4.0.0
 - #877 content-type can be case-insensitive. Yunong Xiao
 - #856 update various dependencies. Alex Liu
-- #851 fix formatters such that they always return cb. Yunong Xiao
+- #851 **BREAKING** fix formatters such that they always return cb. Yunong Xiao
 - #847 fix body parser race condition. Yunong Xiao
 - #842 add `req.matchedVersion()` Nathan Peck, Micah Ransdell
 - #840 Fix issue with server toString Method. OiNutter, Micah Ransdell


### PR DESCRIPTION
This relates to https://github.com/restify/node-restify/pull/851
https://github.com/restify/node-restify/pull/924 is the equivalent change to the changelog in the 5.x branch.