### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/bunyan_helper.js
+++ b/lib/bunyan_helper.js
@@ -8,7 +8,7 @@ var util = require('util');
 var assert = require('assert-plus');
 var bunyan = require('bunyan');
 var LRU = require('lru-cache');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 
 ///--- Globals

--- a/lib/request.js
+++ b/lib/request.js
@@ -9,7 +9,7 @@ var sprintf = require('util').format;
 var assert = require('assert-plus');
 var mime = require('mime');
 var Negotatior = require('negotiator');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 var dtrace = require('./dtrace');
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -14,7 +14,7 @@ var mime = require('mime');
 var once = require('once');
 var semver = require('semver');
 var spdy = require('spdy');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var vasync = require('vasync');
 
 var dtrace = require('./dtrace');

--- a/package.json
+++ b/package.json
@@ -68,12 +68,12 @@
     "lru-cache": "^4.0.1",
     "mime": "^1.2.11",
     "negotiator": "^0.6.1",
-    "node-uuid": "^1.4.7",
     "once": "^1.3.0",
     "qs": "^6.2.1",
     "restify-errors": "^4.2.3",
     "semver": "^5.0.1",
     "spdy": "^3.3.3",
+    "uuid": "^3.0.0",
     "vasync": "^1.6.4"
   },
   "optionalDependencies": {

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -12,7 +12,7 @@ var errors = require('restify-errors');
 var filed = require('filed');
 var plugins = require('restify-plugins');
 var restifyClients = require('restify-clients');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var validator = require('validator');
 
 var RestError = errors.RestError;
@@ -1782,7 +1782,7 @@ test('error handler defers "after" event', function (t) {
         // do not fire prematurely
         t.notOk(true);
     });
-    CLIENT.get('/' + uuid(), function (err, _, res) {
+    CLIENT.get('/' + uuid.v4(), function (err, _, res) {
         t.ok(err);
         t.equal(res.statusCode, 404);
         t.end();


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.