### PR TITLE
BREAKING CHANGE: dropping Node.js support < v4.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,15 @@
 sudo: false
 language: node_js
 node_js:
-   - "4"
-   - "6"
-   - "7"
-   - "8"
-   - "stable"
+   - "4"                    # Maintenance LTS release
+   - "lts/*"                # Active LTS release
+   - "node"                 # Latest stable release
 env:
-  - TEST_SKIP_IP_V6=true
+  - TEST_SKIP_IP_V6=true    # Current TravisCI (trusty) doesn't support IPv6
 notifications:
   webhooks:
     urls:
       - https://webhooks.gitter.im/e/4a4dea774d3ac86cfef1
-    on_success: change  # options: [always|never|change] default: always
-    on_failure: always  # options: [always|never|change] default: always
-    on_start: false     # default: false
+    on_success: change      # options: [always|never|change] default: always
+    on_failure: always      # options: [always|never|change] default: always
+    on_start: false         # default: false

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "report-latency": "./bin/report-latency"
   },
   "engines": {
-    "node": ">=0.10"
+    "node": ">=4.0"
   },
   "dependencies": {
     "assert-plus": "^1.0.0",


### PR DESCRIPTION
Drop Node.js support below `v4.0.0`.
Revisit TravisCI Node.js versions, only keep the supported releases: 

- Maintenance LTS (4.x)
- Current LTS
- Latest release

# Changes

- package.json engines
- TravisCI config
