### PR TITLE
Set Copyright to it's own line

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ $ npm install restify
 ## License
 
 The MIT License (MIT)
+
 Copyright (c) 2016 restify
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of


### PR DESCRIPTION
Currently it looks like this, the Copyright line is in the same line with the *The MIT License (MIT)*:

![image](https://cloud.githubusercontent.com/assets/5832930/25563987/7d3b2686-2db1-11e7-8eb9-ebdb34e8e2b3.png)