### PR TITLE
Opinionated cleanup of emitRouteError

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -220,7 +220,7 @@ function emitRouteError(server, req, res, err) {
     function cb() {
         // Check to see if we have received as many callbacks as there are
         // listeners
-        if (invoked++ === server.listenerCount()) {
+        if (invoked++ === server.listenerCount(name)) {
             cleanup();
         }
     }

--- a/lib/server.js
+++ b/lib/server.js
@@ -208,14 +208,26 @@ function emitRouteError(server, req, res, err) {
 
     req.log.trace({name: name, err: err}, 'entering emitRouteError');
 
-    if (server.listeners(name).length > 0) {
-        server.emit(name, req, res, err, once(function () {
-            res.send(err);
-            server._finishReqResCycle(req, res, null, err);
-        }));
-    } else {
+    // Check to see if any listeners are registered for the error, if not go
+    // ahead and finish the request. If there are listeners, emit the error and
+    // wait for all of the handlers to finish before finishing the request.
+    function cleanup() {
         res.send(err);
         server._finishReqResCycle(req, res, null, err);
+    }
+
+    var invoked = 0;
+    function cb() {
+        // Check to see if we have received as many callbacks as there are
+        // listeners
+        if (invoked++ === server.listenerCount()) {
+            cleanup();
+        }
+    }
+
+    // emit returns false if there weren't any listeners
+    if (!server.emit(name, req, res, err, cb)) {
+        cleanup();
     }
 }
 


### PR DESCRIPTION
## Pre-Submission Checklist

- [x] Opened an issue discussing these changes before opening the PR
- [x] Ran the linter and tests via `make prepush`
- [x] Included comprehensive and convincing tests for changes

## Issues

Closes:

* Issue #1354 

# Changes

* Adding comments
* Simplify edge conditions
* Use `listenerCount` as opposed to creating a copy of the listeners array
* Wait for all event handlers to run before executing cleanup

Alternatively, instead of relying on callbacks, we can assume all event handlers are synchronous and close the request as soon as execution reaches the next line. I believe this would be a significant breaking change. Pushing the requirement onto the user to call a callback on completion seems preferable.