### PR TITLE
Do not publish .github folder to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,7 @@
 .coverage_data
 .dir-locals.el
 .gitmodules
+.github
 .travis.yml
 Makefile
 cover_html


### PR DESCRIPTION
Do not publish `.github` folder to `npm`

# Changes

- Add `.github` folder to `.npmignore`.
