### PR TITLE
Update version of the dtrace-provider optionalDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "vasync": "^1.6.4"
   },
   "optionalDependencies": {
-    "dtrace-provider": "^0.6.0"
+    "dtrace-provider": "^0.8.1"
   },
   "devDependencies": {
     "cover": "^0.2.9",


### PR DESCRIPTION
Fixes https://github.com/restify/node-restify/issues/1305

I ran the unit tests and they still pass. I did not actually test that dtrace still works as expected with the new version, so someone will need to verify that (or show me how that should be checked).