### PR TITLE
chore(package): update dependencies, fix security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "http-signature": "^1.0.0",
     "lodash": "^4.17.4",
     "lru-cache": "^4.0.1",
-    "mime": "^1.4.0",
+    "mime": "^1.4.1",
     "negotiator": "^0.6.1",
     "once": "^1.3.0",
     "pidusage": "^1.1.6",
@@ -120,7 +120,7 @@
   "devDependencies": {
     "chai": "^4.0.1",
     "cover": "^0.2.9",
-    "coveralls": "^2.13.0",
+    "coveralls": "^2.13.2",
     "eslint": "^3.11.1",
     "filed": "^0.1.0",
     "istanbul": "^0.4.1",
@@ -129,12 +129,12 @@
     "mkdirp": "^0.5.1",
     "mocha": "^3.2.0",
     "nodeunit": "^0.11.0",
-    "nsp": "^2.2.0",
+    "nsp": "^2.8.1",
     "proxyquire": "^1.8.0",
-    "restify-clients": "^1.2.1",
-    "rimraf": "^2.4.3",
+    "restify-clients": "^1.5.2",
+    "rimraf": "^2.6.2",
     "validator": "^7.0.0",
-    "watershed": "^0.3.0"
+    "watershed": "^0.3.4"
   },
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
Update dependencies with patch and minor updates.
Escpecially `mime` that had a known security vulnerability, see:

```
┌───────────────┬─────────────────────────────────────────────────────────────────┐
│               │ Regular Expression Denial of Service                            │
├───────────────┼─────────────────────────────────────────────────────────────────┤
│ Name          │ mime                                                            │
├───────────────┼─────────────────────────────────────────────────────────────────┤
│ CVSS          │ 7.5 (High)                                                      │
├───────────────┼─────────────────────────────────────────────────────────────────┤
│ Installed     │ 1.4.0                                                           │
├───────────────┼─────────────────────────────────────────────────────────────────┤
│ Vulnerable    │ < 1.4.1 || > 2.0.0 < 2.0.3                                      │
├───────────────┼─────────────────────────────────────────────────────────────────┤
│ Patched       │ >= 1.4.1 < 2.0.0 || >= 2.0.3                                    │
├───────────────┼─────────────────────────────────────────────────────────────────┤
│ Path          │ restify@6.0.1 > mime@1.4.0                                      │
├───────────────┼─────────────────────────────────────────────────────────────────┤
│ More Info     │ https://nodesecurity.io/advisories/535                          │
└───────────────┴─────────────────────────────────────────────────────────────────┘
```

# Changes

Updated packages:

- mime
- coveralls
- nsp
- restify-clients
- rimraf
- watershed
