### PR TITLE
fix(server): error in pre handler triggers after event

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -755,7 +755,7 @@ Server.prototype._handle = function _handle(req, res) {
         self._run(req, res, null, self.before, function (err) {
             // Like with regular handlers, if we are provided an error, we
             // should abort the middleware chain and fire after events.
-            if (err !== undefined) {
+            if (err === false || err instanceof Error) {
                 self._finishReqResCycle(req, res, null, err);
                 return;
             }

--- a/lib/server.js
+++ b/lib/server.js
@@ -753,17 +753,14 @@ Server.prototype._handle = function _handle(req, res) {
     // run pre() handlers first before routing and running
     if (self.before.length > 0) {
         self._run(req, res, null, self.before, function (err) {
-            // check for return false here - like with the regular handlers,
-            // if false is returned we already sent a response and should stop
-            // processing.
-            if (err === false) {
-                self._finishReqResCycle(req, res);
+            // Like with regular handlers, if we are provided an error, we
+            // should abort the middleware chain and fire after events.
+            if (err !== undefined) {
+                self._finishReqResCycle(req, res, null, err);
                 return;
             }
 
-            if (!err) {
-                routeAndRun();
-            }
+            routeAndRun();
         });
     } else {
         routeAndRun();

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -2957,3 +2957,22 @@ test('calling next twice should throw', function (t) {
         t.ifError(err);
     });
 });
+
+test('aborting pre should still call after', function (t) {
+    setTimeout(function () {
+        t.fail('Timed out');
+        t.end();
+    }, 2000);
+    var error = new Error();
+    SERVER.pre(function (req, res, next) {
+        next(error);
+    });
+    SERVER.get('/', function (req, res, next) {
+        t.fail('should have aborted stack before routing');
+    });
+    SERVER.on('after', function (req, res, route, err) {
+        t.equal(err, error);
+        t.end();
+    });
+    CLIENT.get('/', function () {});
+});

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -630,7 +630,6 @@ test('GH-64 prerouting chain with error', function (t) {
     });
 });
 
-
 test('GH-67 extend access-control headers', function (t) {
     SERVER.get('/hello/:name', function tester(req, res, next) {
         res.header('Access-Control-Allow-Headers',
@@ -2337,6 +2336,24 @@ test('calling next(false) should early exit from pre handlers', function (t) {
 
 });
 
+test('calling next(err) from pre should still emit after event', function (t) {
+    setTimeout(function () {
+        t.fail('Timed out');
+        t.end();
+    }, 2000);
+    var error = new Error();
+    SERVER.pre(function (req, res, next) {
+        next(error);
+    });
+    SERVER.get('/', function (req, res, next) {
+        t.fail('should have aborted stack before routing');
+    });
+    SERVER.on('after', function (req, res, route, err) {
+        t.equal(err, error);
+        t.end();
+    });
+    CLIENT.get('/', function () {});
+});
 
 test('GH-1078: server name should default to restify', function (t) {
 
@@ -2956,23 +2973,4 @@ test('calling next twice should throw', function (t) {
     CLIENT.get('/', function (err, req, res, data) {
         t.ifError(err);
     });
-});
-
-test('aborting pre should still call after', function (t) {
-    setTimeout(function () {
-        t.fail('Timed out');
-        t.end();
-    }, 2000);
-    var error = new Error();
-    SERVER.pre(function (req, res, next) {
-        next(error);
-    });
-    SERVER.get('/', function (req, res, next) {
-        t.fail('should have aborted stack before routing');
-    });
-    SERVER.on('after', function (req, res, route, err) {
-        t.equal(err, error);
-        t.end();
-    });
-    CLIENT.get('/', function () {});
 });


### PR DESCRIPTION
Currently, aborting a middleware chain inside a `pre` handler will cause restify to drop the chain on the floor. This results in the `after` event not firing.

An effect of this is that `after` handlers do not get access to requests rejected by throttles.

This PR fixes that.