### PR TITLE
Fix broken EADDRNOTAVAIL on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ node_js:
    - "7"
    - "8"
    - "stable"
+env:
+  - TEST_SKIP_IP_V6=true
 notifications:
   webhooks:
     urls:

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -28,10 +28,15 @@ var after = helper.after;
 var before = helper.before;
 var test = helper.test;
 
+var SKIP_IP_V6 = !!process.env.TEST_SKIP_IP_V6;
 var PORT = process.env.UNIT_TEST_PORT || 0;
 var CLIENT;
 var FAST_CLIENT;
 var SERVER;
+
+if (SKIP_IP_V6) {
+    console.warning('IPv6 tests are skipped: No IPv6 network is available');
+}
 
 ///--- Tests
 
@@ -108,18 +113,21 @@ test('listen and close (socketPath)', function(t) {
     });
 });
 
-test('gh-751 IPv4/IPv6 server URL', function(t) {
-    t.equal(SERVER.url, 'http://127.0.0.1:' + PORT, 'ipv4 url');
+// Run IPv6 tests only if IPv6 network is available
+if (!SKIP_IP_V6) {
+    test('gh-751 IPv4/IPv6 server URL', function(t) {
+        t.equal(SERVER.url, 'http://127.0.0.1:' + PORT, 'ipv4 url');
 
-    var server = restify.createServer();
-    server.listen(PORT + 1, '::1', function() {
-        t.equal(server.url, 'http://[::1]:' + (PORT + 1), 'ipv6 url');
+        var server = restify.createServer();
+        server.listen(PORT + 1, '::1', function() {
+            t.equal(server.url, 'http://[::1]:' + (PORT + 1), 'ipv6 url');
 
-        server.close(function() {
-            t.end();
+            server.close(function() {
+                t.end();
+            });
         });
     });
-});
+}
 
 test('get (path only)', function(t) {
     var r = SERVER.get('/foo/:id', function echoId(req, res, next) {


### PR DESCRIPTION
## Issues

Closes:

* https://github.com/restify/node-restify/issues/1545

TravisCI trusty lacks IPv6 support and breaks with `EADDRNOTAVAIL`

# Changes

- Add `TEST_SKIP_IP_V6` environment variable to skip IPv6 tests on TravisCI

