### PR TITLE
fix(cpuUsageThrottle): Correctly named handler for debugInfo

### DIFF
--- a/lib/plugins/cpuUsageThrottle.js
+++ b/lib/plugins/cpuUsageThrottle.js
@@ -77,7 +77,7 @@ var EWMA = require('ewma');
  *    unit is in ms. Defaults to 250.
  * @returns {Function} middleware to be registered on server.pre
  */
-function cpuUsageThrottle (opts) {
+function cpuUsageThrottlePlugin (opts) {
 
     // Scrub input and populate our configuration
     assert.object(opts, 'opts');
@@ -150,7 +150,7 @@ function cpuUsageThrottle (opts) {
     // Kick off updating our _reject value
     updateReject();
 
-    function onRequest (req, res, next) {
+    function cpuUsageThrottle (req, res, next) {
         // Check to see if this request gets rejected. Since, in updateReject,
         // we calculate a percentage of traffic we are planning to reject, we
         // can use Math.random() (which picks from a uniform distribution in
@@ -186,10 +186,10 @@ function cpuUsageThrottle (opts) {
     function close () {
         clearTimeout(self._timeout);
     }
-    onRequest.close = close;
+    cpuUsageThrottle.close = close;
 
     // Expose internal plugin state for introspection
-    Object.defineProperty(onRequest, 'state', {
+    Object.defineProperty(cpuUsageThrottle, 'state', {
         get: function () {
             // We intentionally do not expose ewma since we don't want the user
             // to be able to update it's configuration, the current state of
@@ -215,7 +215,7 @@ function cpuUsageThrottle (opts) {
      *    it follows the same format as the constructor for this plugin.
      * @returns {undefined}
      */
-    onRequest.update = function update(newOpts) {
+    cpuUsageThrottle.update = function update(newOpts) {
         assert.object(newOpts, 'newOpts');
         assert.optionalNumber(newOpts.limit, 'newOpts.limit');
         assert.optionalNumber(newOpts.max, 'newOpts.max');
@@ -250,7 +250,7 @@ function cpuUsageThrottle (opts) {
             (self._cpu - self._limit) / (self._max - self._limit);
     };
 
-    return onRequest;
+    return cpuUsageThrottle;
 }
 
-module.exports = cpuUsageThrottle;
+module.exports = cpuUsageThrottlePlugin;

--- a/test/plugins/cpuUsageThrottle.test.js
+++ b/test/plugins/cpuUsageThrottle.test.js
@@ -72,6 +72,18 @@ describe('cpuUsageThrottle', function () {
         done();
     });
 
+    it('Unit: Should have proper name', function(done) {
+        var opts = {
+            max: 1,
+            limit: 0.9,
+            halfLife: 50,
+            interval: 50
+        };
+        var plugin = cpuUsageThrottle(opts);
+        assert.equal(plugin.name, 'cpuUsageThrottle');
+        done();
+    });
+
 
     it('Integration: Should shed load', function (done) {
         var server = restify.createServer();

--- a/test/plugins/cpuUsageThrottle.test.js
+++ b/test/plugins/cpuUsageThrottle.test.js
@@ -72,7 +72,7 @@ describe('cpuUsageThrottle', function () {
         done();
     });
 
-    it('Unit: Should have proper name', function(done) {
+    it('Unit: Should have proper name', function (done) {
         var opts = {
             max: 1,
             limit: 0.9,


### PR DESCRIPTION
## Pre-Submission Checklist

- [x] Ran the linter and tests via `make prepush`
- [x] Included comprehensive and convincing tests for changes

# Changes

> What does this PR do?

Currently, `(cpuUsageThrottle(opts).name)` returns `onRequest`. This causes `server.debugInfo` to display the wrong name for the `pre` handler. This corrects that.
