### PR TITLE
fix: audit timers of same name should accumulate (#1435)

### DIFF
--- a/lib/plugins/audit.js
+++ b/lib/plugins/audit.js
@@ -86,7 +86,7 @@ function auditLogger(opts) {
                 (req.timers || []).forEach(function (time) {
                     var t = time.time;
                     var _t = Math.floor((1000000 * t[0]) + (t[1] / 1000));
-                    timers[time.name] = _t;
+                    timers[time.name] = (timers[time.name] || 0) + _t;
                 });
                 return ({
                     // account for native and queryParser plugin usage


### PR DESCRIPTION
## Pre-Submission Checklist

- [X] Opened an issue discussing these changes before opening the PR
- [X] Ran the linter and tests via `make prepush`
- [X] Included comprehensive and convincing tests for changes

## Issues

Closes:

* Issue #1435

Audit log timers should accumulate their value when startHandlerTimer/endHandlerTimer is called more than once for the same timer name.

# Changes

Accumulates audit log timers by timer name.