### PR TITLE
Fix for #1407

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -116,9 +116,11 @@ Response.prototype.get = function get(name) {
  * @function getHeaders
  * @returns  {Object}
  */
-Response.prototype.getHeaders = function getHeaders() {
-    return (this._headers || {});
-};
+if (typeof Response.prototype.getHeaders !== 'function') {
+    Response.prototype.getHeaders = function getHeaders() {
+        return (this._headers || {});
+    };
+}
 Response.prototype.headers = Response.prototype.getHeaders;
 
 /**

--- a/test/response.test.js
+++ b/test/response.test.js
@@ -542,7 +542,11 @@ test('GH-951: sendRaw accepts only strings or buffers', function (t) {
 
     SERVER.on('uncaughtException', function (req, res, route, err) {
         t.ok(err);
-        t.equal(err.name, 'AssertionError');
+        // Node v8 uses static error codes
+        // and `name` includes the error name and error code as well which
+        // caused this test to break. Just changing the logic to check for
+        // string instead
+        t.equal((err.name.indexOf('AssertionError') >= 0), true);
         t.equal(err.message, 'res.sendRaw() accepts only strings or buffers');
         t.end();
     });


### PR DESCRIPTION
<!--
Thank you for taking the time to open an PR for restify! If this is your first
time here, welcome to our community! We are a group of developers who work on
restify in our free-time. Some of us do it as a hobby, others are using restify
at work. When asking for help here, keep in mind most of us are volunteers
contributing our daily work back to the community at no cost (and often for no
reward). Please be respectful!

Below you will find a checklist to help you create the best PR possible. While
the checklist items aren't all _strictly_ required, they dramatically increase
the probability of your PR getting a response and getting merged. Often times,
the least time consuming part of maintaining and open source project is writing
code, its the process and discussions that happen around the code base that
consume a majority of the maintainers' time. By spending a few moments to
adhere to this template, you are not only improve the quality of your PR, you
are also helping save the maintainers a considerable amount of time when trying
to understand and review your changes.

And remember, positive vibes are met with positive vibes. Kindness helps Free
Software go round, pay it forward!
-->

## Pre-Submission Checklist

- [x] Opened an issue discussing these changes before opening the PR
- [x] Ran the linter and tests via `make prepush`
- [ ] Included comprehensive and convincing tests for changes

## Issues

Closes:

* Issue #1407 

# Changes

In Node 7.7+ we use the `http.ServerResponse.getHeaders()` instead of creating a new prototype function. 