### PR TITLE
refactor(lib): forbid anonymous function in lib code

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -48,6 +48,7 @@ if (!process.env.NO_LINT) {
     config.rules['valid-typeof'] = ERROR;
 
     // best practices
+    config.rules['func-names'] = ERROR;
     config.rules['block-scoped-var'] = ERROR;
     config.rules['consistent-return'] = ERROR;
     config.rules['curly'] = OFF;
@@ -138,7 +139,6 @@ if (!process.env.NO_STYLE) {
     config.rules['no-underscore-dangle'] = OFF;
     config.rules['no-whitespace-before-property'] = ERROR;
     config.rules['yoda'] = ERROR;
-    // config.rules['func-names'] = ERROR;          // TODO: unnamed functions
 
     // require rules
     config.rules['semi'] = ERROR;

--- a/lib/bunyan_helper.js
+++ b/lib/bunyan_helper.js
@@ -159,7 +159,7 @@ RequestCaptureStream.prototype.write = function write(record) {
             if (this.haveNonRawStreams) {
                 ser = JSON.stringify(r, bunyan.safeCycles()) + '\n';
             }
-            self.streams.forEach(function (s) {
+            self.streams.forEach(function forEach (s) {
                 s.stream.write(s.raw ? r : ser);
             });
         }
@@ -174,7 +174,7 @@ RequestCaptureStream.prototype.write = function write(record) {
                 if (this.haveNonRawStreams) {
                     ser = JSON.stringify(r, bunyan.safeCycles()) + '\n';
                 }
-                self.streams.forEach(function (s) {
+                self.streams.forEach(function forEach (s) {
                     s.stream.write(s.raw ? r : ser);
                 });
             }

--- a/lib/dtrace.js
+++ b/lib/dtrace.js
@@ -44,27 +44,27 @@ module.exports = (function exportStaticProvider() {
             PROVIDER = dtrace.createDTraceProvider('restify');
         } catch (e) {
             PROVIDER = {
-                fire: function () {
+                fire: function fire () {
                 },
-                enable: function () {
+                enable: function enable () {
                 },
-                addProbe: function () {
+                addProbe: function addProbe () {
                     var p = {
-                        fire: function () {
+                        fire: function fire () {
                         }
                     };
                     return (p);
                 },
-                removeProbe: function () {
+                removeProbe: function removeProbe () {
                 },
-                disable: function () {
+                disable: function disable () {
                 }
             };
         }
 
         PROVIDER._rstfy_probes = {};
 
-        Object.keys(PROBES).forEach(function (p) {
+        Object.keys(PROBES).forEach(function forEach (p) {
             var args = PROBES[p].splice(0);
             args.unshift(p);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -77,15 +77,16 @@ function createServer(options) {
     server = new Server(opts);
 
     if (opts.handleUncaughtExceptions) {
-        server.on('uncaughtException', function (req, res, route, e) {
-            if (this.listeners('uncaughtException').length > 1 ||
-                res.headersSent) {
-                return (false);
-            }
+        server.on('uncaughtException',
+            function onUncaughtException (req, res, route, e) {
+                if (this.listeners('uncaughtException').length > 1 ||
+                    res.headersSent) {
+                    return (false);
+                }
 
-            res.send(new InternalError(e, e.message || 'unexpected error'));
-            return (true);
-        });
+                res.send(new InternalError(e, e.message || 'unexpected error'));
+                return (true);
+            });
     }
 
     return (server);

--- a/lib/plugins/accept.js
+++ b/lib/plugins/accept.js
@@ -34,11 +34,11 @@ function acceptParser(accepts) {
     }
     assert.arrayOfString(acceptable, 'acceptable');
 
-    acceptable = acceptable.filter(function (a) {
+    acceptable = acceptable.filter(function filter (a) {
         return (a);
-    }).map(function (a) {
+    }).map(function map (a) {
         return ((a.indexOf('/') === -1) ? mime.lookup(a) : a);
-    }).filter(function (a) {
+    }).filter(function filter (a) {
         return (a);
     });
 

--- a/lib/plugins/audit.js
+++ b/lib/plugins/audit.js
@@ -22,7 +22,7 @@ var hrTimeDurationInMs = require('./utils/hrTimeDurationInMs');
  */
 function getResponseHeaders(res) {
     if (res.getHeaderNames && res.getHeader) {
-        return res.getHeaderNames().reduce(function (prev, curr) {
+        return res.getHeaderNames().reduce(function reduce (prev, curr) {
             var header = {};
             header[curr] = res.getHeader(curr);
             return Object.assign({}, prev, header);
@@ -204,7 +204,7 @@ function auditLogger(opts) {
                 }
 
                 var timers = {};
-                (req.timers || []).forEach(function (time) {
+                (req.timers || []).forEach(function forEach (time) {
                     var t = time.time;
                     var _t = Math.floor((1000000 * t[0]) + (t[1] / 1000));
                     timers[time.name] = (timers[time.name] || 0) + _t;

--- a/lib/plugins/bodyReader.js
+++ b/lib/plugins/bodyReader.js
@@ -37,10 +37,10 @@ function createBodyWriter(req) {
 
     req.body = new Buffer(0);
     return {
-        write: function (chunk) {
+        write: function write (chunk) {
             buffers.push(chunk);
         },
-        end: function () {
+        end: function end () {
             req.body = Buffer.concat(buffers);
 
             if (isText) {

--- a/lib/plugins/bunyan.js
+++ b/lib/plugins/bunyan.js
@@ -61,7 +61,7 @@ function requestLogger(options) {
         var log = req.log || opts.log;
 
         props.req_id = req.getId();
-        headersToCopy.forEach(function (k) {
+        headersToCopy.forEach(function forEach (k) {
 
             if (req.headers[k]) {
                 props[k] = req.headers[k];

--- a/lib/plugins/cpuUsageThrottle.js
+++ b/lib/plugins/cpuUsageThrottle.js
@@ -137,7 +137,7 @@ function cpuUsageThrottlePlugin (opts) {
     // updateReject should be called on an interval, it checks the average CPU
     // usage between two invocations of updateReject.
     function updateReject() {
-        pidusage.stat(process.pid, function (e, stat) {
+        pidusage.stat(process.pid, function pidusageStat (e, stat) {
             // Requeue an updateReject irrespective of whether or not pidusage
             // encountered an error
             plugin._timeout = setTimeout(updateReject, plugin._interval);
@@ -213,7 +213,7 @@ function cpuUsageThrottlePlugin (opts) {
 
     // Expose internal plugin state for introspection
     Object.defineProperty(cpuUsageThrottle, 'state', {
-        get: function () {
+        get: function get () {
             // We intentionally do not expose ewma since we don't want the user
             // to be able to update it's configuration, the current state of
             // ewma is represented in plugin._cpu

--- a/lib/plugins/fieldedTextBodyParser.js
+++ b/lib/plugins/fieldedTextBodyParser.js
@@ -55,13 +55,13 @@ function fieldedTextParser(options) {
             columns: columns
         };
 
-        csv.parse(req.body, parserOptions, function (err, parsedBody) {
+        csv.parse(req.body, parserOptions, function parse (err, parsedBody) {
             if (err) {
                 return (next(err));
             }
 
             // Add an "index" property to every row
-            parsedBody.forEach(function (row, index) {
+            parsedBody.forEach(function forEach (row, index) {
                 row.index = index;
             });
             req.body = parsedBody;

--- a/lib/plugins/formBodyParser.js
+++ b/lib/plugins/formBodyParser.js
@@ -48,7 +48,7 @@ function urlEncodedBodyParser(options) {
 
             if (opts.mapParams === true) {
                 var keys = Object.keys(params);
-                keys.forEach(function (k) {
+                keys.forEach(function forEach (k) {
                     var p = req.params[k];
 
                     if (p && !override) {

--- a/lib/plugins/fullResponse.js
+++ b/lib/plugins/fullResponse.js
@@ -61,7 +61,7 @@ function setHeaders(req, res) {
  */
 function fullResponse() {
     function restifyResponseHeaders(req, res, next) {
-        res.once('header', function () {
+        res.once('header', function onceHeader () {
 
             // Restify 1.0 compatibility
             if (res.defaultResponseFormatters) {

--- a/lib/plugins/jsonBodyParser.js
+++ b/lib/plugins/jsonBodyParser.js
@@ -55,7 +55,7 @@ function jsonBodyParser(options) {
                 req.params = params;
             } else if (typeof (params) === 'object' && params !== null) {
                 // else, try to merge the objects
-                Object.keys(params).forEach(function (k) {
+                Object.keys(params).forEach(function forEach (k) {
                     var p = req.params[k];
 
                     if (p && !override) {

--- a/lib/plugins/multipartBodyParser.js
+++ b/lib/plugins/multipartBodyParser.js
@@ -84,7 +84,7 @@ function multipartBodyParser(options) {
             }
         };
 
-        return form.parse(req, function (err, fields, files) {
+        return form.parse(req, function parse (err, fields, files) {
             if (err) {
                 return (next(new errors.BadRequestError(err.message)));
             }
@@ -93,7 +93,7 @@ function multipartBodyParser(options) {
             req.files = files;
 
             if (opts.mapParams !== false) {
-                Object.keys(fields).forEach(function (k) {
+                Object.keys(fields).forEach(function forEach (k) {
                     if (req.params[k] && !override) {
                         return;
                     }
@@ -103,33 +103,35 @@ function multipartBodyParser(options) {
 
                 if (opts.mapFiles) {
                     var barrier = vasync.barrier();
-                    barrier.on('drain', function () {
+                    barrier.on('drain', function onDrain () {
                         return next();
                     });
 
                     barrier.start('fs');
-                    Object.keys(files).forEach(function (f) {
+                    Object.keys(files).forEach(function forEach (f) {
                         if (req.params[f] && !override) {
                             return;
                         }
                         barrier.start('fs' + f);
-                        fs.readFile(files[f].path, function (ex, data) {
-                            barrier.done('fs' + f);
-                            /*
-                             * We want to stop the request here, if there's an
-                             * error trying to read the file from disk.
-                             * Ideally we'd like to stop the other oustanding
-                             * file reads too, but there's no way to cancel in
-                             * flight fs reads.  So we just return an error, and
-                             * be grudgingly let the other file reads finish.
-                             */
-                            if (ex) {
-                                return next(new errors.InternalError(ex,
-                                    'unable to read file' + f));
-                            }
-                            req.params[f] = data;
-                            return (true);
-                        });
+                        fs.readFile(files[f].path,
+                            function readFile (ex, data) {
+                                barrier.done('fs' + f);
+                                /*
+                                * We want to stop the request here, if there's 
+                                * an error trying to read the file from disk.
+                                * Ideally we'd like to stop the other oustanding
+                                * file reads too, but there's no way to cancel 
+                                * in flight fs reads.  So we just return an 
+                                * error, and be grudgingly let the other file 
+                                * reads finish.
+                                */
+                                if (ex) {
+                                    return next(new errors.InternalError(ex,
+                                        'unable to read file' + f));
+                                }
+                                req.params[f] = data;
+                                return (true);
+                            });
                     });
                     barrier.done('fs');
                     return (false);

--- a/lib/plugins/query.js
+++ b/lib/plugins/query.js
@@ -58,7 +58,7 @@ function queryParser(options) {
         req.query = qs.parse(req.getQuery(), opts);
 
         if (opts.mapParams === true) {
-            Object.keys(req.query).forEach(function (k) {
+            Object.keys(req.query).forEach(function forEach (k) {
                 if (req.params[k] && !opts.overrideParams) {
                     return;
                 }

--- a/lib/plugins/static.js
+++ b/lib/plugins/static.js
@@ -111,7 +111,7 @@ function serveStatic(options) {
 
         var fstream = fs.createReadStream(file + (isGzip ? '.gz' : ''));
         var maxAge = opts.maxAge === undefined ? 3600 : opts.maxAge;
-        fstream.once('open', function (fd) {
+        fstream.once('open', function onceOpen (fd) {
             res.cache({maxAge: maxAge});
             res.set('Content-Length', stats.size);
             res.set('Content-Type', mime.lookup(file));
@@ -128,22 +128,22 @@ function serveStatic(options) {
             }
             res.writeHead(200);
             fstream.pipe(res);
-            fstream.once('close', function () {
+            fstream.once('close', function onceClose () {
                 next(false);
             });
         });
 
-        res.once('close', function () {
+        res.once('close', function onceClose () {
             fstream.close();
         });
     }
 
     function serveNormal(file, req, res, next) {
-        fs.stat(file, function (err, stats) {
+        fs.stat(file, function fileStat (err, stats) {
             if (!err && stats.isDirectory() && opts.default) {
                 // Serve an index.html page or similar
                 var filePath = path.join(file, opts.default);
-                fs.stat(filePath, function (dirErr, dirStats) {
+                fs.stat(filePath, function dirStat (dirErr, dirStats) {
                     serveFileFromStats(filePath,
                         dirErr,
                         dirStats,
@@ -206,7 +206,7 @@ function serveStatic(options) {
         }
 
         if (opts.gzip && req.acceptsEncoding('gzip')) {
-            fs.stat(file + '.gz', function (err, stats) {
+            fs.stat(file + '.gz', function stat (err, stats) {
                 if (!err) {
                     res.setHeader('Content-Encoding', 'gzip');
                     serveFileFromStats(file,

--- a/lib/plugins/utils/shallowCopy.js
+++ b/lib/plugins/utils/shallowCopy.js
@@ -15,7 +15,7 @@ function shallowCopy(obj) {
         return (obj);
     }
     var copy = {};
-    Object.keys(obj).forEach(function (k) {
+    Object.keys(obj).forEach(function forEach (k) {
         copy[k] = obj[k];
     });
     return (copy);

--- a/lib/request.js
+++ b/lib/request.js
@@ -112,7 +112,7 @@ Request.prototype.accepts = function accepts(types) {
         types = [types];
     }
 
-    types = types.map(function (t) {
+    types = types.map(function map (t) {
         assert.string(t, 'type');
 
         if (t.indexOf('/') === -1) {
@@ -685,7 +685,7 @@ Request.prototype.toString = function toString() {
     var self = this;
     var str;
 
-    Object.keys(this.headers).forEach(function (k) {
+    Object.keys(this.headers).forEach(function forEach (k) {
         headers += sprintf('%s: %s\n', k, self.headers[k]);
     });
 
@@ -763,7 +763,7 @@ Request.prototype.startHandlerTimer = function startHandlerTimer(handlerName) {
 
     self._timerMap[name] = process.hrtime();
 
-    dtrace._rstfy_probes['handler-start'].fire(function () {
+    dtrace._rstfy_probes['handler-start'].fire(function fire () {
         return ([
             self.serverName,
             self._currentRoute, // set in server._run
@@ -802,7 +802,7 @@ Request.prototype.endHandlerTimer = function endHandlerTimer(handlerName) {
         time: self._timerMap[name]
     });
 
-    dtrace._rstfy_probes['handler-done'].fire(function () {
+    dtrace._rstfy_probes['handler-done'].fire(function fire () {
         return ([
             self.serverName,
             self._currentRoute, // set in server._run

--- a/lib/response.js
+++ b/lib/response.js
@@ -389,7 +389,7 @@ Response.prototype.__send = function __send() {
     // Populate our response object with the derived arguments
     self.statusCode = code;
     self._body = body;
-    Object.keys(headers).forEach(function (k) {
+    Object.keys(headers).forEach(function forEach (k) {
         self.setHeader(k, headers[k]);
     });
 
@@ -553,7 +553,7 @@ Response.prototype.set = function set(name, val) {
     } else {
         assert.object(name,
             'res.set(headers) requires headers to be an object');
-        Object.keys(name).forEach(function (k) {
+        Object.keys(name).forEach(function forEach (k) {
             self.set(k, name[k]);
         });
     }
@@ -594,7 +594,7 @@ Response.prototype.toString = function toString() {
     var headerString = '';
     var str;
 
-    Object.keys(headers).forEach(function (k) {
+    Object.keys(headers).forEach(function forEach (k) {
         headerString += k + ': ' + headers[k] + '\n';
     });
     str = sprintf('HTTP/1.1 %s %s\n%s',

--- a/lib/router.js
+++ b/lib/router.js
@@ -70,7 +70,7 @@ function matchURL(re, req) {
     }
 
     // This was the "normal" case, of /foo/:id
-    re.restifyParams.forEach(function (p) {
+    re.restifyParams.forEach(function forEach (p) {
         if (++i < result.length) {
             params[p] = decodeURIComponent(result[i]);
         }
@@ -98,7 +98,7 @@ function compileURL(options) {
     var pattern = '^';
     var re;
     var _url = url.parse(options.url).pathname;
-    _url.split('/').forEach(function (frag) {
+    _url.split('/').forEach(function forEach (frag) {
         if (frag.length <= 0) {
             return (false);
         }
@@ -201,7 +201,7 @@ function Router(options) {
     }
     assert.arrayOfString(this.versions, 'options.versions');
 
-    this.versions.forEach(function (v) {
+    this.versions.forEach(function forEach (v) {
         if (semver.valid(v)) {
             return (true);
         }
@@ -276,7 +276,7 @@ Router.prototype.mount = function mount(options) {
         if (!Array.isArray(type)) {
             type = [type];
         }
-        type.filter(function (t) {
+        type.filter(function filter (t) {
             return (t);
         }).sort().join();
     }
@@ -288,7 +288,7 @@ Router.prototype.mount = function mount(options) {
         versions.sort();
     }
 
-    exists = routes.some(function (r) {
+    exists = routes.some(function some (r) {
         return (r.name === name);
     });
 
@@ -348,12 +348,12 @@ Router.prototype.unmount = function unmount(name) {
 
     var reverse = this.reverse[route.path.source];
     var routes = this.routes[route.method];
-    this.routes[route.method] = routes.filter(function (r) {
+    this.routes[route.method] = routes.filter(function filter (r) {
         return (r.name !== route.name);
     });
 
     if (!this.findByPath(route.spec.path, { method: route.method })) {
-        this.reverse[route.path.source] = reverse.filter(function (r) {
+        this.reverse[route.path.source] = reverse.filter(function filter (r) {
             return (r !== route.method);
         });
 
@@ -365,7 +365,7 @@ Router.prototype.unmount = function unmount(name) {
     delete this.mounts[name];
 
     var cache = this.cache;
-    cache.dump().forEach(function (i) {
+    cache.dump().forEach(function forEach (i) {
         if (i.v.name === name) {
             cache.del(i.k);
         }
@@ -494,7 +494,7 @@ Router.prototype.find = function find(req, res, callback) {
         // If upload and typed
         if (typed) {
             var _t = ct.split(/\s*,\s*/);
-            candidates = candidates.filter(function (c) {
+            candidates = candidates.filter(function  filter(c) {
                 neg = new Negotiator({
                     headers: {
                         accept: c.r.types.join(', ')
@@ -512,7 +512,7 @@ Router.prototype.find = function find(req, res, callback) {
         }
 
         if (versioned) {
-            candidates.forEach(function (c) {
+            candidates.forEach(function forEach (c) {
                 var k = c.r.versions;
                 var v = semver.maxSatisfying(k, req.version());
 
@@ -633,8 +633,8 @@ Router.prototype.toString = function toString() {
     var self = this;
     var str = this.name + ':\n';
 
-    Object.keys(this.routes).forEach(function (k) {
-        var routes = self.routes[k].map(function (r) {
+    Object.keys(this.routes).forEach(function forEach (k) {
+        var routes = self.routes[k].map(function map (r) {
             return (r.name);
         });
 
@@ -654,7 +654,7 @@ Router.prototype.getDebugInfo = function getRoutes() {
     var self = this;
     var routeInfo = [];
 
-    _.forOwn(self.mounts, function (value, routeName) {
+    _.forOwn(self.mounts, function forOwn (value, routeName) {
         if (self.mounts.hasOwnProperty(routeName)) {
             var mountedRoute = self.mounts[routeName];
             var routeRegex = mountedRoute.path;

--- a/lib/server.js
+++ b/lib/server.js
@@ -149,7 +149,7 @@ function Server(options) {
     if (!options.handleUpgrades && PROXY_EVENTS.indexOf('upgrade') === -1) {
         PROXY_EVENTS.push('upgrade');
     }
-    PROXY_EVENTS.forEach(function (e) {
+    PROXY_EVENTS.forEach(function forEach (e) {
         self.server.on(e, self.emit.bind(self, e));
     });
 
@@ -188,16 +188,16 @@ function Server(options) {
         self._handle(req, res);
     });
 
-    this.__defineGetter__('maxHeadersCount', function () {
+    this.__defineGetter__('maxHeadersCount', function getMaxHeadersCount () {
         return (self.server.maxHeadersCount);
     });
 
-    this.__defineSetter__('maxHeadersCount', function (c) {
+    this.__defineSetter__('maxHeadersCount', function setMaxHeadersCount (c) {
         self.server.maxHeadersCount = c;
         return (c);
     });
 
-    this.__defineGetter__('url', function () {
+    this.__defineGetter__('url', function getUrl () {
         if (self.socketPath) {
             return ('http://' + self.socketPath);
         }
@@ -447,7 +447,7 @@ Server.prototype.pre = function pre() {
     var self = this;
     var handlers = Array.prototype.slice.call(arguments);
 
-    argumentsToChain(handlers).forEach(function (h) {
+    argumentsToChain(handlers).forEach(function forEach (h) {
         self.before.push(h);
     });
 
@@ -476,7 +476,7 @@ Server.prototype.use = function use() {
     var self = this;
     var handlers = Array.prototype.slice.call(arguments);
 
-    argumentsToChain(handlers).forEach(function (h) {
+    argumentsToChain(handlers).forEach(function forEach (h) {
         self.chain.push(h);
     });
 
@@ -548,7 +548,7 @@ Server.prototype.versionedUse = function versionedUse(versions, fn) {
     }
     assert.arrayOfString(versions, 'versions');
 
-    versions.forEach(function (v) {
+    versions.forEach(function forEach (v) {
         if (!semver.valid(v)) {
             throw new TypeError('%s is not a valid semver', v);
         }
@@ -686,7 +686,7 @@ Server.prototype.getDebugInfo = function getDebugInfo() {
         // output the actual routes registered with restify
         var routeInfo = self.router.getDebugInfo();
         // get each route's handler chain
-        _.forEach(routeInfo, function (value, key) {
+        _.forEach(routeInfo, function forEach (value, key) {
             var routeName = value.name;
             value.handlers = self.routes[routeName].map(funcNameMapper);
         });
@@ -747,7 +747,7 @@ Server.prototype.toString = function toString() {
     var str = '';
 
     function handlersToString(arr) {
-        var s = '[' + arr.map(function (b) {
+        var s = '[' + arr.map(function map (b) {
             return (b.name || 'function');
         }).join(', ') + ']';
 
@@ -759,7 +759,7 @@ Server.prototype.toString = function toString() {
     str += sprintf(LINE_FMT, 'Pre', handlersToString(this.before));
     str += sprintf(LINE_FMT, 'Router', this.router.toString());
     str += sprintf(LINE_FMT, 'Routes', '');
-    Object.keys(this.routes).forEach(function (k) {
+    Object.keys(this.routes).forEach(function forEach (k) {
         var handlers = handlersToString(self.routes[k]);
         str += sprintf(SUB_LINE_FMT, k, handlers);
     });
@@ -794,7 +794,7 @@ Server.prototype._handle = function _handle(req, res) {
     self.emit('pre', req, res);
 
     function routeAndRun() {
-        self._route(req, res, function (route, context) {
+        self._route(req, res, function _route (route, context) {
             // emit 'routed' event after the req has been routed
             self.emit('routed', req, res, route);
             req.context = req.params = context;
@@ -811,7 +811,7 @@ Server.prototype._handle = function _handle(req, res) {
 
     // run pre() handlers first before routing and running
     if (self.before.length > 0) {
-        self._run(req, res, null, self.before, function (err) {
+        self._run(req, res, null, self.before, function _run (err) {
             // Like with regular handlers, if we are provided an error, we
             // should abort the middleware chain and fire after events.
             if (err === false || err instanceof Error) {
@@ -845,10 +845,11 @@ Server.prototype._route = function _route(req, res, name, cb) {
     // helper function to, when on router error, emit error events and then
     // flush the err.
     var errResponse = function errResponse(err) {
-        return self._emitErrorEvents(req, res, null, err, function () {
-            res.send(err);
-            return self._finishReqResCycle(req, res, null, err);
-        });
+        return self._emitErrorEvents(req, res, null, err,
+            function _emitErrorEvents () {
+                res.send(err);
+                return self._finishReqResCycle(req, res, null, err);
+            });
     };
 
     if (typeof (name) === 'function') {
@@ -876,7 +877,7 @@ Server.prototype._route = function _route(req, res, name, cb) {
             }
         });
     } else {
-        return this.router.get(name, req, function (err, route, ctx) {
+        return this.router.get(name, req, function get (err, route, ctx) {
             if (err) {
                 return errResponse(err);
             } else {
@@ -958,7 +959,7 @@ Server.prototype._run = function _run(req, res, route, chain, cb) {
     req.once('aborted', _requestAborted);
 
     // attach a listener for the response's 'redirect' event
-    res.on('redirect', function (redirectLocation) {
+    res.on('redirect', function onRedirect (redirectLocation) {
         self.emit('redirect', redirectLocation);
     });
 
@@ -999,7 +1000,7 @@ Server.prototype._run = function _run(req, res, route, chain, cb) {
                 // Stop running the rest of this route since we're redirecting.
                 // do this instead of setting done since the route technically
                 // isn't complete yet.
-                return self._route(req, res, arg, function (r, ctx) {
+                return self._route(req, res, arg, function _route (r, ctx) {
                     req.context = req.params = ctx;
                     req.route = r.spec;
 
@@ -1057,7 +1058,7 @@ Server.prototype._run = function _run(req, res, route, chain, cb) {
 
         // if we have reached this last section of next(), then we are 'done'
         // with this route.
-        dtrace._rstfy_probes['route-done'].fire(function () {
+        dtrace._rstfy_probes['route-done'].fire(function fire () {
             return ([
                 self.name,
                 route !== null ? route.name : 'pre',
@@ -1092,7 +1093,7 @@ Server.prototype._run = function _run(req, res, route, chain, cb) {
 
     var n1 = self._once(next);
 
-    dtrace._rstfy_probes['route-start'].fire(function () {
+    dtrace._rstfy_probes['route-start'].fire(function fire () {
         return ([
             self.name,
             route !== null ? route.name : 'pre',
@@ -1206,7 +1207,8 @@ function _emitErrorEvents(req, res, route, err, cb) {
                 return vasyncCb();
             });
         }
-    }, function (nullErr, results) { // eslint-disable-line handle-callback-err
+    // eslint-disable-next-line handle-callback-err
+    }, function onResult (nullErr, results) {
         // vasync will never return error here. callback with the original
         // error to pass it on.
         return cb(err);
@@ -1365,9 +1367,9 @@ function mergeFormatters(fmt) {
     Object.keys(formatters).forEach(addFormatter.bind(this, formatters));
     Object.keys(fmt || {}).forEach(addFormatter.bind(this, fmt || {}));
 
-    arr = arr.sort(function (a, b) {
+    arr = arr.sort(function sort (a, b) {
         return (b.q - a.q);
-    }).map(function (a) {
+    }).map(function map (a) {
         return (a.t);
     });
 
@@ -1459,7 +1461,7 @@ function errEvtNameFromError(err) {
  * @returns {Function}
  */
 function serverMethodFactory (method) {
-    return function (opts) {
+    return function serverMethod (opts) {
         if (opts instanceof RegExp || typeof (opts) === 'string') {
             opts = {
                 path: opts

--- a/lib/upgrade.js
+++ b/lib/upgrade.js
@@ -99,11 +99,11 @@ util.inherits(ServerUpgradeResponse, EventEmitter);
  */
 function notImplemented(method) {
     if (!method.throws) {
-        return function () {
+        return function returns () {
             return (method.returns);
         };
     } else {
-        return function () {
+        return function throws () {
             throw (new Error('Method ' + method.name + ' is not ' +
                 'implemented!'));
         };
@@ -128,7 +128,7 @@ var NOT_IMPLEMENTED = [
 ];
 
 // programatically add a bunch of methods to the ServerUpgradeResponse proto
-NOT_IMPLEMENTED.forEach(function (method) {
+NOT_IMPLEMENTED.forEach(function forEach (method) {
     ServerUpgradeResponse.prototype[method.name] = notImplemented(method);
 });
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -14,7 +14,7 @@ function shallowCopy(obj) {
         return (obj);
     }
     var copy = {};
-    Object.keys(obj).forEach(function (k) {
+    Object.keys(obj).forEach(function forEach (k) {
         copy[k] = obj[k];
     });
     return (copy);
@@ -36,7 +36,7 @@ function mergeQs(obj1, obj2) {
 
     // defend against null cause null is an object. yay js.
     if (obj2 && typeof (obj2) === 'object') {
-        Object.keys(obj2).forEach(function (key) {
+        Object.keys(obj2).forEach(function forEach (key) {
             // if we already have this key and it isn't an array,
             // make it one array of the same element.
             if (merged.hasOwnProperty(key) && !(merged[key] instanceof Array)) {

--- a/test/formatter.test.js
+++ b/test/formatter.test.js
@@ -1,6 +1,7 @@
 // Copyright 2012 Mark Cavage, Inc.  All rights reserved.
 
 'use strict';
+/* eslint-disable func-names */
 
 var restifyClients = require('restify-clients');
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,6 +1,7 @@
 // Copyright 2012 Mark Cavage, Inc.  All rights reserved.
 
 'use strict';
+/* eslint-disable func-names */
 
 var httpDate = require('../lib/http_date');
 

--- a/test/lib/helper.js
+++ b/test/lib/helper.js
@@ -5,6 +5,7 @@
 //
 
 'use strict';
+/* eslint-disable func-names */
 
 var domain = require('domain');
 

--- a/test/lib/server-withDisableUncaughtException.js
+++ b/test/lib/server-withDisableUncaughtException.js
@@ -3,6 +3,7 @@
 // and sends back the server's bound port number.
 
 'use strict';
+/* eslint-disable func-names */
 
 var restify = require('../../lib');
 

--- a/test/plugins/accept.test.js
+++ b/test/plugins/accept.test.js
@@ -1,4 +1,5 @@
 'use strict';
+/* eslint-disable func-names */
 
 // external requires
 var assert = require('chai').assert;

--- a/test/plugins/audit.test.js
+++ b/test/plugins/audit.test.js
@@ -1,4 +1,5 @@
 'use strict';
+/* eslint-disable func-names */
 
 // runtime modules
 var PassThrough = require('stream').PassThrough;

--- a/test/plugins/authorization.test.js
+++ b/test/plugins/authorization.test.js
@@ -1,4 +1,5 @@
 'use strict';
+/* eslint-disable func-names */
 
 // external requires
 var assert = require('chai').assert;

--- a/test/plugins/bodyReader.js
+++ b/test/plugins/bodyReader.js
@@ -1,4 +1,5 @@
 'use strict';
+/* eslint-disable func-names */
 
 // core requires
 

--- a/test/plugins/conditionalRequest.test.js
+++ b/test/plugins/conditionalRequest.test.js
@@ -1,4 +1,5 @@
 'use strict';
+/* eslint-disable func-names */
 
 // external requires
 var assert = require('chai').assert;

--- a/test/plugins/context.test.js
+++ b/test/plugins/context.test.js
@@ -1,4 +1,5 @@
 'use strict';
+/* eslint-disable func-names */
 
 // external requires
 var assert = require('chai').assert;

--- a/test/plugins/cpuUsageThrottle.test.js
+++ b/test/plugins/cpuUsageThrottle.test.js
@@ -1,4 +1,5 @@
 'use strict';
+/* eslint-disable func-names */
 
 var assert = require('chai').assert;
 var proxyquire = require('proxyquire');

--- a/test/plugins/dedupeSlashes.js
+++ b/test/plugins/dedupeSlashes.js
@@ -1,4 +1,5 @@
 'use strict';
+/* eslint-disable func-names */
 
 // external requires
 var assert = require('chai').assert;

--- a/test/plugins/fieldedTextParser.test.js
+++ b/test/plugins/fieldedTextParser.test.js
@@ -1,4 +1,5 @@
 'use strict';
+/* eslint-disable func-names */
 
 // core requires
 var fs = require('fs');

--- a/test/plugins/formBodyParser.test.js
+++ b/test/plugins/formBodyParser.test.js
@@ -1,4 +1,5 @@
 'use strict';
+/* eslint-disable func-names */
 
 // core requires
 var http = require('http');

--- a/test/plugins/gzip.test.js
+++ b/test/plugins/gzip.test.js
@@ -1,4 +1,5 @@
 'use strict';
+/* eslint-disable func-names */
 
 // external requires
 var assert = require('chai').assert;

--- a/test/plugins/inflightRequestThrottle.test.js
+++ b/test/plugins/inflightRequestThrottle.test.js
@@ -1,4 +1,5 @@
 'use strict';
+/* eslint-disable func-names */
 
 var assert = require('chai').assert;
 var restify = require('../../lib/index.js');

--- a/test/plugins/jsonBodyParser.test.js
+++ b/test/plugins/jsonBodyParser.test.js
@@ -1,4 +1,5 @@
 'use strict';
+/* eslint-disable func-names */
 
 // core requires
 var net = require('net');

--- a/test/plugins/metrics.test.js
+++ b/test/plugins/metrics.test.js
@@ -1,4 +1,5 @@
 'use strict';
+/* eslint-disable func-names */
 
 // external requires
 var assert = require('chai').assert;

--- a/test/plugins/multipart.test.js
+++ b/test/plugins/multipart.test.js
@@ -1,4 +1,5 @@
 'use strict';
+/* eslint-disable func-names */
 
 // core requires
 var http = require('http');

--- a/test/plugins/oauth2.test.js
+++ b/test/plugins/oauth2.test.js
@@ -1,6 +1,7 @@
 // Copyright 2016 Brian Aabel, Inc.  All rights reserved.
 
 'use strict';
+/* eslint-disable func-names */
 
 var http = require('http');
 // external requires

--- a/test/plugins/plugins.test.js
+++ b/test/plugins/plugins.test.js
@@ -1,6 +1,7 @@
 // Copyright 2012 Mark Cavage, Inc.  All rights reserved.
 
 'use strict';
+/* eslint-disable func-names */
 
 // external requires
 var assert = require('chai').assert;

--- a/test/plugins/query.test.js
+++ b/test/plugins/query.test.js
@@ -1,4 +1,5 @@
 'use strict';
+/* eslint-disable func-names */
 
 // external requires
 var assert = require('chai').assert;

--- a/test/plugins/reqIdHeaders.test.js
+++ b/test/plugins/reqIdHeaders.test.js
@@ -1,4 +1,5 @@
 'use strict';
+/* eslint-disable func-names */
 
 // external modules
 var assert = require('chai').assert;

--- a/test/plugins/requestExpiry.test.js
+++ b/test/plugins/requestExpiry.test.js
@@ -1,4 +1,5 @@
 'use strict';
+/* eslint-disable func-names */
 
 // external modules
 var assert = require('chai').assert;

--- a/test/plugins/static.test.js
+++ b/test/plugins/static.test.js
@@ -1,4 +1,5 @@
 'use strict';
+/* eslint-disable func-names */
 
 // core requires
 var fs = require('fs');

--- a/test/plugins/strictQueryParams.test.js
+++ b/test/plugins/strictQueryParams.test.js
@@ -1,4 +1,5 @@
 'use strict';
+/* eslint-disable func-names */
 
 // external requires
 var assert = require('chai').assert;

--- a/test/plugins/throttle.test.js
+++ b/test/plugins/throttle.test.js
@@ -1,6 +1,7 @@
 // Copyright 2012 Mark Cavage, Inc.  All rights reserved.
 
 'use strict';
+/* eslint-disable func-names */
 
 var assert = require('chai').assert;
 var restify = require('../../lib/index.js');

--- a/test/plugins/userAgent.js
+++ b/test/plugins/userAgent.js
@@ -1,4 +1,5 @@
 'use strict';
+/* eslint-disable func-names */
 
 // core requires
 var child_process = require('child_process');

--- a/test/plugins/utilsHrTimeDurationInMs.test.js
+++ b/test/plugins/utilsHrTimeDurationInMs.test.js
@@ -1,4 +1,5 @@
 'use strict';
+/* eslint-disable func-names */
 
 var assert = require('chai').assert;
 var hrTimeDurationInMs =

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -1,4 +1,5 @@
 'use strict';
+/* eslint-disable func-names */
 
 var restifyClients = require('restify-clients');
 var validator = require('validator');

--- a/test/response.test.js
+++ b/test/response.test.js
@@ -1,4 +1,5 @@
 'use strict';
+/* eslint-disable func-names */
 
 var url = require('url');
 var restifyClients = require('restify-clients');

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -1,6 +1,7 @@
 // Copyright 2012 Mark Cavage, Inc.  All rights reserved.
 
 'use strict';
+/* eslint-disable func-names */
 
 var restify = require('../lib');
 var clients = require('restify-clients');

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,6 +1,7 @@
 // Copyright 2012 Mark Cavage, Inc.  All rights reserved.
 
 'use strict';
+/* eslint-disable func-names */
 
 var assert = require('assert-plus');
 var bunyan = require('bunyan');

--- a/test/upgrade.test.js
+++ b/test/upgrade.test.js
@@ -2,6 +2,7 @@
 // vim: set ts=8 sts=8 sw=8 et:
 
 'use strict';
+/* eslint-disable func-names */
 
 var restifyClients = require('restify-clients');
 var Watershed = require('watershed').Watershed;

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,4 +1,5 @@
 'use strict';
+/* eslint-disable func-names */
 
 var mergeQs = require('../lib/utils').mergeQs;
 

--- a/tools/docsBuild.js
+++ b/tools/docsBuild.js
@@ -89,12 +89,12 @@ function build (options) {
         shallow: true,
         config: options.config
     })
-        .then(function (docs) {
+        .then(function docsFormat (docs) {
             return documentation.formats.md(docs, {
                 markdownToc: true
             });
         })
-        .then(function (docsContent) {
+        .then(function docsWrite (docsContent) {
             var output = util.format(JEKYLL_HEADER_TEMPLATE, options.title,
                 options.permalink, docsContent);
 
@@ -104,11 +104,11 @@ function build (options) {
 
 // eslint-disable-next-line
 Promise.all(docsConfig.map(build))
-    .then(function (res) {
+    .then(function onSucceed (res) {
         console.log('Docs built');
         process.exit(0);
     })
-    .catch(function (err) {
+    .catch(function onError (err) {
         console.error(err);
         process.exit(1);
     });


### PR DESCRIPTION
## Pre-Submission Checklist

- [ ] Opened an issue discussing these changes before opening the PR
- [x] Ran the linter and tests via `make prepush`
- [x] Included comprehensive and convincing tests for changes

Forbids and refactors anonymous functions.

Anonymus functions make debugging harder with stack traces, however, I've to admit that this ESLint rule is a little bit too aggressive as anonymous `map`, `sort`, `forEach` etc. functions don't decrease observability in stack-traces.

# Changes

- ESLint rule to forbid anonymous functions
- Refactor `lib` code to avoid anonymous functions 
- Add disable rule to test files
