### PR TITLE
allow custom request id resolver

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -41,6 +41,7 @@ var PROXY_EVENTS = [
     'listening',
     'secureConnection'
 ];
+var DEFAULT_REQ_ID_HEADERS = ['request-id', 'x-request-id'];
 
 
 ///--- Helpers
@@ -248,8 +249,10 @@ function optionsError(err, req, res) {
  * @public
  * @class
  * @param {Object} options an options object
- * @param {Array} [options.reqIdHeaders] an array of request id headers to
- * re-use from incoming requests
+ * @param {Array } [options.reqIdHeaders] an array of request id
+ * headers to re-use from incoming requests
+ * @param {Function} [options.reqId] a user supplied function that is invoked on
+ * every request to determine the request id
  */
 function Server(options) {
     assert.object(options, 'options');
@@ -257,6 +260,7 @@ function Server(options) {
     assert.object(options.router, 'options.router');
     assert.string(options.name, 'options.name');
     assert.optionalArrayOfString(options.reqIdHeaders, 'options.reqIdHeaders');
+    assert.optionalFunc(options.reqId, 'options.reqId');
 
     var self = this;
 
@@ -273,11 +277,11 @@ function Server(options) {
     this.versions = options.versions || options.version || [];
     this.socketio = options.socketio || false;
     this._unfinishedRequests = 0;
-
-    var defaultReqIdHeaders = ['request-id', 'x-request-id'];
-    this.reqIdHeaders = (options.reqIdHeaders) ?
-                    options.reqIdHeaders.concat(defaultReqIdHeaders) :
-                    defaultReqIdHeaders;
+    this._reqIdResolver = (options.hasOwnProperty('reqId')) ?
+                            options.reqId : null;
+    this._reqIdHeaders = (options.hasOwnProperty('reqIdHeaders')) ?
+                        options.reqIdHeaders.concat(DEFAULT_REQ_ID_HEADERS) :
+                        DEFAULT_REQ_ID_HEADERS;
 
     var fmt = mergeFormatters(options.formatters);
     this.acceptable = fmt.acceptable;
@@ -1124,16 +1128,18 @@ Server.prototype._setupRequest = function _setupRequest(req, res) {
     }
     res.version = self.router.versions[self.router.versions.length - 1];
 
-    // GH-1086: set request id based on array of headers, lowest index
-    // is highest priority.
-    var i = 0;
+    // GH-1086 & GH-XYZ: set request id based on array of headers, lowest index
+    // is highest priority. or, if custom function provided, prefer that.
+    if (self._reqIdResolver) {
+        req._id = self._reqIdResolver(req, res);
+    } else {
+        for (var i = 0; i < self._reqIdHeaders.length; i++) {
+            var idName = self._reqIdHeaders[i];
 
-    for (i = 0; i < self.reqIdHeaders.length; i++) {
-        var idName = self.reqIdHeaders[i];
-
-        if (req.headers.hasOwnProperty(idName) && req.headers[idName]) {
-            req._id = req.headers[idName];
-            break;
+            if (req.headers.hasOwnProperty(idName) && req.headers[idName]) {
+                req._id = req.headers[idName];
+                break;
+            }
         }
     }
 };


### PR DESCRIPTION
I opted to introduce a new option since this new function resolver really has nothing to do with headers, so it's weird to reuse the`reqIdHeaders` option. It's currently just called `reqId` but open to naming suggestions. 