### PR TITLE
Handle non-trailing slashes correctly

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -134,7 +134,7 @@ function compileURL(options) {
     }
 
     if (!options.strict) {
-        pattern += '[\\/]*';
+        pattern += '[\\/]?';
     }
 
     if (pattern === '^') {

--- a/lib/router.js
+++ b/lib/router.js
@@ -103,7 +103,7 @@ function compileURL(options) {
             return (false);
         }
 
-        pattern += '\\/{1}';
+        pattern += '\\/';
 
         if (frag.charAt(0) === ':') {
             var label = frag;

--- a/lib/router.js
+++ b/lib/router.js
@@ -103,7 +103,7 @@ function compileURL(options) {
             return (false);
         }
 
-        pattern += '\\/+';
+        pattern += '\\/{1}';
 
         if (frag.charAt(0) === ':') {
             var label = frag;

--- a/test/plugins/dedupeSlashes.js
+++ b/test/plugins/dedupeSlashes.js
@@ -67,18 +67,8 @@ describe('dedupe forward slashes in URL', function () {
             });
         });
 
-        it('should remove duplicate slashes', function (done) {
-            CLIENT.get('//foo//bar', function (err, _, res, data) {
-                assert.ifError(err);
-                assert.equal(res.statusCode, 200);
-                assert.equal(data, '/foo/bar');
-                done();
-            });
-        });
-
-        it('should remove duplicate slashes including trailing slashes',
-        function (done) {
-            CLIENT.get('//foo//bar//', function (err, _, res, data) {
+        it('should merge multiple slashes', function (done) {
+            CLIENT.get('//////foo///bar///////', function (err, _, res, data) {
                 assert.ifError(err);
                 assert.equal(res.statusCode, 200);
                 assert.equal(data, '/foo/bar/');
@@ -131,19 +121,8 @@ describe('dedupe forward slashes in URL', function () {
             });
         });
 
-        it('should remove duplicate slashes', function (done) {
-            CLIENT.get('//foo//bar//', function (err, _, res, data) {
-                assert.ifError(err);
-                assert.equal(res.statusCode, 200);
-                assert.equal(data, '/foo/bar/');
-                done();
-            });
-        });
-
-
-        it('should remove duplicate slashes including trailing slashes',
-        function (done) {
-            CLIENT.get('//foo//bar//', function (err, _, res, data) {
+        it('should merge multiple slashes', function (done) {
+            CLIENT.get('//////foo///bar///////', function (err, _, res, data) {
                 assert.ifError(err);
                 assert.equal(res.statusCode, 200);
                 assert.equal(data, '/foo/bar/');

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -210,13 +210,26 @@ test('Default non-strict routing ignores trailing slash(es)', function (t) {
 
     var trailing = server.router.routes.GET[0];
     t.ok(trailing.path.test('/trailing/'));
-    t.ok(trailing.path.test('//trailing//'));
+    t.ok(trailing.path.test('/trailing//'));
     t.ok(trailing.path.test('/trailing'));
 
     var noTrailing = server.router.routes.GET[1];
     t.ok(noTrailing.path.test('/no-trailing'));
-    t.ok(noTrailing.path.test('//no-trailing//'));
+    t.ok(noTrailing.path.test('/no-trailing//'));
     t.ok(noTrailing.path.test('/no-trailing/'));
+
+    t.end();
+});
+
+test('Default non-strict routing doesn\'t match non-trailing slash(es)',
+  function (t) {
+    var server = restify.createServer();
+    function noop () {}
+
+    server.get('/no-trailing', noop);
+
+    var noTrailing = server.router.routes.GET[0];
+    t.notOk(noTrailing.path.test('//no-trailing'));
 
     t.end();
 });

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -189,19 +189,27 @@ test('Strict routing distinguishes trailing slash', function (t) {
     server.get('/trailing/', noop);
     server.get('/no-trailing', noop);
 
-
     var trailing = server.router.routes.GET[0];
-    t.ok(trailing.path.test('/trailing/'));
-    t.notOk(trailing.path.test('/trailing'));
+    t.ok(trailing.path.test('/trailing/'), 'Single trailing slash is ok');
+    t.notOk(trailing.path.test('/trailing'), 'No trailing slash is not ok');
+    t.notOk(trailing.path.test('/trailing//'),
+            'Double trailing slash is not ok');
+    t.notOk(trailing.path.test('//trailing/'),
+            'Double heading slash is not ok');
 
     var noTrailing = server.router.routes.GET[1];
-    t.ok(noTrailing.path.test('/no-trailing'));
-    t.notOk(noTrailing.path.test('/no-trailing/'));
+    t.ok(noTrailing.path.test('/no-trailing', 'No trailing slash is ok'));
+    t.notOk(noTrailing.path.test('/no-trailing/'),
+            'Single trailing slash is not ok');
+    t.notOk(noTrailing.path.test('/no-trailing//'),
+            'Double trailing slash is not ok');
+    t.notOk(noTrailing.path.test('//no-trailing'),
+            'Double heading slash is not ok');
 
     t.end();
 });
 
-test('Default non-strict routing ignores trailing slash(es)', function (t) {
+test('Non-strict routing distinguishes trailing slash', function (t) {
     var server = restify.createServer();
     function noop () {}
 
@@ -209,27 +217,20 @@ test('Default non-strict routing ignores trailing slash(es)', function (t) {
     server.get('/no-trailing', noop);
 
     var trailing = server.router.routes.GET[0];
-    t.ok(trailing.path.test('/trailing/'));
-    t.ok(trailing.path.test('/trailing//'));
-    t.ok(trailing.path.test('/trailing'));
+    t.ok(trailing.path.test('/trailing/', 'Single trailing slash is ok'));
+    t.ok(trailing.path.test('/trailing'), 'No trailing slash is not ok');
+    t.notOk(trailing.path.test('/trailing//'),
+            'Double trailing slash is not ok');
+    t.notOk(trailing.path.test('//trailing'),
+            'Double heading slash is not ok');
 
     var noTrailing = server.router.routes.GET[1];
-    t.ok(noTrailing.path.test('/no-trailing'));
-    t.ok(noTrailing.path.test('/no-trailing//'));
-    t.ok(noTrailing.path.test('/no-trailing/'));
-
-    t.end();
-});
-
-test('Default non-strict routing doesn\'t match non-trailing slash(es)',
-  function (t) {
-    var server = restify.createServer();
-    function noop () {}
-
-    server.get('/no-trailing', noop);
-
-    var noTrailing = server.router.routes.GET[0];
-    t.notOk(noTrailing.path.test('//no-trailing'));
+    t.ok(noTrailing.path.test('/no-trailing', 'No trailing slash is ok'));
+    t.ok(noTrailing.path.test('/no-trailing/'), 'Single trailing slash is ok');
+    t.notOk(noTrailing.path.test('/no-trailing//'),
+            'Double trailing slash is not ok');
+    t.notOk(noTrailing.path.test('//no-trailing'),
+            'Double heading slash is not ok');
 
     t.end();
 });


### PR DESCRIPTION
## Issues

Closes:

https://github.com/restify/node-restify/issues/1464
https://github.com/restify/node-restify/pull/1478

Non-trailing slash leads to incorrect routing match (and parameter parsing).

# Changes

Fix router regexp matching with non-trailing slash(es)
