### PR TITLE
Do not use shrinkwrap file to run nsp check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,8 @@ NPM		:= npm
 #
 DOC_FILES	 = index.restdown
 JS_FILES	 = '.'
-SHRINKWRAP	 = npm-shrinkwrap.json
 
-CLEAN_FILES	+= node_modules $(SHRINKWRAP) cscope.files
+CLEAN_FILES	+= node_modules cscope.files
 
 include ./tools/mk/Makefile.defs
 
@@ -65,9 +64,7 @@ test: $(NODEUNIT)
 
 .PHONY: nsp
 nsp: node_modules $(NSP)
-	@$(NPM) shrinkwrap --dev
 	@($(NSP) check) | $(NSP_BADGE)
-	@rm $(SHRINKWRAP)
 
 include ./tools/mk/Makefile.deps
 include ./tools/mk/Makefile.targ


### PR DESCRIPTION
# Issues

The current master is broken by shrinkwrap's "extraneous" issues.

TravisCI output:

```
npm ERR! Linux 4.11.6-041106-generic
npm ERR! argv "/home/travis/.nvm/versions/node/v4.8.4/bin/node" "/home/travis/.nvm/versions/node/v4.8.4/bin/npm" "shrinkwrap" "--dev"
npm ERR! node v4.8.4
npm ERR! npm  v2.15.11
npm ERR! Problems were encountered
npm ERR! Please correct and try again.
npm ERR! extraneous: abbrev@1.1.0 /home/travis/build/restify/node-restify/node_modules/nsp/node_modules/abbrev
```

# Changes

Do not use `shrinkwrap` file to run `nsp check`.

Shrinkwrap file is only required with `--offline` flag, which is not recommended anymore, see: https://github.com/nodesecurity/nsp/blob/56f9848b6950ea821e4b92d1f1fb66ffc93bd79e/README.md#offline-mode
