### PR TITLE
fix: Add migration guid to website

### DIFF
--- a/docs/guides/4TO5GUIDE.md
+++ b/docs/guides/4TO5GUIDE.md
@@ -1,5 +1,7 @@
-
-# restify 4.x to 5.x migration guide
+---
+title: restify 4.x to 5.x migration guide
+permalink: /docs/4to5/
+---
 
 
 ## Introduction


### PR DESCRIPTION
## Pre-Submission Checklist

- [ x ] Opened an issue discussing these changes before opening the PR
- [ x ] Ran the linter and tests via `make prepush`
- [ x ] Included comprehensive and convincing tests for changes

## Issues

Closes:

none (conversation was part of #1400)

> Summarize the issues that discussed these changes

Migration documentation was not on the website

# Changes

> What does this PR do?

Moves the migration documentation down into the documentation directory so it can be used by jekyll when building the website.