### PR TITLE
sanitizePath filters double-slashes in the queryString

### DIFF
--- a/lib/plugins/pre/pre_path.js
+++ b/lib/plugins/pre/pre_path.js
@@ -16,6 +16,7 @@ function strip(path) {
     var cur;
     var next;
     var str = '';
+    var inQS = false;
 
     for (var i = 0; i < path.length; i++) {
         cur = path.charAt(i);
@@ -24,8 +25,10 @@ function strip(path) {
             next = path.charAt(i + 1);
         }
 
-        if (cur === '/' && (next === '/' || (next === '?' && i > 0))) {
+        if (cur === '/' && (next === '/' || (next === '?' && i > 0)) && !inQS) {
             continue;
+        } else if (cur === '?') {
+            inQS = true;
         }
 
         str += cur;

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1268,7 +1268,6 @@ test('GH-323: <url>/<path>/?<queryString> broken', function (t) {
     });
 });
 
-
 test('<url>/?<queryString> broken', function (t) {
     SERVER.pre(restify.pre.sanitizePath());
     SERVER.use(restify.queryParser());
@@ -1285,6 +1284,21 @@ test('<url>/?<queryString> broken', function (t) {
     });
 });
 
+test('<url>/?<queryString> filters the queryString', function (t) {
+    SERVER.pre(restify.pre.sanitizePath());
+    SERVER.use(restify.queryParser());
+    SERVER.get('/foo', function (req, res, next) {
+        res.send(req.params);
+    });
+
+    SERVER.listen(8080, function () {
+        CLIENT.get('/foo?bar=http://example.com', function (err, _, __, obj) {
+            t.ifError(err);
+            t.deepEqual(obj, {bar: 'http://example.com'});
+            t.end();
+        });
+    });
+});
 
 test('GH #704: Route with a valid RegExp params', function (t) {
 


### PR DESCRIPTION
I stumbled upon a somewhat interesting bug in the sanitizePath pre-filter. It will continue it's sanitisation into the queryString-part of the URL.

The filter is meant to turn `foo///bar//` into `foo/bar`, but since the path it gets in also includes the QS, it will also turn `foo//bar//?baz=///` into `foo/bar?baz=/`. I doubt this is intentionally, as the contents of query-parameters often aren't subject to the same laxness as we assign urls.

So I have created a very simple fix, that simply tracks when the path transitions into the query-string part, and then skips any further filtering.

This is targeted against the 4.x branch, because I can see that this functionality has been moved to _restify-plugins_ in 5.x. But in my opinion this bug is important enough to have it applied to 4.x.
If this fix is accepted, I will gladly forward port the same changes to _restify-plugins_ so they can make it into 5.x as well.

Kind regards
Morten