### PR TITLE
jsonp formatter unicode escapes line and paragraph separators

### DIFF
--- a/lib/formatters/jsonp.js
+++ b/lib/formatters/jsonp.js
@@ -6,6 +6,9 @@
 
 /**
  * JSONP formatter. like JSON, but with a callback invocation.
+ *
+ * Unicode escapes line and paragraph separators.
+ *
  * @public
  * @function formatJSONP
  * @param    {Object} req  the request object
@@ -32,6 +35,9 @@ function formatJSONP(req, res, body) {
     } else {
         data = JSON.stringify(body);
     }
+
+    data = data.replace(/\u2028/g, '\\u2028')
+               .replace(/\u2029/g, '\\u2029');
 
     res.setHeader('Content-Length', Buffer.byteLength(data));
     return data;

--- a/test/formatter.test.js
+++ b/test/formatter.test.js
@@ -87,6 +87,12 @@ before(function (callback) {
                 res.send('dummy response');
                 return next();
             });
+            SERVER.get('/jsonpSeparators', function (req, res, next) {
+                res.setHeader('content-type', 'application/javascript');
+                res.send(String.fromCharCode(0x2028)
+                         + String.fromCharCode(0x2029));
+                return next();
+            });
             process.nextTick(callback);
         });
     } catch (e) {
@@ -341,6 +347,27 @@ test('GH-937 should return 500 when no default formatter found ' +
         t.ok(req);
         t.ok(res);
         t.equal(res.statusCode, 500);
+        t.end();
+    });
+});
+
+
+test('default jsonp formatter should escape ' +
+     'line and paragraph separators', function (t) {
+
+    // ensure client accepts only a type not specified by server
+    var opts = {
+        path: '/jsonpSeparators',
+        headers: {
+            accept: 'application/javascript'
+        }
+    };
+
+    CLIENT.get(opts, function (err, req, res, data) {
+        t.ifError(err);
+        t.ok(req);
+        t.ok(res);
+        t.equal(data, '"\\u2028\\u2029"');
         t.end();
     });
 });


### PR DESCRIPTION
http://timelessrepo.com/json-isnt-a-javascript-subset

see also:

https://golang.org/src/encoding/json/encode.go#L184
https://github.com/expressjs/express/blob/9722202df964bfbfc0f579e4baeb5a4e1b43b344/lib/response.js#L314-L317