### PR TITLE
added optional limit, rate and remaining headers when using throttle

### DIFF
--- a/lib/plugins/throttle.js
+++ b/lib/plugins/throttle.js
@@ -204,6 +204,8 @@ TokenTable.prototype.get = function get(key) {
  *                   - {Boolean} ip (optional).
  *                   - {Boolean} username (optional).
  *                   - {Boolean} xff (optional).
+ *                   - {Boolean} setHeaders: Set response headers for rate,
+ *                               limit (burst) and remaining. Default is false.
  *                   - {Object} overrides (optional).
  *                   - {Object} tokensTable: a storage engine this plugin will
  *                              use to store throttling keys -> bucket mappings.
@@ -278,7 +280,16 @@ function throttle(options) {
         req.log.trace('Throttle(%s): num_tokens= %d',
             attr, bucket.tokens);
 
-        if (!bucket.consume(1)) {
+        var tooManyRequests = !bucket.consume(1);
+
+        // set throttle headers after consume which changes the remaining tokens
+        if (options.setHeaders) {
+            res.header('X-RateLimit-Remaining', Math.floor(bucket.tokens));
+            res.header('X-RateLimit-Limit', burst);
+            res.header('X-RateLimit-Rate', rate);
+        }
+
+        if (tooManyRequests) {
             req.log.info({
                 address: req.connection.remoteAddress || '?',
                 method: req.method,


### PR DESCRIPTION
As request in #1344 this exposes headers that specify how the api is throttled. This will not happen unless explicitly set in `setHeaders`. 

Added headers are: 
* `X-RateLimit-Remaining` for remaining tokens
* `X-RateLimit-Limit` for burst 
* `X-RateLimit-Rate` for the refresh reate

I did some quick research and i only found that Twitter uses `x-rate-limit-*` instead of camelCase. 

Most changes were made in the test since i had to setup a new server for that test. As far es I can tell there is no way to change plugins options after they were added.