### PR TITLE
Update auditLogger documentation

### DIFF
--- a/docs/api/plugins.md
+++ b/docs/api/plugins.md
@@ -614,6 +614,7 @@ the `after` event:
 
 ```js
 server.on('after', restify.plugins.auditLogger({
+  event: 'after',
   log: bunyan.createLogger({
     name: 'audit',
     stream: process.stdout


### PR DESCRIPTION
## Pre-Submission Checklist

- [x] Opened an issue discussing these changes before opening the PR
- [x] Ran the linter and tests via `make prepush`
- [ ] Included comprehensive and convincing tests for changes

## Issues

Closes:
* Issue #1395

> The documentation example is missing the the fact that `event` property of the `options` object
that needs to be passed to `restify.plugins.auditLogger(options)` is a mandatory parameter of type string.

# Changes
> Update documentation for `auditLogger` plugin.
