### PR TITLE
docs(README): remove NSP badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@
 [![Dependency Status](https://david-dm.org/restify/node-restify.svg)](https://david-dm.org/restify/node-restify)
 [![devDependency Status](https://david-dm.org/restify/node-restify/dev-status.svg)](https://david-dm.org/restify/node-restify#info=devDependencies)
 [![bitHound Score](https://www.bithound.io/github/restify/node-restify/badges/score.svg)](https://www.bithound.io/github/restify/node-restify/master)
-[![NSP Status](https://img.shields.io/badge/NSP%20status-no%20vulnerabilities-green.svg)](https://travis-ci.org/restify/node-restify)
 
 
 [restify](http://restify.com) is a framework, utilizing


### PR DESCRIPTION
The current `nsp` badge is static, it's always green.
However, it's probably correct at the moment when a new PR is merged to master, as CI checks it.
It's not necessarily valid at any point in the time, like now.

# Changes

- remove "always green" `nsp` badge from README.md
