### PR TITLE
Correct doc: inflightRequests() returns a number, not a string.

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -432,7 +432,7 @@ Server.prototype.close = function close(callback) {
  * Returns the number of currently inflight requests.
  * @public
  * @function inflightRequests
- * @returns  {String}
+ * @returns  {number}
  */
 Server.prototype.inflightRequests = function inflightRequests() {
     var self = this;


### PR DESCRIPTION
The attached pull request makes a trivial correction to the inline documentation in restify.

`server.inflightRequests()` was incorrectly documented as returning a `String`. It actually returns a `number`.