### PR TITLE
docs(index): add createServer missing http2 option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -43,6 +43,8 @@ require('./errorTypes');
  * response header, default is `restify`. Pass empty string to unset the header.
  * @param {Object} [options.spdy] - Any options accepted by
  * [node-spdy](https://github.com/indutny/node-spdy).
+ * @param {Object} [options.http2] - Any options accepted by
+ * [http2.createSecureServer](https://nodejs.org/api/http2.html).
  * @param {Boolean} [options.handleUpgrades=false] - Hook the `upgrade` event
  * from the node HTTP server, pushing `Connection: Upgrade` requests through the
  *  regular request handling chain.


### PR DESCRIPTION
Docs: add createServer missing http2 option

# Changes

> Docs: add createServer missing http2 option
