### PR TITLE
fix(audit): use public APIs for accessing response headers

### DIFF
--- a/lib/plugins/audit.js
+++ b/lib/plugins/audit.js
@@ -7,6 +7,27 @@ var bunyan = require('bunyan');
 var HttpError = require('restify-errors').HttpError;
 var VError = require('verror');
 
+/**
+ * Utility to get response headers from a given response.
+ * Manually generates a POJO from `res.getHeaderNames` and `res.getHeader`,
+ * if available, falling back to deprecated `res._headers`, otherwise.
+ * Intentionally does not use `res.getHeaders` to avoid deserialization
+ * issues with object returned by that method.
+ * @param {http.ServerResponse} res the OutgoingMessage
+ * @private
+ * @function getResponseHeaders
+ * @returns {object} map from header name to header value
+ */
+function getResponseHeaders(res) {
+    if (res.getHeaderNames && res.getHeader) {
+        return res.getHeaderNames().reduce(function (prev, curr) {
+            var header = {};
+            header[curr] = res.getHeader(curr);
+            return Object.assign({}, prev, header);
+        }, {});
+    }
+    return res._headers;
+}
 
 ///--- API
 
@@ -99,7 +120,7 @@ function auditLogger(opts) {
 
                 return ({
                     statusCode: res.statusCode,
-                    headers: res._headers,
+                    headers: getResponseHeaders(res),
                     trailer: res._trailer || false,
                     body: body
                 });


### PR DESCRIPTION
<!--
Thank you for taking the time to open an PR for restify! If this is your first
time here, welcome to our community! We are a group of developers who work on
restify in our free-time. Some of us do it as a hobby, others are using restify
at work. When asking for help here, keep in mind most of us are volunteers
contributing our daily work back to the community at no cost (and often for no
reward). Please be respectful!

Below you will find a checklist to help you create the best PR possible. While
the checklist items aren't all _strictly_ required, they dramatically increase
the probability of your PR getting a response and getting merged. Often times,
the least time consuming part of maintaining and open source project is writing
code, its the process and discussions that happen around the code base that
consume a majority of the maintainers' time. By spending a few moments to
adhere to this template, you are not only improve the quality of your PR, you
are also helping save the maintainers a considerable amount of time when trying
to understand and review your changes.

And remember, positive vibes are met with positive vibes. Kindness helps Free
Software go round, pay it forward!
-->

## Pre-Submission Checklist

- [x] Opened an issue discussing these changes before opening the PR
- [x] Ran the linter and tests via `make prepush`
- [ ] Included comprehensive and convincing tests for changes

## Issues

Closes:

* Issue #1370

# Changes

- `res._headers` has been deprecated and accessing it in `auditResponseSerializer` generates exception (RangeError: Maximum call stack size exceeded)
- `res.getHeaders` returns an object that does not inherit from `Object`, so is unsuitable for use here
- falls back to `res._headers` if public APIs (introduced in v7.7.0) do not exist
- see https://nodejs.org/api/deprecations.html#deprecations_dep0066_outgoingmessage_headers_outgoingmessage_headernames
- see https://nodejs.org/api/http.html#http_response_getheaders
