### PR TITLE
Emit `close` event

### DIFF
--- a/docs/pages/components/server.md
+++ b/docs/pages/components/server.md
@@ -326,3 +326,7 @@ function(req, res, route, error) { }
 * res - the response object
 * route - the route object that serviced the request
 * error - the error passed to `next()`, if applicable
+
+## close
+
+Emitted when the server closes.

--- a/lib/server.js
+++ b/lib/server.js
@@ -429,11 +429,14 @@ Server.prototype.listen = function listen() {
  * @returns  {undefined}
  */
 Server.prototype.close = function close(callback) {
+    var sendCloseEvent = this.emit.bind(this, 'close');
+
     if (callback) {
         assert.func(callback, 'callback');
     }
 
     this.server.once('close', function onClose() {
+        sendCloseEvent();
         return (callback ? callback() : false);
     });
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -429,14 +429,14 @@ Server.prototype.listen = function listen() {
  * @returns  {undefined}
  */
 Server.prototype.close = function close(callback) {
-    var sendCloseEvent = this.emit.bind(this, 'close');
+    var self = this;
 
     if (callback) {
         assert.func(callback, 'callback');
     }
 
     this.server.once('close', function onClose() {
-        sendCloseEvent();
+        self.emit('close');
         return (callback ? callback() : false);
     });
 

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -2528,6 +2528,17 @@ function (t) {
     });
 });
 
+test('should emit \'close\' on server close', function (t) {
+    var server = restify.createServer();
+
+    server.listen(PORT + 1, '127.0.0.1', function () {
+        server.on('close', function () {
+            t.end();
+        });
+        server.close();
+    });
+});
+
 
 test('should cleanup queue for 404s', function (t) {
 


### PR DESCRIPTION
Emit a `close` event when server is closed.
Can be useful for middlewares that needs this information to clear up things or stop timers.