### PR TITLE
Migrate spdy, dtrace and jsonp examples to the latest restify

### DIFF
--- a/examples/dtrace/hello.js
+++ b/examples/dtrace/hello.js
@@ -1,14 +1,14 @@
-var restify = require('../lib');
+var restify = require('../../lib');
 
 var server = restify.createServer({
     name: 'helloworld'
 });
 
-server.use(restify.acceptParser(server.acceptable));
-server.use(restify.authorizationParser());
-server.use(restify.dateParser());
-server.use(restify.queryParser());
-server.use(restify.urlEncodedBodyParser());
+server.use(restify.plugins.acceptParser(server.acceptable));
+server.use(restify.plugins.authorizationParser());
+server.use(restify.plugins.dateParser());
+server.use(restify.plugins.queryParser());
+server.use(restify.plugins.urlEncodedBodyParser());
 
 server.use(function slowHandler(req, res, next) {
     setTimeout(function () {
@@ -29,4 +29,3 @@ server.get({
 server.listen(8080, function () {
     console.log('listening: %s', server.url);
 });
-

--- a/examples/jsonp/jsonp.js
+++ b/examples/jsonp/jsonp.js
@@ -1,8 +1,8 @@
 var restify = require('../../lib');
 
 var srv = restify.createServer();
-srv.use(restify.queryParser());
-srv.use(restify.jsonp());
+srv.use(restify.plugins.queryParser());
+srv.use(restify.plugins.jsonp());
 srv.get('/', function (req, res, next) {
     res.send({hello: 'world'});
     next();

--- a/examples/spdy/spdy.js
+++ b/examples/spdy/spdy.js
@@ -1,12 +1,13 @@
+var path = require('path');
 var fs = require('fs');
 var bunyan = require('bunyan');
 var restify = require('../../lib');
 
 var srv = restify.createServer({
     spdy: {
-        cert: fs.readFileSync('./keys/spdy-cert.pem'),
-        key: fs.readFileSync('./keys/spdy-key.pem'),
-        ca: fs.readFileSync('keys/spdy-csr.pem')
+        cert: fs.readFileSync(path.join(__dirname, './keys/spdy-cert.pem')),
+        key: fs.readFileSync(path.join(__dirname, './keys/spdy-key.pem')),
+        ca: fs.readFileSync(path.join(__dirname, 'keys/spdy-csr.pem'))
     }
 });
 
@@ -16,6 +17,7 @@ srv.get('/', function (req, res, next) {
 });
 
 srv.on('after', restify.plugins.auditLogger({
+    event: 'after',
     body: true,
     log: bunyan.createLogger({
         name: 'audit',


### PR DESCRIPTION
Migrate spdy, dtrace and jsonp examples to the latest restify

# Changes

- migrate spdy example
- migrate dtrace example
- migrate jsonp example
