### PR TITLE
Fix get headers 4.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
    - "0.10"
    - "0.12"
    - "4"
+   - "6"
    - "stable"
 notifications:
   webhooks:

--- a/lib/response.js
+++ b/lib/response.js
@@ -167,13 +167,16 @@ Response.prototype.get = function get(name) {
 };
 
 
-/**
- * retrieves all headers off the response.
- * @public
- * @function getHeaders
- * @returns  {Object}
- */
+// If getHeaders is not provided by the Node platform, monkey patch our own.
+// This is needed since versions of Node <7 did not come with a getHeaders.
+// For more see GH-1408
 if (typeof Response.prototype.getHeaders !== 'function') {
+  /**
+   * retrieves all headers off the response.
+   * @public
+   * @function getHeaders
+   * @returns  {Object}
+   */
     Response.prototype.getHeaders = function getHeaders() {
         return (this._headers || {});
     };

--- a/lib/response.js
+++ b/lib/response.js
@@ -171,12 +171,12 @@ Response.prototype.get = function get(name) {
 // This is needed since versions of Node <7 did not come with a getHeaders.
 // For more see GH-1408
 if (typeof Response.prototype.getHeaders !== 'function') {
-  /**
-   * retrieves all headers off the response.
-   * @public
-   * @function getHeaders
-   * @returns  {Object}
-   */
+    /**
+     * retrieves all headers off the response.
+     * @public
+     * @function getHeaders
+     * @returns  {Object}
+     */
     Response.prototype.getHeaders = function getHeaders() {
         return (this._headers || {});
     };

--- a/lib/response.js
+++ b/lib/response.js
@@ -173,9 +173,11 @@ Response.prototype.get = function get(name) {
  * @function getHeaders
  * @returns  {Object}
  */
-Response.prototype.getHeaders = function getHeaders() {
-    return (this._headers || {});
-};
+if (typeof Response.prototype.getHeaders !== 'function') {
+    Response.prototype.getHeaders = function getHeaders() {
+        return (this._headers || {});
+    };
+}
 Response.prototype.headers = Response.prototype.getHeaders;
 
 


### PR DESCRIPTION
Fixes #1470. Exactly the same as #1407 except for 4.x.

Happy to land this and get 4.x working for node 8. Longer term, might be worth starting a discussion for EOL for 4.x. What is our level of support moving forward? 