### PR TITLE
Add HTTP COPY support for Restify 4.x

### DIFF
--- a/lib/clients/http_client.js
+++ b/lib/clients/http_client.js
@@ -481,6 +481,11 @@ HttpClient.prototype.close = function close() {
     });
 };
 
+HttpClient.prototype.copy = function copy(options, callback) {
+    var opts = this._options('COPY', options);
+
+    return (this.request(opts, callback));
+};
 
 HttpClient.prototype.del = function del(options, callback) {
     var opts = this._options('DELETE', options);

--- a/lib/clients/string_client.js
+++ b/lib/clients/string_client.js
@@ -34,6 +34,18 @@ util.inherits(StringClient, HttpClient);
 module.exports = StringClient;
 
 
+StringClient.prototype.copy = function copy(options, body, callback) {
+    var opts = this._options('COPY', options);
+
+    if (typeof (body) === 'function') {
+        callback = body;
+        body = null;
+    }
+
+    return (this.write(opts, body, callback));
+};
+
+
 StringClient.prototype.post = function post(options, body, callback) {
     var opts = this._options('POST', options);
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -168,6 +168,7 @@ function Router(options) {
 
     // A list of methods to routes
     this.routes = {
+        COPY: [],
         DELETE: [],
         GET: [],
         HEAD: [],

--- a/lib/server.js
+++ b/lib/server.js
@@ -431,12 +431,13 @@ Server.prototype.close = function close(callback) {
  * Mounts a chain on the given path against this HTTP verb
  *
  * @public
- * @function del, get, head, opts, post, put, patch
+ * @function copy, del, get, head, opts, post, put, patch
  * @param   {String | Object} opts if string, the URL to handle.
  *                                 if options, the URL to handle, at minimum.
  * @returns {Route}                the newly created route.
  */
 [
+    'copy',
     'del',
     'get',
     'head',

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -149,6 +149,7 @@ before(function (callback) {
         SERVER.get('/json/false', sendJsonFalse);
         SERVER.get('/json/null', sendJsonNull);
 
+        SERVER.copy('/json/:name', sendJson);
         SERVER.get('/json/:name', sendJson);
         SERVER.head('/json/:name', sendJson);
         SERVER.put('/json/:name', sendJson);
@@ -277,6 +278,16 @@ test('Check error (404)', function (t) {
         t.ok(obj);
         t.equal(obj.code, 'ResourceNotFound');
         t.ok(obj.message);
+        t.end();
+    });
+});
+
+
+test('COPY json', function (t) {
+    JSON_CLIENT.copy('/json/mcavage', function (err, req, res) {
+        t.ifError(err);
+        t.ok(req);
+        t.ok(res);
         t.end();
     });
 });

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -233,6 +233,29 @@ test('405', function (t) {
 });
 
 
+test('COPY ok', function (t) {
+    SERVER.copy('/foo/:id', function tester(req, res, next) {
+        t.ok(req.params);
+        t.equal(req.params.id, 'bar');
+        res.send();
+        next();
+    });
+
+    var opts = {
+        hostname: '127.0.0.1',
+        port: PORT,
+        path: '/foo/bar',
+        method: 'COPY',
+        agent: false
+    };
+
+    http.request(opts, function (res) {
+        t.equal(res.statusCode, 200);
+        t.end();
+    }).end();
+});
+
+
 test('PUT ok', function (t) {
     SERVER.put('/foo/:id', function tester(req, res, next) {
         t.ok(req.params);


### PR DESCRIPTION
# Feature Request
Add HTTP COPY support to Restify 4.x - [http://www.restpatterns.org/HTTP_Methods/COPY](http://www.restpatterns.org/HTTP_Methods/COPY)

Issue: [https://github.com/restify/node-restify/issues/1372](https://github.com/restify/node-restify/issues/1372)

## Use Case

I am adding an asset duplication endpoint to an API. I have the need for the Restify module to support the COPY verb for proper routing and the usage of the destination and depth headers.

## Example API

Frontend
An example of the request that is made in AngularJS:
```javascript
$http({
    method: 'COPY',
    url: '/someUrl'`,
    headers: {
        Authorization: {auth token},
        Destination: {absolute URI}
        Depth: {required depth}
    }
})
.then(function successCallback(response) {
    // handle success response from API
},
function errorCallback(response) {
    // handle error response from API
});
```

Backend
An example of the route in NodeJS:
```javascript
server.copy({
    name: 'api-copy-endpoint',
    path: 'someUrl',
    version: '1.0.0'
},
authenticateAuthHeader(),
validateUrlParams(),
controller.copyFn());
```