### PR TITLE
Port ignored in response redirect [5.X]

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -640,6 +640,11 @@ Response.prototype.redirect = function redirect(arg1, arg2, arg3) {
             finalUri.pathname = opt.pathname;
         }
 
+        // then set port
+        if (opt.port) {
+            finalUri.port = opt.port;
+        }
+
         // then add query params
         if (opt.query) {
             if (opt.overrideQuery === true) {

--- a/test/response.test.js
+++ b/test/response.test.js
@@ -287,6 +287,43 @@ test('redirect using options.url', function (t) {
 });
 
 
+test('redirect using opts.port', function (t) {
+    SERVER.get('/9', function (req, res, next) {
+        res.redirect({
+            port: 3000
+        }, next);
+    });
+
+    CLIENT.get(join(LOCALHOST, '/9'), function (err, _, res) {
+        t.ifError(err);
+        t.equal(res.statusCode, 302);
+        var parsedUrl = url.parse(res.headers.location, true);
+        t.equal(parsedUrl.port, 3000);
+        t.end();
+    });
+});
+
+
+test('redirect using external url and custom port', function (t) {
+    SERVER.get('/9', function (req, res, next) {
+        res.redirect({
+            hostname: 'www.foo.com',
+            pathname: '/99',
+            port: 3000
+        }, next);
+    });
+
+    CLIENT.get(join(LOCALHOST, '/9'), function (err, _, res) {
+        t.ifError(err);
+        t.equal(res.statusCode, 302);
+        var parsedUrl = url.parse(res.headers.location, true);
+        t.equal(parsedUrl.port, 3000);
+        t.equal(parsedUrl.hostname, 'www.foo.com');
+        t.equal(parsedUrl.pathname, '/99');
+        t.end();
+    });
+});
+
 // jscs:disable maximumLineLength
 test('redirect should cause InternalError when invoked without next', function (t) {
 

--- a/test/response.test.js
+++ b/test/response.test.js
@@ -324,6 +324,25 @@ test('redirect using external url and custom port', function (t) {
     });
 });
 
+test('redirect using default hostname with custom port', function (t) {
+    SERVER.get('/9', function (req, res, next) {
+        res.redirect({
+            pathname: '/99',
+            port: 3000
+        }, next);
+    });
+
+    CLIENT.get(join(LOCALHOST, '/9'), function (err, _, res) {
+        t.ifError(err);
+        t.equal(res.statusCode, 302);
+        var parsedUrl = url.parse(res.headers.location, true);
+        t.equal(parsedUrl.port, 3000);
+        t.equal(parsedUrl.pathname, '/99');
+        t.equal(res.headers.location, 'http://127.0.0.1:3000/99');
+        t.end();
+    });
+});
+
 // jscs:disable maximumLineLength
 test('redirect should cause InternalError when invoked without next', function (t) {
 


### PR DESCRIPTION
## Pre-Submission Checklist

- [x] Opened an issue discussing these changes before opening the PR
- [x] Ran the linter and tests via `make prepush`
- [x] Included comprehensive and convincing tests for changes

## Issues

Closes:

* Issue #1362 

# Changes

Take in account opts.port passed in the object of response.redirect. If the parameter is in the object as documentation describes [Response API](http://restify.com/#response-api), then override the port.