### PR TITLE
fix: respect when status code is set with res.status (GH-1429)

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -304,7 +304,7 @@ Response.prototype.__send = function __send() {
 
     // Set sane defaults for optional arguments if they were not provided and
     // we failed to derive their values
-    code = code || 200;
+    code = code || self.statusCode || 200;
     headers = headers || {};
 
     // Populate our response object with the derived arguments

--- a/test/response.test.js
+++ b/test/response.test.js
@@ -562,3 +562,15 @@ test('GH-951: sendRaw accepts only strings or buffers', function (t) {
     // throw away response, we don't need it.
     STRING_CLIENT.get(join(LOCALHOST, '/16'));
 });
+
+test('GH-1429: setting code with res.status not respected', function (t) {
+    SERVER.get('/404', function (req, res, next) {
+        res.status(404);
+        res.send(null);
+    });
+
+    CLIENT.get(join(LOCALHOST, '/404'), function (err, _, res) {
+        t.equal(res.statusCode, 404);
+        t.end();
+    });
+});


### PR DESCRIPTION
## Pre-Submission Checklist

- [x] Opened an issue discussing these changes before opening the PR
- [x] Ran the linter and tests via `make prepush`
- [x] Included comprehensive and convincing tests for changes

## Issues

Closes:

* Issue #1429

# Changes

Before setting the default status code to 200 if there's been no error, it checks to see if `res.status` has been set and uses the value there if it has.