### PR TITLE
fix(server): avoid http2 experimental warning without http2 option

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -30,14 +30,6 @@ var patchResponse = require('./response');
 
 var http2;
 
-// http2 module is not available < v8.4.0 (only with flag <= 8.8.0)
-try {
-    http2 = require('http2');
-    patchResponse(http2.Http2ServerResponse);
-    patchRequest(http2.Http2ServerRequest);
-    // eslint-disable-next-line no-empty
-} catch (err) {}
-
 patchResponse(http.ServerResponse);
 patchRequest(http.IncomingMessage);
 
@@ -137,6 +129,17 @@ function Server(options) {
         this.spdy = true;
         this.server = spdy.createServer(options.spdy);
     } else if (options.http2) {
+        // http2 module is not available < v8.4.0 (only with flag <= 8.8.0)
+        // load http2 module here to avoid experimental warning in other cases
+        if (!http2) {
+            try {
+                http2 = require('http2');
+                patchResponse(http2.Http2ServerResponse);
+                patchRequest(http2.Http2ServerRequest);
+                // eslint-disable-next-line no-empty
+            } catch (err) {}
+        }
+
         assert(
             http2,
             'http2 module is not available, ' +


### PR DESCRIPTION
Avoid http2 experimental warning message without http2 option

```
(node:11390) ExperimentalWarning: The http2 module is an experimental API.
```

# Changes

- Only load http2 module when `http2` option is presented
