### PR TITLE
Upgrade dtrace-provider to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "verror": "^1.4.0"
   },
   "optionalDependencies": {
-    "dtrace-provider": "^0.6.0"
+    "dtrace-provider": "^0.8.2"
   },
   "devDependencies": {
     "cover": "^0.2.9",


### PR DESCRIPTION
<!--
Thank you for taking the time to open an PR for restify! If this is your first
time here, welcome to our community! We are a group of developers who work on
restify in our free-time. Some of us do it as a hobby, others are using restify
at work. When asking for help here, keep in mind most of us are volunteers
contributing our daily work back to the community at no cost (and often for no
reward). Please be respectful!

Below you will find a checklist to help you create the best PR possible. While
the checklist items aren't all _strictly_ required, they dramatically increase
the probability of your PR getting a response and getting merged. Often times,
the least time consuming part of maintaining and open source project is writing
code, its the process and discussions that happen around the code base that
consume a majority of the maintainers' time. By spending a few moments to
adhere to this template, you are not only improve the quality of your PR, you
are also helping save the maintainers a considerable amount of time when trying
to understand and review your changes.

And remember, positive vibes are met with positive vibes. Kindness helps Free
Software go round, pay it forward!
-->

## Pre-Submission Checklist

- [ ] Opened an issue discussing these changes before opening the PR
- [x] Ran the linter and tests via `make prepush`
- [ ] Included comprehensive and convincing tests for changes

# Changes

dtrace-provider 0.6.0 does not work on the node 8.  This will allow restify 4.x to be compatible with node 8, rather than requiring an upgrade to restify 5.x.
