### PR TITLE
Performance improvement: benchmark suite and accept content-type optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ nbproject
 deps/javascriptlint
 deps/jsstyle
 package-lock.json
+benchmark/results

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,12 @@ make docs-build
 
 To add a new page, simply give it a [permalink](https://github.com/restify/node-restify/blob/94fe715173ffcebd8814bed7e17a22a24fac4ae8/docs/index.md) and then update [docs.yml](https://github.com/restify/restify.github.io/blob/master/_data/docs.yml) with the new permalink.
 
+## Running a benchmark
+
+```
+make benchmark
+```
+
 ## Cutting a release
 
 Cutting a release is currently a manual process. We use a [Conventional Changelog](http://conventionalcommits.org/) to simplify the process of managing semver on this project. Generally, the following series of commands will cut a release from the `master` branch:

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ NODEUNIT	:= ./node_modules/.bin/nodeunit
 MOCHA		:= ./node_modules/.bin/mocha
 NODECOVER	:= ./node_modules/.bin/cover
 DOCS_BUILD	:= ./tools/docsBuild.js
+BENCHMARK	:= ./benchmark/index.js
 NPM		:= npm
 NODE		:= node
 PRETTIER		:= ./node_modules/.bin/prettier
@@ -70,6 +71,10 @@ nsp: node_modules $(NSP)
 .PHONY: docs-build
 docs-build:
 	@($(NODE) $(DOCS_BUILD))
+
+.PHONY: benchmark
+benchmark:
+		@($(NODE) $(BENCHMARK))
 
 include ./tools/mk/Makefile.deps
 include ./tools/mk/Makefile.targ

--- a/benchmark/benchmarks/response-json.js
+++ b/benchmark/benchmarks/response-json.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var restify = process.argv.includes('version=head')
+    ? require('../../lib')
+    : require('restify');
+
+var server = restify.createServer();
+
+server.get('/', function onRequest(req, res) {
+    res.send({ hello: 'world' });
+});
+
+server.listen(3000);

--- a/benchmark/benchmarks/response-text.js
+++ b/benchmark/benchmarks/response-text.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var restify = process.argv.includes('version=head')
+    ? require('../../lib')
+    : require('restify');
+
+var server = restify.createServer();
+
+server.get('/', function onRequest(req, res) {
+    res.send('hello world');
+});
+
+server.listen(3000);

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+'use strict';
+
+var inquirer = require('inquirer');
+var bench = require('./lib/bench');
+
+var BENCHMARKS = ['response-json', 'response-text'];
+
+function select(callback) {
+    var choices = BENCHMARKS.map(function map(name) {
+        return {
+            name: name,
+            checked: true
+        };
+    });
+
+    choices.unshift(new inquirer.Separator(' = The usual ='));
+
+    inquirer
+        .prompt([
+            {
+                type: 'checkbox',
+                message: 'Select packages',
+                name: 'list',
+                choices: choices,
+                validate: function validate(answer) {
+                    if (answer.length < 1) {
+                        return 'You must choose at least one package.';
+                    }
+                    return true;
+                }
+            }
+        ])
+        .then(function onPrompted(answers) {
+            callback(answers.list);
+        });
+}
+
+inquirer
+    .prompt([
+        {
+            type: 'confirm',
+            name: 'track',
+            message: 'Do you want to track progress?',
+            default: false
+        },
+        {
+            type: 'confirm',
+            name: 'compare',
+            message: 'Do you want to compare HEAD with latest release?',
+            default: true
+        },
+        {
+            type: 'confirm',
+            name: 'all',
+            message: 'Do you want to run all benchmark tests?',
+            default: true
+        },
+        {
+            type: 'input',
+            name: 'connection',
+            message: 'How many connection you need?',
+            default: 100,
+            validate: function validate(value) {
+                return (
+                    !Number.isNaN(parseFloat(value)) || 'Please enter a number'
+                );
+            },
+            filter: Number
+        },
+        {
+            type: 'input',
+            name: 'pipelining',
+            message: 'How many pipelining you need?',
+            default: 10,
+            validate: function validate(value) {
+                return (
+                    !Number.isNaN(parseFloat(value)) || 'Please enter a number'
+                );
+            },
+            filter: Number
+        },
+        {
+            type: 'input',
+            name: 'duration',
+            message: 'How long does it takes?',
+            default: 30,
+            validate: function validate(value) {
+                return (
+                    !Number.isNaN(parseFloat(value)) || 'Please enter a number'
+                );
+            },
+            filter: Number
+        }
+    ])
+    .then(function validate(opts) {
+        if (!opts.all) {
+            select(function onSelected(list) {
+                bench(opts, list);
+            });
+        } else {
+            bench(opts, BENCHMARKS);
+        }
+    });

--- a/benchmark/lib/autocannon.js
+++ b/benchmark/lib/autocannon.js
@@ -1,0 +1,76 @@
+'use strict';
+
+var autocannon = require('autocannon');
+var fs = require('fs');
+var autocannonCompare = require('autocannon-compare');
+var path = require('path');
+
+var resultsDirectory = path.join(__dirname, '../results');
+
+function writeResult(handler, version, result) {
+    try {
+        fs.accessSync(resultsDirectory);
+    } catch (e) {
+        fs.mkdirSync(resultsDirectory);
+    }
+
+    result.server = handler;
+
+    var dest = path.join(resultsDirectory, handler + '-' + version + '.json');
+    return fs.writeFileSync(dest, JSON.stringify(result, null, 4));
+}
+
+function fire(opts, handler, version, save, cb) {
+    opts = opts || {};
+    opts.url = 'http://localhost:3000';
+
+    var instance = autocannon(opts, function onResult(err, result) {
+        if (err) {
+            cb(err);
+            return;
+        }
+
+        if (save) {
+            writeResult(handler, version, result);
+        }
+
+        cb();
+    });
+
+    if (opts.track && save) {
+        autocannon.track(instance);
+    }
+}
+
+function compare(handler) {
+    var resStable = require(resultsDirectory + '/' + handler + '-stable.json');
+    var resHead = require(resultsDirectory + '/' + handler + '-head.json');
+    var comp = autocannonCompare(resStable, resHead);
+    var result = {
+        throughput: {
+            significant: comp.throughput.significant
+        }
+    };
+
+    if (comp.equal) {
+        result.throughput.equal = true;
+    } else if (comp.aWins) {
+        result.throughput.equal = false;
+        result.throughput.wins = 'stable';
+        result.throughput.diff = comp.throughput.difference;
+    } else {
+        result.throughput.equal = false;
+        result.throughput.wins = 'head';
+        result.throughput.diff = autocannonCompare(
+            resHead,
+            resStable
+        ).throughput.difference;
+    }
+
+    return result;
+}
+
+module.exports = {
+    fire: fire,
+    compare: compare
+};

--- a/benchmark/lib/bench.js
+++ b/benchmark/lib/bench.js
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+'use strict';
+
+var fork = require('child_process').fork;
+var ora = require('ora');
+var path = require('path');
+var autocannon = require('./autocannon');
+var pipeline = require('vasync').pipeline;
+
+function runBenchmark(opts, handler, version, cb) {
+    if (opts.track) {
+        console.log(version.toUpperCase() + ':');
+    }
+
+    var spinner = ora('Started ' + version + '/' + handler).start();
+    var modulePath = path.join(__dirname, '../benchmarks', handler);
+    var forked = fork(modulePath, ['version=' + version]);
+
+    pipeline(
+        {
+            funcs: [
+                function warm(_, callback) {
+                    spinner.color = 'magenta';
+                    spinner.text =
+                        'Warming ' + version + '/' + handler + ' for 5s';
+
+                    autocannon.fire(
+                        Object.assign({}, opts, { duration: 5 }),
+                        handler,
+                        version,
+                        false,
+                        callback
+                    );
+                },
+
+                function benchmark(_, callback) {
+                    if (opts.track) {
+                        spinner.stop();
+                    } else {
+                        spinner.color = 'yellow';
+                        spinner.text =
+                            'Benchmarking ' +
+                            version +
+                            '/' +
+                            handler +
+                            ' for ' +
+                            opts.duration +
+                            's';
+                    }
+
+                    autocannon.fire(opts, handler, version, true, callback);
+                }
+            ]
+        },
+        function onPipelineFinished(err) {
+            forked.kill('SIGINT');
+
+            if (err) {
+                spinner.fail();
+                cb(err);
+                return;
+            }
+
+            spinner.text = 'Results saved for ' + version + '/' + handler;
+            spinner.succeed();
+
+            cb();
+        }
+    );
+}
+
+function start(opts, list, index) {
+    index = index || 0;
+
+    // No more item
+    if (list.length === index) {
+        return;
+    }
+
+    var handler = list[index];
+    console.log('---- ' + handler + ' ----');
+
+    pipeline(
+        {
+            funcs: [
+                function head(_, callback) {
+                    runBenchmark(opts, handler, 'head', callback);
+                },
+                function stable(_, callback) {
+                    if (!opts.compare) {
+                        callback();
+                        return;
+                    }
+                    runBenchmark(opts, handler, 'stable', callback);
+                }
+            ]
+        },
+        function onPipelineFinished(err) {
+            if (err) {
+                console.log(err);
+                return;
+            }
+
+            // Compare versions
+            if (opts.compare) {
+                var result = autocannon.compare(handler);
+
+                console.log(handler + ' throughput:');
+                console.log(JSON.stringify(result.throughput, null, 4) + '\n');
+            }
+
+            // Benchmark next handler
+            start(opts, list, ++index);
+        }
+    );
+}
+
+module.exports = start;

--- a/lib/response.js
+++ b/lib/response.js
@@ -74,7 +74,7 @@ function patch(Response) {
             type += ', max-age=' + options.maxAge;
         }
 
-        return this.header('Cache-Control', type);
+        return this.setHeader('Cache-Control', type);
     };
 
     /**
@@ -88,13 +88,13 @@ function patch(Response) {
      */
     Response.prototype.noCache = function noCache() {
         // HTTP 1.1
-        this.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+        this.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
 
         // HTTP 1.0
-        this.header('Pragma', 'no-cache');
+        this.setHeader('Pragma', 'no-cache');
 
         // Proxies
-        this.header('Expires', '0');
+        this.setHeader('Expires', '0');
 
         return this;
     };
@@ -248,10 +248,7 @@ function patch(Response) {
      * res.send({hello: 'world'});
      */
     Response.prototype.json = function json(code, body, headers) {
-        if (!/application\/json/.test(this.header('content-type'))) {
-            this.header('Content-Type', 'application/json');
-        }
-
+        this.setHeader('Content-Type', 'application/json');
         return this.send(code, body, headers);
     };
 

--- a/lib/response.js
+++ b/lib/response.js
@@ -5,6 +5,7 @@
 var http = require('http');
 var sprintf = require('util').format;
 var url = require('url');
+var util = require('util');
 
 var assert = require('assert-plus');
 var mime = require('mime');
@@ -491,6 +492,12 @@ function patch(Response) {
 
         var formatter;
         var type = self.contentType || self.getHeader('Content-Type');
+
+        // Set Content-Type to application/json when
+        // res.send is called with an Object instead of calling res.json
+        if (!type && typeof body === 'object' && !util.isBuffer(body)) {
+            type = 'application/json';
+        }
 
         // Derive type if not provided by the user
         type = type || self.req.accepts(self.acceptable);

--- a/lib/response.js
+++ b/lib/response.js
@@ -419,35 +419,10 @@ function patch(Response) {
             log.trace(_props, 'response::send entered');
         }
 
-        // Flush takes our constructed response object and sends it
-        // to the client
-        function _flush(formattedBody) {
-            self._data = formattedBody;
-
-            // Flush headers
-            self.writeHead(self.statusCode);
-
-            // Send body if it was provided
-            if (self._data) {
-                self.write(self._data);
-            }
-
-            // Finish request
-            self.end();
-
-            // If log level is set to trace, log the entire response object
-            if (log.trace()) {
-                log.trace({ res: self }, 'response sent');
-            }
-
-            // Return the response object back out to the caller of __send
-            return self;
-        }
-
         // 204 = No Content and 304 = Not Modified, we don't want to send the
         // body in these cases. HEAD never provides a body.
         if (isHead || code === 204 || code === 304) {
-            return _flush();
+            return flush(self);
         }
 
         // if no formatting, assert that the value to be written is a string
@@ -457,38 +432,17 @@ function patch(Response) {
                 typeof body === 'string' || Buffer.isBuffer(body),
                 'res.sendRaw() accepts only strings or buffers'
             );
-            return _flush(body);
+            return flush(self, body);
         }
 
         // if no body, then no need to format. if this was an error caught by a
         // domain, don't send the domain error either.
         if (body === undefined || (body instanceof Error && body.domain)) {
-            return _flush();
+            return flush(self);
         }
 
         // At this point we know we have a body that needs to be formatted, so
         // lets derive the formatter based on the response object's properties
-
-        // _formatterError is used to handle any case where we were unable to
-        // properly format the provided body
-        function _formatterError(err) {
-            // If the user provided a non-success error code, we don't want to
-            // mess with it since their error is probably more important than
-            // our inability to format their message.
-            if (self.statusCode >= 200 && self.statusCode < 300) {
-                self.statusCode = err.statusCode;
-            }
-
-            log.warn(
-                {
-                    req: self.req,
-                    err: err
-                },
-                'error retrieving formatter'
-            );
-
-            return _flush();
-        }
 
         var formatter;
         var type = self.contentType || self.getHeader('Content-Type');
@@ -504,7 +458,8 @@ function patch(Response) {
 
         // Check to see if we can find a valid formatter
         if (!type) {
-            return _formatterError(
+            return formatterError(
+                self,
                 new errors.NotAcceptableError({
                     message: 'could not find suitable formatter'
                 })
@@ -528,7 +483,8 @@ function patch(Response) {
         // If after the above attempts we were still unable to derive a
         // formatter, provide a meaningful error message
         if (!formatter) {
-            return _formatterError(
+            return formatterError(
+                self,
                 new errors.InternalServerError({
                     message:
                         'could not find formatter for application/octet-stream'
@@ -544,7 +500,7 @@ function patch(Response) {
         self.setHeader('Content-Type', type);
 
         // Finally, invoke the formatter and flush the request with it's results
-        return _flush(formatter(self.req, self, body));
+        return flush(self, formatter(self.req, self, body));
     };
 
     /**
@@ -857,6 +813,67 @@ function patch(Response) {
         // tell server to stop processing the handler stack.
         return next(false);
     }
+}
+
+/**
+ * Flush takes our constructed response object and sends it to the client
+ *
+ * @private
+ * @function flush
+ * @param {Response} res - response
+ * @param {String|Buffer} formattedBody - formatted body
+ * @returns {Response} response
+ */
+function flush(res, formattedBody) {
+    res._data = formattedBody;
+
+    // Flush headers
+    res.writeHead(res.statusCode);
+
+    // Send body if it was provided
+    if (res._data) {
+        res.write(res._data);
+    }
+
+    // Finish resuest
+    res.end();
+
+    // If log level is set to trace, log the entire response object
+    if (res.log.trace()) {
+        res.log.trace({ res: res }, 'response sent');
+    }
+
+    // Return the response object back out to the caller of __send
+    return res;
+}
+
+/**
+ * formatterError is used to handle any case where we were unable to
+ * properly format the provided body
+ *
+ * @private
+ * @function formatterError
+ * @param {Response} res - response
+ * @param {Error} err - error
+ * @returns {Response} response
+ */
+function formatterError(res, err) {
+    // If the user provided a non-success error code, we don't want to
+    // mess with it since their error is probably more important than
+    // our inability to format their message.
+    if (res.statusCode >= 200 && res.statusCode < 300) {
+        res.statusCode = err.statusCode;
+    }
+
+    res.log.warn(
+        {
+            req: res.req,
+            err: err
+        },
+        'error retrieving formatter'
+    );
+
+    return flush(res);
 }
 
 module.exports = patch;

--- a/lib/response.js
+++ b/lib/response.js
@@ -492,18 +492,16 @@ function patch(Response) {
         var formatter;
         var type = self.contentType || self.getHeader('Content-Type');
 
+        // Derive type if not provided by the user
+        type = type || self.req.accepts(self.acceptable);
+
         // Check to see if we can find a valid formatter
-        if (!type && !self.req.accepts(self.acceptable)) {
+        if (!type) {
             return _formatterError(
                 new errors.NotAcceptableError({
                     message: 'could not find suitable formatter'
                 })
             );
-        }
-
-        // Derive type if not provided by the user
-        if (!type) {
-            type = self.req.accepts(self.acceptable);
         }
 
         type = type.split(';')[0];

--- a/lib/server.js
+++ b/lib/server.js
@@ -800,6 +800,35 @@ Server.prototype.toString = function toString() {
 ///--- Private methods
 
 /**
+ * Route and run
+ *
+ * @private
+ * @memberof Server
+ * @instance
+ * @function _routeAndRun
+ * @param  {Request} req - request
+ * @param  {Response} res - response
+ * @returns {undefined} no return value
+ */
+Server.prototype._routeAndRun = function _routeAndRun(req, res) {
+    var self = this;
+
+    self._route(req, res, function _route(route, context) {
+        // emit 'routed' event after the req has been routed
+        self.emit('routed', req, res, route);
+        req.context = req.params = context;
+        req.route = route.spec;
+
+        var r = route ? route.name : null;
+        var chain = self.routes[r];
+
+        self._run(req, res, route, chain, function done(e) {
+            self._finishReqResCycle(req, res, route, e);
+        });
+    });
+};
+
+/**
  * Upon receivng a request, route the request, then run the chain of handlers.
  *
  * @private
@@ -818,22 +847,6 @@ Server.prototype._handle = function _handle(req, res) {
     // emit 'pre' event before we run the pre handlers
     self.emit('pre', req, res);
 
-    function routeAndRun() {
-        self._route(req, res, function _route(route, context) {
-            // emit 'routed' event after the req has been routed
-            self.emit('routed', req, res, route);
-            req.context = req.params = context;
-            req.route = route.spec;
-
-            var r = route ? route.name : null;
-            var chain = self.routes[r];
-
-            self._run(req, res, route, chain, function done(e) {
-                self._finishReqResCycle(req, res, route, e);
-            });
-        });
-    }
-
     // run pre() handlers first before routing and running
     if (self.before.length > 0) {
         self._run(req, res, null, self.before, function _run(err) {
@@ -844,11 +857,43 @@ Server.prototype._handle = function _handle(req, res) {
                 return;
             }
 
-            routeAndRun();
+            self._routeAndRun(req, res);
         });
     } else {
-        routeAndRun();
+        self._routeAndRun(req, res);
     }
+};
+
+/**
+ * Helper function to, when on router error, emit error events and then
+ * flush the err.
+ *
+ * @private
+ * @memberof Server
+ * @instance
+ * @function _routeErrorResponse
+ * @param    {Request}     req -    the request object
+ * @param    {Response}    res -    the response object
+ * @param    {Error}       err -    error
+ * @returns  {undefined} no return value
+ */
+Server.prototype._routeErrorResponse = function _routeErrorResponse(
+    req,
+    res,
+    err
+) {
+    var self = this;
+
+    return self._emitErrorEvents(
+        req,
+        res,
+        null,
+        err,
+        function _emitErrorEvents() {
+            res.send(err);
+            return self._finishReqResCycle(req, res, null, err);
+        }
+    );
 };
 
 /**
@@ -867,20 +912,6 @@ Server.prototype._handle = function _handle(req, res) {
  */
 Server.prototype._route = function _route(req, res, name, cb) {
     var self = this;
-    // helper function to, when on router error, emit error events and then
-    // flush the err.
-    var errResponse = function errResponse(err) {
-        return self._emitErrorEvents(
-            req,
-            res,
-            null,
-            err,
-            function _emitErrorEvents() {
-                res.send(err);
-                return self._finishReqResCycle(req, res, null, err);
-            }
-        );
-    };
 
     if (typeof name === 'function') {
         cb = name;
@@ -896,11 +927,11 @@ Server.prototype._route = function _route(req, res, name, cb) {
                     res.send(200);
                     return self._finishReqResCycle(req, res, null, null);
                 } else {
-                    return errResponse(err);
+                    return self._routeErrorResponse(req, res, err);
                 }
             } else if (!r || !self.routes[r]) {
                 err = new ResourceNotFoundError(req.path());
-                return errResponse(err);
+                return self._routeErrorResponse(req, res, err);
             } else {
                 // else no err, continue
                 return cb(route, ctx);
@@ -909,7 +940,7 @@ Server.prototype._route = function _route(req, res, name, cb) {
     } else {
         return this.router.get(name, req, function get(err, route, ctx) {
             if (err) {
-                return errResponse(err);
+                return self._routeErrorResponse(req, res, err);
             } else {
                 // else no err, continue
                 return cb(route, ctx);

--- a/lib/server.js
+++ b/lib/server.js
@@ -1218,7 +1218,7 @@ Server.prototype._setupRequest = function _setupRequest(req, res) {
 
     // set header only if name isn't empty string
     if (self.name !== '') {
-        res.header('Server', self.name);
+        res.setHeader('Server', self.name);
     }
     res.version = self.router.versions[self.router.versions.length - 1];
 };

--- a/package.json
+++ b/package.json
@@ -118,6 +118,8 @@
     "dtrace-provider": "^0.8.1"
   },
   "devDependencies": {
+    "autocannon": "0.16.5",
+    "autocannon-compare": "0.3.0",
     "chai": "^4.1.2",
     "cover": "^0.2.9",
     "coveralls": "^2.13.3",
@@ -127,11 +129,13 @@
     "eslint-plugin-jsdoc": "^3.1.3",
     "eslint-plugin-prettier": "^2.3.1",
     "filed": "^0.1.0",
+    "inquirer": "3.3.0",
     "istanbul": "^0.4.5",
     "mkdirp": "^0.5.1",
     "mocha": "^3.5.3",
     "nodeunit": "^0.11.2",
     "nsp": "^2.8.1",
+    "ora": "1.3.0",
     "pre-commit": "^1.2.2",
     "prettier": "^1.8.1",
     "proxyquire": "^1.8.0",


### PR DESCRIPTION
Benchmark and improve performance.

# Changes

- Add benchmark suite based on https://github.com/fastify/benchmarks
- Set Content-Type to `application/json` when `res.send` is called with an Object instead of calling `res.json`
- Call `req.accepts` only once when not provided type is derived
- Eliminate some closures
- Optimize internal set header calls: use raw `res.setHeader`

# Improvement

Dumb servers:

```sh
$ npm start

> restify-benchmark@0.0.0 start /node-restify/benchmark
> node .

? Do you want to track progress? No
? Do you want to compare HEAD with latest release? Yes
? Do you want to run all benchmark tests? Yes
? How many connection you need? 100
? How many pipelining you need? 10
? How long does it takes? 30
---- response-json ----
✔ Results saved for head/response-json
✔ Results saved for stable/response-json
response-json throughput:
{
    "significant": "***",
    "equal": false,
    "wins": "head",
    "diff": "21.3%"
}

---- response-text ----
✔ Results saved for head/response-text
✔ Results saved for stable/response-text
response-text throughput:
{
    "significant": "***",
    "equal": false,
    "wins": "head",
    "diff": "7.3%"
}

```
