### PR TITLE
fix: dont include interval in lag

### DIFF
--- a/lib/plugins/cpuUsageThrottle.js
+++ b/lib/plugins/cpuUsageThrottle.js
@@ -142,7 +142,7 @@ function cpuUsageThrottlePlugin (opts) {
             // updated the _reject value and how long it actually took. This
             // metric accounts for the misbehaviour of pidusage.stat
             var now = Date.now();
-            self._timeoutDelta = now - self._timeoutStart;
+            self._timeoutDelta = now - self._timeoutStart - self._interval;
             self._timeoutStart = now;
         });
     }

--- a/test/plugins/cpuUsageThrottle.test.js
+++ b/test/plugins/cpuUsageThrottle.test.js
@@ -19,7 +19,7 @@ var cpuUsageThrottle = proxyquire('../../lib/plugins/cpuUsageThrottle.js', {
 var MR = Math.random;
 describe('cpuUsageThrottle', function () {
 
-    var plugin = undefined
+    var plugin;
 
     before('Setup: stub math.random', function (done) {
         Math.random = function () {
@@ -125,8 +125,8 @@ describe('cpuUsageThrottle', function () {
         });
     });
 
-    afterEach(function(done) {
-        if(plugin) {
+    afterEach(function (done) {
+        if (plugin) {
             plugin.close();
         }
         plugin = undefined;

--- a/test/plugins/cpuUsageThrottle.test.js
+++ b/test/plugins/cpuUsageThrottle.test.js
@@ -86,16 +86,18 @@ describe('cpuUsageThrottle', function () {
     });
 
     it('Unit: Should report proper lag', function (done) {
-      var opts = { max: 1, limit: 0.9, halfLife: 50, interval: 50 };
-      var dn = Date.now;
-      var now = 0;
-      // First timer will be 0, all future timers will be interval
-      Date.now = () => (now++ > 0) * opts.interval;
-      var plugin = cpuUsageThrottle(opts);
-      Date.now = dn;
-      plugin.close();
-      assert.equal(plugin.state.lag, 0);
-      done();
+        var opts = { max: 1, limit: 0.9, halfLife: 50, interval: 50 };
+        var dn = Date.now;
+        var now = 0;
+        // First timer will be 0, all future timers will be interval
+        Date.now = function () {
+            return (now++ > 0) * opts.interval;
+        };
+        var plugin = cpuUsageThrottle(opts);
+        Date.now = dn;
+        plugin.close();
+        assert.equal(plugin.state.lag, 0);
+        done();
     });
 
 


### PR DESCRIPTION
<!--
Thank you for taking the time to open an PR for restify! If this is your first
time here, welcome to our community! We are a group of developers who work on
restify in our free-time. Some of us do it as a hobby, others are using restify
at work. When asking for help here, keep in mind most of us are volunteers
contributing our daily work back to the community at no cost (and often for no
reward). Please be respectful!

Below you will find a checklist to help you create the best PR possible. While
the checklist items aren't all _strictly_ required, they dramatically increase
the probability of your PR getting a response and getting merged. Often times,
the least time consuming part of maintaining and open source project is writing
code, its the process and discussions that happen around the code base that
consume a majority of the maintainers' time. By spending a few moments to
adhere to this template, you are not only improve the quality of your PR, you
are also helping save the maintainers a considerable amount of time when trying
to understand and review your changes.

And remember, positive vibes are met with positive vibes. Kindness helps Free
Software go round, pay it forward!
-->

## Pre-Submission Checklist

- [ ] Opened an issue discussing these changes before opening the PR
- [x] Ran the linter and tests via `make prepush`
- [x] Included comprehensive and convincing tests for changes

# Changes

> What does this PR do?

Currently the `lag` metric for `cpuUsageThrottle` includes the interval. For example, an interval of `50` firing at the exact right moment will result in a lag of `50` as opposed to `0`. This fixes that.

Also, this PR removes all timeouts after the `cpuUsageThrottle` tests.