### PR TITLE
Revert async formatters

### DIFF
--- a/4TO5GUIDE.md
+++ b/4TO5GUIDE.md
@@ -206,60 +206,6 @@ Connection: keep-alive
 {"code":"Gone","message":"gone girl"}
 ```
 
-## sync vs async formatters
-
-Restify now supports both sync and async formatters. In 4.x, all formatters had
-an async signature despite not being async. For example, the text formatter in
-4.x might have looked like this:
-
-```js
-function formatText(req, res, body, cb) {
-    return cb(null, body.toString());
-}
-```
-
-This caused a scenario where formatting could potentially fail, but the handler
-chain would continue on. To address this gap, as of 5.x, any formatters that
-are async require a callback to be passed into `res.send()`. For example,
-imagine this async formatter:
-
-```js
-function specialFormat(req, res, body, cb) {
-    return asyncSerializer.format(body, cb);
-}
-
-server.get('/', function(req, res, next) {
-    res.send('hello world', function(err) {
-        if (err) {
-            res.end('some other backup content when formatting fails');
-        }
-        return next();
-    });
-});
-
-server.get('/', function(req, res, next) {
-    // alternatively, you can pass the error to next, which will render the
-    // error to the client.
-    res.send('hello world', next);
-});
-```
-
-This way we are able to block the handler chain from moving on when an async
-formatter fails. If you have any custom formatters, migrating from 4.x will
-require you to change the formatter to be sync. Imagine the previous text
-formatter changed to sync. Notice that the signature no longer takes a
-callback.  This hints to restify that the formatter is sync:
-
-```js
-function formatText(req, res, body) {
-    return body.toString();
-}
-```
-
-Thus, if your formatter takes 4 parameters (i.e., takes a callback),
-invocations of `res.send()` must take a callback, or else restify will throw.
-
-
 ## Deprecations
 
 The following are still currently supported, but are on life support and may be

--- a/docs/pages/components/response.md
+++ b/docs/pages/components/response.md
@@ -128,7 +128,6 @@ res.status(201);
 * `code` {Number} an http status code
 * `body` {String | Object | Array | Buffer} the payload to send
 * `[headers]` {Object} an optional object of headers (key/val pairs)
-* `[callback]` {Function} an optional callback, used in conjunction with async
   formatters
 
 You can use `send()` to wrap up all the usual `writeHead()`, `write()`, `end()`

--- a/docs/pages/guides/server.md
+++ b/docs/pages/guides/server.md
@@ -484,7 +484,7 @@ want:
 ```js
 restify.createServer({
   formatters: {
-    'application/foo; q=0.9': function formatFoo(req, res, body, cb) {
+    'application/foo; q=0.9': function formatFoo(req, res, body) {
       if (body instanceof Error)
         return body.stack;
 
@@ -510,53 +510,6 @@ res.writeHead(200, {
 res.write(body);
 res.end();
 ```
-
-Formatters can also be async, in which case a callback is available to you as
-the fourth parameter. If you choose to use an async formatter for a particular
-content-type, it is required to pass a callback parameter to `res.send()`. If a
-callback is not provided, then restify will throw an error:
-
-```js
-var server = restify.createServer({
-  formatters: {
-    'application/foo-async': function formatFoo(req, res, body, cb) {
-
-      someAsyncMethod(body, function(err, formattedBody) {
-        if (err) {
-          return cb(err);
-        }
-        return cb(null, formattedBody);
-      });
-    }
-  }
-});
-
-server.get('/fooAsync', function(req, res, next) {
-  res.send(fooData, next); // => callback required!
-});
-```
-
-In the event of an error with your async formatter, ensure that the error is
-passed to the callback. The default behavior in this scenario is for restify to
-send an empty 500 response to the client, since restify can make no assumptions
-about the correct format for your data. Alternatively, you can listen to a
-`FormatterError` event on the server. This event is fired whenever an async
-formatter returns an error, allowing you to write a custom response if
-necessary.  response if necessary. If you listen to this event, you _must_
-flush a response, or else the request will hang. It is highly recommended to
-avoid using `res.send()` within this handler to avoid any issues that might
-have caused the async formatter to fail to begin with. Instead, use the native
-node response methods:
-
-
-```js
-server.on('FormatterError', function(req, res, route, err) {
-  // the original body that caused formatting failure is available provided
-  // on the error object - err.context.rawBody
-  res.end('boom! could not format body!');
-});
-```
-
 
 ## Error handling
 

--- a/lib/response.js
+++ b/lib/response.js
@@ -410,6 +410,8 @@ Response.prototype.__send = function __send() {
         type = mime.lookup(type);
     }
 
+    // If we were unable to derive a valid type, default to treating it as
+    // arbitrary binary data per RFC 2046 Section 4.5.1
     if (!self.formatters[type] && self.acceptable.indexOf(type) === -1) {
         type = 'application/octet-stream';
     }

--- a/lib/response.js
+++ b/lib/response.js
@@ -255,7 +255,7 @@ Response.prototype.__send = function __send() {
     var code, body, headers, format;
 
     // derive arguments from types, one by one
-    var index = 0
+    var index = 0;
     // Check to see if the first argument is a status code
     if (typeof arguments[index] === 'number') {
         code = arguments[index++];
@@ -282,7 +282,7 @@ Response.prototype.__send = function __send() {
     // optional arguments was of an invalid type or we were provided with
     // too many arguments
     assert(arguments[index] === undefined,
-      `Unknown argument: ${arguments[index]}\nProvided: ${arguments}`)
+      'Unknown argument: ' + arguments[index] + '\nProvided: ' + arguments);
 
     // Now lets try to derive values for optional arguments that we were not
     // provided, otherwise we choose sane defaults.
@@ -346,7 +346,7 @@ Response.prototype.__send = function __send() {
 
     // 204 = No Content and 304 = Not Modified, we don't want to send the
     // body in these cases. HEAD never provides a body.
-    if(isHead || code === 204 || code === 304) {
+    if (isHead || code === 204 || code === 304) {
         return _flush();
     }
 
@@ -374,15 +374,15 @@ Response.prototype.__send = function __send() {
         // with it since their error is probably more important than our
         // inability to format their message.
         if (self.statusCode >= 200 && self.statusCode < 300) {
-            self.statusCode = findErr.statusCode;
+            self.statusCode = err.statusCode;
         }
 
         log.warn({
             req: self.req,
-            err: findErr
+            err: err
         }, 'error retrieving formatter');
 
-        return _flush()
+        return _flush();
     }
 
     var formatter;
@@ -392,7 +392,7 @@ Response.prototype.__send = function __send() {
     if (!type && !self.req.accepts(self.acceptable)) {
         return _formatterError(new errors.NotAcceptableError({
             message: 'could not find suitable formatter'
-        }))
+        }));
     }
 
     // Derive type if not provided by the user
@@ -414,7 +414,7 @@ Response.prototype.__send = function __send() {
 
     // If after the above attempts we were still unable to derive a formatter,
     // provide a meaningful error message
-    if(!formatter) {
+    if (!formatter) {
         return _formatterError(new errors.InternalServerError({
             message: 'could not find formatter for application/octet-stream'
         }));

--- a/lib/response.js
+++ b/lib/response.js
@@ -206,14 +206,16 @@ Response.prototype.link = function link(l, rel) {
  * formatter based on the content-type header.
  * @public
  * @function send
- * @param    {Number} code http status code
- * @param    {Object | Buffer | Error} body the content to send
- * @param    {Object} headers  any add'l headers to set
+ * @param    {Number} [code] http status code
+ * @param    {Object | Buffer | Error} [body] the content to send
+ * @param    {Object} [headers]  any add'l headers to set
  * @returns  {Object} the response object
  */
 Response.prototype.send = function send(code, body, headers) {
     var self = this;
-    return self.__send(code, body, headers, true);
+    var args = Array.prototype.slice.call(arguments);
+    args.push(true); // Append format = true to __send invocation
+    return self.__send.apply(self, args);
 };
 
 
@@ -222,14 +224,16 @@ Response.prototype.send = function send(code, body, headers) {
  * formatters entirely and sends the content as is.
  * @public
  * @function sendRaw
- * @param    {Number} code http status code
- * @param    {Object | Buffer | Error} body the content to send
- * @param    {Object} headers  any add'l headers to set
+ * @param    {Number} [code] http status code
+ * @param    {Object | Buffer | Error} [body] the content to send
+ * @param    {Object} [headers]  any add'l headers to set
  * @returns  {Object} the response object
  */
 Response.prototype.sendRaw = function sendRaw(code, body, headers) {
     var self = this;
-    return self.__send(code, body, headers, false);
+    var args = Array.prototype.slice.call(arguments);
+    args.push(false); // Append format = false to __send invocation
+    return self.__send.apply(self, args);
 };
 
 
@@ -238,7 +242,7 @@ Response.prototype.sendRaw = function sendRaw(code, body, headers) {
  * writeHead(), write(), end().
  *
  * Both body and headers are optional, but you MUST provide body if you are
- * providing headers
+ * providing headers.
  *
  * @private
  * @private

--- a/lib/response.js
+++ b/lib/response.js
@@ -97,66 +97,6 @@ Response.prototype.charSet = function charSet(type) {
 
 
 /**
- * finds a formatter that is both acceptable and works for the content-type
- * specified on the response. Can return two errors:
- *      NotAcceptableError - couldn't find a suitable formatter
- *      InternalServerError - couldn't find a fallback formatter
- * @public
- * @function _findFormatter
- * @param    {Function} callback a callback fn
- * @returns  {undefined}
- */
-Response.prototype._findFormatter = function _findFormatter(callback) {
-
-    var formatter;
-    var type = this.contentType || this.getHeader('Content-Type');
-
-    if (!type) {
-        if (this.req.accepts(this.acceptable)) {
-            type = this.req.accepts(this.acceptable);
-        }
-
-        if (!type) {
-            return callback(new errors.NotAcceptableError({
-                message: 'could not find suitable formatter'
-            }));
-        }
-    } else if (type.indexOf(';') !== '-1') {
-        type = type.split(';')[0];
-    }
-
-    if (!(formatter = this.formatters[type])) {
-
-        if (type.indexOf('/') === -1) {
-            type = mime.lookup(type);
-        }
-
-        if (this.acceptable.indexOf(type) === -1) {
-            type = 'application/octet-stream';
-        }
-
-        formatter = this.formatters[type] || this.formatters['*/*'];
-
-        // this is a catastrophic case - should always fall back on
-        // octet-stream but if for some reason that's gone, return a 500.
-        if (!formatter) {
-            return callback(new errors.InternalServerError({
-                message: 'could not find formatter for application/octet-stream'
-            }));
-        }
-    }
-
-    if (this._charSet) {
-        type = type + '; charset=' + this._charSet;
-    }
-
-    this.setHeader('Content-Type', type);
-
-    return callback(null, formatter, type);
-};
-
-
-/**
  * retrieves a header off the response.
  * @public
  * @function get
@@ -269,13 +209,11 @@ Response.prototype.link = function link(l, rel) {
  * @param    {Number} code http status code
  * @param    {Object | Buffer | Error} body the content to send
  * @param    {Object} headers  any add'l headers to set
- * @param    {Function} callback a callback for use with async formatters
- * @returns  {Object | undefined} when async formatter in use, returns null,
- * otherwise returns the response object
+ * @returns  {Object} the response object
  */
-Response.prototype.send = function send(code, body, headers, callback) {
+Response.prototype.send = function send(code, body, headers) {
     var self = this;
-    return self.__send(code, body, headers, callback, true);
+    return self.__send(code, body, headers, true);
 };
 
 
@@ -287,111 +225,129 @@ Response.prototype.send = function send(code, body, headers, callback) {
  * @param    {Number} code http status code
  * @param    {Object | Buffer | Error} body the content to send
  * @param    {Object} headers  any add'l headers to set
- * @param    {Function} callback a callback for use with async formatters
- * @returns  {Object | undefined} when async formatter in use, returns null,
- * otherwise returns the response object
+ * @returns  {Object} the response object
  */
-Response.prototype.sendRaw = function sendRaw(code, body, headers, callback) {
+Response.prototype.sendRaw = function sendRaw(code, body, headers) {
     var self = this;
-    return self.__send(code, body, headers, callback, false);
+    return self.__send(code, body, headers, false);
 };
 
 
 /**
  * internal implementation of send. convenience method that handles:
  * writeHead(), write(), end().
+ *
+ * Both body and headers are optional, but you MUST provide body if you are
+ * providing headers
+ *
  * @private
  * @private
- * @param    {Number} [maybeCode] http status code
- * @param    {Object | Buffer | Error} [maybeBody] the content to send
- * @param    {Object} [maybeHeaders] any add'l headers to set
- * @param    {Function} [maybeCallback] optional callback for async formatters
- * @param    {Function} format when false, skip formatting
+ * @param    {Number} [code] http status code
+ * @param    {Object | Buffer | String | Error} [body] the content to send
+ * @param    {Object} [headers] any add'l headers to set
+ * @param    {Boolean} [format] When false, skip formatting
  * @returns  {Object} returns the response object
  */
-Response.prototype.__send =
-function __send(maybeCode, maybeBody, maybeHeaders, maybeCallback, format) {
-
+Response.prototype.__send = function __send() {
     var self = this;
     var isHead = (self.req.method === 'HEAD');
     var log = self.log;
-    var code;
-    var body;
-    var headers;
-    var callback;
+    var code, body, headers, format;
 
-    // normalize variadic args.
-    if (typeof maybeCode === 'number') {
-        // if status code was passed in, then signature should look like jsdoc
-        // signature and we only need to figure out headers/callback variation.
-        code = maybeCode;
-
-        // signature should look like jsdoc signature
-        body = maybeBody;
-
-        if (typeof maybeHeaders === 'function') {
-            callback = maybeHeaders;
-        } else {
-            callback = maybeCallback;
-            headers = maybeHeaders;
-        }
-    } else {
-        // if status code was omitted, then first arg must be body.
-        body = maybeCode;
-
-        // now figure out headers/callback variation
-        if (typeof maybeBody === 'function') {
-            callback = maybeBody;
-        } else {
-            callback = maybeHeaders;
-            headers = maybeBody;
-        }
+    // derive arguments from types, one by one
+    var index = 0
+    // Check to see if the first argument is a status code
+    if (typeof arguments[index] === 'number') {
+        code = arguments[index++];
     }
 
-    // if an error object is being sent and a status code isn't explicitly set,
-    // infer one from the error object itself.
+    // Check to see if the next argument is a body
+    if (typeof arguments[index] === 'object' ||
+        typeof arguments[index] === 'string') {
+        body = arguments[index++];
+    }
+
+    // Check to see if the next argument is a collection of headers
+    if (typeof arguments[index] === 'object') {
+        headers = arguments[index++];
+    }
+
+    // Check to see if the next argument is the format boolean
+    if (typeof arguments[index] === 'boolean') {
+        format = arguments[index++];
+    }
+
+    // Ensure the function was provided with arguments of the proper types,
+    // if we reach this line and there are still arguments, either one of the
+    // optional arguments was of an invalid type or we were provided with
+    // too many arguments
+    assert(arguments[index] === undefined,
+      `Unknown argument: ${arguments[index]}\nProvided: ${arguments}`)
+
+    // Now lets try to derive values for optional arguments that we were not
+    // provided, otherwise we choose sane defaults.
+
+    // If the body is an error object and we were not given a status code, try
+    // to derive it from the error object, otherwise default to 500
     if (!code && body instanceof Error) {
-        self.statusCode = body.statusCode || 500;
-    } else {
-        self.statusCode = code || 200;
+        code = body.statusCode || 500;
     }
 
+    // Set sane defaults for optional arguments if they were not provided and
+    // we failed to derive their values
+    code = code || 200;
     headers = headers || {};
 
+    // Populate our response object with the derived arguments
+    self.statusCode = code;
+    self._body = body;
+    Object.keys(headers).forEach(function (k) {
+        self.setHeader(k, headers[k]);
+    });
+
+    // If log level is set to trace, output our constructed response object
     if (log.trace()) {
         var _props = {
             code: self.statusCode,
-            headers: headers
+            headers: self._headers
         };
 
         if (body instanceof Error) {
-            _props.err = body;
+            _props.err = self._body;
         } else {
-            _props.body = body;
+            _props.body = self._body;
         }
         log.trace(_props, 'response::send entered');
     }
 
-    self._body = body;
-
+    // Flush takes our constructed response object and sends it to the client
     function _flush(formattedBody) {
         self._data = formattedBody;
 
-        Object.keys(headers).forEach(function (k) {
-            self.setHeader(k, headers[k]);
-        });
-
+        // Flush headers
         self.writeHead(self.statusCode);
 
-        if (self._data && !(isHead || code === 204 || code === 304)) {
+        // Send body if it was provided
+        if (self._data) {
             self.write(self._data);
         }
 
+        // Finish request
         self.end();
 
+        // If log level is set to trace, log the entire response object
         if (log.trace()) {
             log.trace({res: self}, 'response sent');
         }
+
+        // Return the response object back out to the caller of __send
+        return self;
+    }
+
+    // 204 = No Content and 304 = Not Modified, we don't want to send the
+    // body in these cases. HEAD never provides a body.
+    if(isHead || code === 204 || code === 304) {
+        return _flush();
     }
 
     // if no formatting, assert that the value to be written is a string
@@ -404,68 +360,75 @@ function __send(maybeCode, maybeBody, maybeHeaders, maybeCallback, format) {
 
     // if no body, then no need to format. if this was an error caught by a
     // domain, don't send the domain error either.
-    if (body === null ||
-        body === undefined ||
-        (body instanceof Error && body.domain)) {
+    if (body === undefined || (body instanceof Error && body.domain)) {
         return _flush();
     }
 
-    // otherwise, try to find a formatter
-    self._findFormatter(
-    function foundFormatter(findErr, formatter, contentType) {
+    // At this point we know we have a body that needs to be formatted, so lets
+    // derive the formatter based on the response object's properties
 
-        // handle missing formatters
-        if (findErr) {
-            // if user set a status code outside of the 2xx range, it probably
-            // outweighs being unable to format the response. set a status code
-            // then flush empty response.
-            if (self.statusCode >= 200 && self.statusCode < 300) {
-                self.statusCode = findErr.statusCode;
-            }
-            log.warn({
-                req: self.req,
-                err: findErr
-            }, 'error retrieving formatter');
-            return _flush();
+    // _formatterError is used to handle any case where we were unable to
+    // properly format the provided body
+    function _formatterError(err) {
+        // If the user provided a non-success error code, we don't want to mess
+        // with it since their error is probably more important than our
+        // inability to format their message.
+        if (self.statusCode >= 200 && self.statusCode < 300) {
+            self.statusCode = findErr.statusCode;
         }
 
-        // if we have formatter, happy path.
-        var asyncFormat = (formatter && formatter.length === 4) ? true : false;
+        log.warn({
+            req: self.req,
+            err: findErr
+        }, 'error retrieving formatter');
 
-        if (asyncFormat === true) {
+        return _flush()
+    }
 
-            assert.func(callback, 'async formatter for ' + contentType +
-                                  ' requires callback to res.send()');
+    var formatter;
+    var type = self.contentType || self.getHeader('Content-Type');
 
-            // if async formatter error, propagate error back up to
-            // res.send() caller, most likely a handler.
-            return formatter.call(self, self.req, self, body,
-            function _formatDone(formatErr, formattedBody) {
+    // Check to see if we can find a valid formatter
+    if (!type && !self.req.accepts(self.acceptable)) {
+        return _formatterError(new errors.NotAcceptableError({
+            message: 'could not find suitable formatter'
+        }))
+    }
 
-                if (formatErr) {
+    // Derive type if not provided by the user
+    if (!type) {
+        type = self.req.accepts(self.acceptable);
+    }
 
-                    return callback(new errors.FormatterError(formatErr, {
-                        message: 'unable to format response for ' +
-                                    self.header('content-type'),
-                        context: {
-                            rawBody: body
-                        }
-                    }));
-                }
-                return _flush(formattedBody);
-            });
-        }
-        // for sync formatters, invoke formatter and send response body.
-        else {
-            _flush(formatter.call(self, self.req, self, body), body);
-            // users can always opt to pass in next, even when formatter is not
-            // async. invoke callback in that case. return null when no
-            // callback because eslint wants consistent-return.
-            return (callback) ? callback() : null;
-        }
-    });
+    type = type.split(';')[0];
 
-    return self;
+    if (!self.formatters[type] && type.indexOf('/') === -1) {
+        type = mime.lookup(type);
+    }
+
+    if (!self.formatters[type] && self.acceptable.indexOf(type) === -1) {
+        type = 'application/octet-stream';
+    }
+
+    formatter = self.formatters[type] || self.formatters['*/*'];
+
+    // If after the above attempts we were still unable to derive a formatter,
+    // provide a meaningful error message
+    if(!formatter) {
+        return _formatterError(new errors.InternalServerError({
+            message: 'could not find formatter for application/octet-stream'
+        }));
+    }
+
+    if (self._charSet) {
+        type = type + '; charset=' + self._charSet;
+    }
+
+    // Update header to the derived content type for our formatter
+    self.setHeader('Content-Type', type);
+
+    // Finally, invoke the formatter and flush the request with it's results
+    return _flush(formatter(self.req, self, body));
 };
 
 


### PR DESCRIPTION
## Pre-Submission Checklist

- [X] Opened an issue discussing these changes before opening the PR
- [X] Ran the linter and tests via `make prepush`
- [X] Included comprehensive and convincing tests for changes

## Issues

Closes:

* Issue #1347 

> Summarize the issues that discussed these changes

Async formatters were introduced as a way to handle formatting an response body by binding it to data coming from an asyncronous data source. This introduced complexities that were difficult to reconsile with the rest of the code base. By requiring all formatters to be syncronous we simplify the codebase and can :clap: **ship 5.x** :clap: 

# Changes

> What does this PR do?

* Removes asynchronous formatters
* Subjectively simplifies `__send` implementation
