### PR TITLE
fix(static): avoid user-provided data in Error messages being interpreted as sprintf codes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,12 +2,8 @@
 
 ## not yet released
 
-(nothing yet)
-
-## 4.3.1
-
 - #1382 Fix "static" plugin to not throw on a 404 for a path with sprintf-like
-  percent escape codes. Trent Mick
+  percent escape codes.
 
 ## 4.3.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@
 
 (nothing yet)
 
+## 4.3.1
+
+- #1382 Fix "static" plugin to not throw on a 404 for a path with sprintf-like
+  percent escape codes. Trent Mick
+
 ## 4.3.0
 
 - #1024 Add `handleUncaughtExceptions` server option to supporting disabling

--- a/lib/plugins/static.js
+++ b/lib/plugins/static.js
@@ -44,8 +44,7 @@ function serveStatic(opts) {
 
     function serveFileFromStats(file, err, stats, isGzip, req, res, next) {
         if (err) {
-            next(new ResourceNotFoundError(err,
-                req.path()));
+            next(new ResourceNotFoundError(err, '%s', req.path()));
             return;
         } else if (!stats.isFile()) {
             next(new ResourceNotFoundError('%s does not exist', req.path()));
@@ -120,17 +119,17 @@ function serveStatic(opts) {
         }
 
         if (req.method !== 'GET' && req.method !== 'HEAD') {
-            next(new MethodNotAllowedError(req.method));
+            next(new MethodNotAllowedError('%s', req.method));
             return;
         }
 
         if (!re.test(file.replace(/\\/g, '/'))) {
-            next(new NotAuthorizedError(req.path()));
+            next(new NotAuthorizedError('%s', req.path()));
             return;
         }
 
         if (opts.match && !opts.match.test(file)) {
-            next(new NotAuthorizedError(req.path()));
+            next(new NotAuthorizedError('%s', req.path()));
             return;
         }
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "name": "restify",
   "homepage": "http://restifyjs.com",
   "description": "REST framework",
-  "version": "4.3.1",
+  "version": "4.3.0",
   "repository": {
     "type": "git",
     "url": "git://github.com/restify/node-restify.git"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "name": "restify",
   "homepage": "http://restifyjs.com",
   "description": "REST framework",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "repository": {
     "type": "git",
     "url": "git://github.com/restify/node-restify.git"

--- a/test/plugins.test.js
+++ b/test/plugins.test.js
@@ -999,10 +999,8 @@ test('static responds 404 for missing file', function (t) {
     });
 });
 
-// Earlier versons would throw:
-//      > new restify.ResourceNotFoundError('/%22s not found')
-//      Error: too few args to sprintf
-test('static responds 404 for missing file with percent-codes', function (t) {
+test('GH-1382 static responds 404 for missing file with percent-codes',
+        function (t) {
     var p = '/public/no-%22such-file.json';
     var tmpPath = path.join(process.cwd(), '.tmp');
 

--- a/test/plugins.test.js
+++ b/test/plugins.test.js
@@ -984,6 +984,39 @@ test('GH-719 serve a specific static file', function (t) {
     serveStaticTest(t, false, '.tmp', null, true);
 });
 
+test('static responds 404 for missing file', function (t) {
+    var p = '/public/no-such-file.json';
+    var tmpPath = path.join(process.cwd(), '.tmp');
+
+    SERVER.get(new RegExp('/public/.*'),
+        restify.serveStatic({directory: tmpPath}));
+
+    CLIENT.get(p, function (err, req, res, obj) {
+        t.ok(err);
+        t.equal(err.statusCode, 404);
+        t.equal(err.restCode, 'ResourceNotFound');
+        t.end();
+    });
+});
+
+// Earlier versons would throw:
+//      > new restify.ResourceNotFoundError('/%22s not found')
+//      Error: too few args to sprintf
+test('static responds 404 for missing file with percent-codes', function (t) {
+    var p = '/public/no-%22such-file.json';
+    var tmpPath = path.join(process.cwd(), '.tmp');
+
+    SERVER.get(new RegExp('/public/.*'),
+        restify.serveStatic({directory: tmpPath}));
+
+    CLIENT.get(p, function (err, req, res, obj) {
+        t.ok(err);
+        t.equal(err.statusCode, 404);
+        t.equal(err.restCode, 'ResourceNotFound');
+        t.end();
+    });
+});
+
 
 test('audit logger timer test', function (t) {
     // Dirty hack to capture the log record using a ring buffer.


### PR DESCRIPTION
The 'static' plugin had a few cases where the path in a request would be
passed as the first ("message") field to a RestError constructor.
RestError uses verror.WError, which uses extsprintf to render the given
arguments. If the "message" includes "%...s" or similar printf codes,
then it will error output.

Also bump to 4.3.1.
Fixes #1382.