### PR TITLE
Fix docs for: req.getQuery() with queryParser()

### DIFF
--- a/docs/api/request.md
+++ b/docs/api/request.md
@@ -96,13 +96,13 @@ req.getQuery();
 // => 'a=1'
 ```
 
-Note that if the query parser plugin is used, then this method will returned
-the parsed query string:
+If the `queryParser` plugin is used, the parsed query string is available 
+under the `req.query`:
 
 ```js
 // incoming request is /foo?a=1
 server.use(restify.plugins.queryParser());
-req.getQuery();
+req.query;
 // => { a: 1 }
 ```
 

--- a/test/plugins/query.test.js
+++ b/test/plugins/query.test.js
@@ -57,6 +57,23 @@ describe('query parser', function () {
         });
     });
 
+    it('req.getQuery() should return with raw query string', function (done) {
+        SERVER.use(restify.plugins.queryParser());
+
+        SERVER.get('/query/:id', function (req, res, next) {
+            assert.equal(req.getQuery(), 'a=1');
+            assert.deepEqual(req.query, { a: '1' });
+            res.send();
+            next();
+        });
+
+        CLIENT.get('/query/foo?a=1', function (err, _, res) {
+            assert.ifError(err);
+            assert.equal(res.statusCode, 200);
+            done();
+        });
+    });
+
     it('should parse req.query and req.params independently', function (done) {
         SERVER.use(restify.plugins.queryParser());
 


### PR DESCRIPTION
## Pre-Submission Checklist

- [x] Opened an issue discussing these changes before opening the PR
- [x] Ran the linter and tests via `make prepush`
- [x] Included comprehensive and convincing tests for changes

## Issues

Closes:

* https://github.com/restify/node-restify/issues/1502

`req.getQuery()` returns a raw query string with a `queryParser()` plugin.

# Changes

- Fix `req` documentation
- Add a test for `getQuery` with `queryParser()`
