### PR TITLE
test(server): fix ERR_SERVER_ALREADY_LISTEN issue with Node v9.0.0

### DIFF
--- a/test/plugins/query.test.js
+++ b/test/plugins/query.test.js
@@ -225,12 +225,10 @@ describe('query parser', function() {
             res.send(req.params);
         });
 
-        SERVER.listen(8080, function() {
-            CLIENT.get('/hello/foo/?bar=baz', function(err, _, __, obj) {
-                assert.ifError(err);
-                assert.deepEqual(obj, { name: 'foo', bar: 'baz' });
-                done();
-            });
+        CLIENT.get('/hello/foo/?bar=baz', function(err, _, __, obj) {
+            assert.ifError(err);
+            assert.deepEqual(obj, { name: 'foo', bar: 'baz' });
+            done();
         });
     });
 
@@ -245,12 +243,10 @@ describe('query parser', function() {
             res.send(req.params);
         });
 
-        SERVER.listen(8080, function() {
-            CLIENT.get('/?bar=baz', function(err, _, __, obj) {
-                assert.ifError(err);
-                assert.deepEqual(obj, { bar: 'baz' });
-                done();
-            });
+        CLIENT.get('/?bar=baz', function(err, _, __, obj) {
+            assert.ifError(err);
+            assert.deepEqual(obj, { bar: 'baz' });
+            done();
         });
     });
 });

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1229,18 +1229,16 @@ test('GH-652 throw InvalidVersion on version mismatch', function(t) {
         return res.send(req.route.version);
     }
     SERVER.get({ path: '/ping', version: '1.0.1' }, response);
-    SERVER.listen(0, '127.0.0.1', function() {
-        var opts = {
-            path: '/ping',
-            headers: {
-                'accept-version': '1.0.2'
-            }
-        };
-        CLIENT.get(opts, function(err, req, res, data) {
-            t.equal(res.statusCode, 400);
-            t.equal(data.code, 'InvalidVersion');
-            t.done();
-        });
+    var opts = {
+        path: '/ping',
+        headers: {
+            'accept-version': '1.0.2'
+        }
+    };
+    CLIENT.get(opts, function(err, req, res, data) {
+        t.equal(res.statusCode, 400);
+        t.equal(data.code, 'InvalidVersion');
+        t.done();
     });
 });
 
@@ -1249,18 +1247,16 @@ test('GH-652 throw InvalidVersion on non-versioned route', function(t) {
         return res.send(req.route.version);
     }
     SERVER.get({ path: '/ping' }, response);
-    SERVER.listen(0, '127.0.0.1', function() {
-        var opts = {
-            path: '/ping',
-            headers: {
-                'accept-version': '1.0.1'
-            }
-        };
-        CLIENT.get(opts, function(err, req, res, data) {
-            t.equal(res.statusCode, 400);
-            t.equal(data.code, 'InvalidVersion');
-            t.done();
-        });
+    var opts = {
+        path: '/ping',
+        headers: {
+            'accept-version': '1.0.1'
+        }
+    };
+    CLIENT.get(opts, function(err, req, res, data) {
+        t.equal(res.statusCode, 400);
+        t.equal(data.code, 'InvalidVersion');
+        t.done();
     });
 });
 
@@ -1380,38 +1376,36 @@ test('content-type routing vendor', function(t) {
         }
     );
 
-    SERVER.listen(8080, function() {
-        var _done = 0;
+    var _done = 0;
 
-        function done() {
-            if (++_done === 2) {
-                t.end();
-            }
+    function done() {
+        if (++_done === 2) {
+            t.end();
         }
+    }
 
-        var opts = {
-            path: '/',
-            headers: {
-                'content-type': 'application/vnd.joyent.com.foo+json'
-            }
-        };
-        CLIENT.post(opts, {}, function(err, _, res) {
-            t.ifError(err);
-            t.equal(res.statusCode, 201);
-            done();
-        });
+    var opts = {
+        path: '/',
+        headers: {
+            'content-type': 'application/vnd.joyent.com.foo+json'
+        }
+    };
+    CLIENT.post(opts, {}, function(err, _, res) {
+        t.ifError(err);
+        t.equal(res.statusCode, 201);
+        done();
+    });
 
-        var opts2 = {
-            path: '/',
-            headers: {
-                'content-type': 'application/vnd.joyent.com.bar+json'
-            }
-        };
-        CLIENT.post(opts2, {}, function(err, _, res) {
-            t.ifError(err);
-            t.equal(res.statusCode, 202);
-            done();
-        });
+    var opts2 = {
+        path: '/',
+        headers: {
+            'content-type': 'application/vnd.joyent.com.bar+json'
+        }
+    };
+    CLIENT.post(opts2, {}, function(err, _, res) {
+        t.ifError(err);
+        t.equal(res.statusCode, 202);
+        done();
     });
 });
 


### PR DESCRIPTION
## Pre-Submission Checklist

- [x] Ran the linter and tests via `make prepush`
- [x] Included comprehensive and convincing tests for changes

Node v9.0.0 doesn't allow to call server.listen() multiple times.
(It's not clear why it was necessary earlier)

See: https://nodejs.org/api/errors.html#errors_err_server_already_listen

# Changes

- remove duplicated server.listen() calls from tests
