### PR TITLE
Skip dev dependencies from nsp check to prevent extraneous dependencies issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,8 @@ test: $(NODEUNIT)
 
 .PHONY: nsp
 nsp: node_modules $(NSP)
-	@$(NPM) shrinkwrap --dev
+	@$(NPM) prune
+	@$(NPM) shrinkwrap
 	@($(NSP) check) | $(NSP_BADGE)
 	@rm $(SHRINKWRAP)
 


### PR DESCRIPTION
# Changes

Current master is broken by npm shinkwrap issue, skip dev dependencies to avoid extraneous packages error.

Symptom (TravisCI output):

```
npm ERR! Linux 4.11.6-041106-generic
npm ERR! argv "/home/travis/.nvm/versions/node/v7.10.1/bin/node" "/home/travis/.nvm/versions/node/v7.10.1/bin/npm" "shrinkwrap" "--dev"
npm ERR! node v7.10.1
npm ERR! npm  v4.2.0
npm ERR! Problems were encountered
npm ERR! Please correct and try again.
npm ERR! extraneous: abbrev@1.1.0 /home/travis/build/restify/node-restify/node_modules/nsp/node_modules/abbrev
..
```
