### PR TITLE
fix(static): avoid user-provided data in Error messages being interpreted as sprintf codes

### DIFF
--- a/lib/plugins/static.js
+++ b/lib/plugins/static.js
@@ -153,7 +153,7 @@ function serveStatic(options) {
         }
 
         if (req.method !== 'GET' && req.method !== 'HEAD') {
-            next(new MethodNotAllowedError(req.method));
+            next(new MethodNotAllowedError('%s', req.method));
             return;
         }
 

--- a/test/plugins/static.test.js
+++ b/test/plugins/static.test.js
@@ -355,4 +355,35 @@ describe('static resource plugin', function () {
             });
         });
     });
+
+    it('static responds 404 for missing file', function (done) {
+        var p = '/public/no-such-file.json';
+        var tmpPath = path.join(process.cwd(), '.tmp');
+
+        SERVER.get(new RegExp('/public/.*'),
+            restify.plugins.serveStatic({directory: tmpPath}));
+
+        CLIENT.get(p, function (err, req, res, obj) {
+            assert.ok(err);
+            assert.equal(err.statusCode, 404);
+            assert.equal(err.restCode, 'ResourceNotFound');
+            return done();
+        });
+    });
+
+    it('GH-1382 static responds 404 for missing file with percent-codes',
+    function (done) {
+        var p = '/public/no-%22such-file.json';
+        var tmpPath = path.join(process.cwd(), '.tmp');
+
+        SERVER.get(new RegExp('/public/.*'),
+            restify.plugins.serveStatic({directory: tmpPath}));
+
+        CLIENT.get(p, function (err, req, res, obj) {
+            assert.ok(err);
+            assert.equal(err.statusCode, 404);
+            assert.equal(err.restCode, 'ResourceNotFound');
+            return done();
+        });
+    });
 });


### PR DESCRIPTION
Same as #1384 but for 5.x. Fixes #1411 

I cherry picked @trentm's commits, and migrated tests to the new directory. 

