### PR TITLE
BREAKING CHANGE: bump restify-errors version to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "negotiator": "^0.6.1",
     "once": "^1.3.0",
     "qs": "^6.2.1",
-    "restify-errors": "^4.2.3",
+    "restify-errors": "^5.0.0",
     "semver": "^5.0.1",
     "spdy": "^3.3.3",
     "uuid": "^3.0.0",


### PR DESCRIPTION
Updating dependencies. This changes the format of custom errors when they are serialized as a string.