### PR TITLE
chore(makefile): improve feedback

### DIFF
--- a/tools/mk/Makefile.targ
+++ b/tools/mk/Makefile.targ
@@ -128,11 +128,11 @@ check-eslint::
 
 .PHONY: check-lint
 check-lint::
-	NO_STYLE=true $(ESLINT) $(JS_FILES)
+	@(echo 'Running "make check-lint"'; NO_STYLE=true $(ESLINT) $(JS_FILES))
 
 .PHONY: check-style
 check-style::
-	NO_LINT=true $(ESLINT) $(JS_FILES)
+	 @(echo 'Running "make check-style"'; NO_LINT=true $(ESLINT) $(JS_FILES) || (echo 'Run "make fix-style" to auto-fix styling issues'; exit 1))
 
 .PHONY: fix-style
 fix-style::


### PR DESCRIPTION
Improve linting and style checking feedbacks in the makefile.

## Example output

```sh
$ make prepush
Running "make check-lint"

/Users/pmarton/Documents/dev/node-restify/lib/formatters/text.js
  23:5  warning  Unexpected 'todo' comment  no-warning-comments

/Users/pmarton/Documents/dev/node-restify/lib/plugins/conditionalRequest.js
  109:9  warning  Unexpected 'todo' comment  no-warning-comments

/Users/pmarton/Documents/dev/node-restify/lib/server.js
  866:17  warning  Unexpected 'todo' comment  no-warning-comments

/Users/pmarton/Documents/dev/node-restify/test/server.test.js
  2204:21  warning  Unexpected 'todo' comment  no-warning-comments

✖ 4 problems (0 errors, 4 warnings)

Running "make check-style"

/Users/pmarton/Documents/dev/node-restify/test/server.test.js
  19:32  error  Insert `;`  prettier/prettier

✖ 1 problem (1 error, 0 warnings)
  1 error, 0 warnings potentially fixable with the `--fix` option.

Run "make fix-style" to auto-fix styling issues
make: *** [check-style] Error 1
```
