### PR TITLE
Add node 7-8 travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: node_js
 node_js:
    - "4"
    - "6"
+   - "7"
+   - "8"
    - "stable"
 notifications:
   webhooks:


### PR DESCRIPTION
## Pre-Submission Checklist

- [ ] Opened an issue discussing these changes before opening the PR
- [x] Ran the linter and tests via `make prepush`
- [ ] Included comprehensive and convincing tests for changes

# Changes
Restify is fully compatible with both node 7 and 8 and they are quite used in production also if they aren't LTS at the moment.
