### PR TITLE
chore(prettier): update to 1.8.1

### DIFF
--- a/docs/_api/plugins.md
+++ b/docs/_api/plugins.md
@@ -303,7 +303,7 @@ Many options correspond directly to option defined for the underlying
     -   `options.overrideParams` **[Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Only applies when if
         mapParams true.
         When true, will stomp on req.params field when existing value is found. (optional, default `false`)
-    -   `options.allowDots` **[Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Transform `?foo.bar=baz` to a 
+    -   `options.allowDots` **[Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Transform `?foo.bar=baz` to a
         nested object: `{foo: {bar: 'baz'}}`. (optional, default `false`)
     -   `options.arrayLimit` **[Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Only transform `?a[$index]=b`
         to an array if `$index` is less than `arrayLimit`. (optional, default `20`)
@@ -762,7 +762,7 @@ you would like to keep CPU bound tasks from piling up causing an increased
 per-request latency.
 
 The algorithm asks you for a maximum CPU utilization rate, which it uses to
-determine at what point it should be rejecting 100% of traffic. For a normal 
+determine at what point it should be rejecting 100% of traffic. For a normal
 Node.js service, this is 1 since Node is single threaded. It uses this,
 paired with a limit that you provide to determine the total % of traffic it
 should be rejecting. For example, if you specify a limit of .5 and a max of

--- a/docs/_api/server.md
+++ b/docs/_api/server.md
@@ -62,6 +62,8 @@ routes and handlers for incoming requests.
         response header, default is `restify`. Pass empty string to unset the header. (optional, default `false`)
     -   `options.spdy` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)?** Any options accepted by
         [node-spdy](https://github.com/indutny/node-spdy).
+    -   `options.http2` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)?** Any options accepted by
+        [http2.createSecureServer](https://nodejs.org/api/http2.html).
     -   `options.handleUpgrades` **[Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Hook the `upgrade` event
         from the node HTTP server, pushing `Connection: Upgrade` requests through the
          regular request handling chain. (optional, default `false`)

--- a/lib/bunyan_helper.js
+++ b/lib/bunyan_helper.js
@@ -20,7 +20,7 @@ var STR_FMT = '[object %s<level=%d, limit=%d, maxRequestIds=%d>]';
 
 /**
  * Appends streams
- * 
+ *
  * @private
  * @function appendStream
  * @param    {Stream}    streams - the stream to append to

--- a/lib/formatters/json.js
+++ b/lib/formatters/json.js
@@ -7,7 +7,7 @@
 /**
  * JSON formatter. Will look for a toJson() method on the body. If one does not
  * exist then a JSON.stringify will be attempted.
- * 
+ *
  * @public
  * @function formatJSON
  * @param    {Object} req - the request object (not used)

--- a/lib/plugins/cpuUsageThrottle.js
+++ b/lib/plugins/cpuUsageThrottle.js
@@ -15,7 +15,7 @@ var EWMA = require('ewma');
  * per-request latency.
  *
  * The algorithm asks you for a maximum CPU utilization rate, which it uses to
- * determine at what point it should be rejecting 100% of traffic. For a normal 
+ * determine at what point it should be rejecting 100% of traffic. For a normal
  * Node.js service, this is 1 since Node is single threaded. It uses this,
  * paired with a limit that you provide to determine the total % of traffic it
  * should be rejecting. For example, if you specify a limit of .5 and a max of

--- a/lib/plugins/pre/dedupeSlashes.js
+++ b/lib/plugins/pre/dedupeSlashes.js
@@ -13,7 +13,7 @@
  *     res.send(200);
  *     return next();
  * });
- * 
+ *
  * // the server will now convert requests to /hello//jake => /hello/jake
  */
 function createDedupeSlashes() {

--- a/lib/plugins/pre/strictQueryParams.js
+++ b/lib/plugins/pre/strictQueryParams.js
@@ -17,7 +17,7 @@ var assert = require('assert-plus');
  *
  * part of Hypertext Transfer Protocol -- HTTP/1.1 | 5.1.2 Request-URI
  * RFC 2616 Fielding, et al.
- * 
+ *
  * @public
  * @function strictQueryParams
  * @param    {Object}   [options] - an options object

--- a/lib/plugins/query.js
+++ b/lib/plugins/query.js
@@ -23,7 +23,7 @@ var assert = require('assert-plus');
  * @param {Boolean} [options.overrideParams=false] - Only applies when if
  * mapParams true.
  * When true, will stomp on req.params field when existing value is found.
- * @param {Boolean} [options.allowDots=false] - Transform `?foo.bar=baz` to a 
+ * @param {Boolean} [options.allowDots=false] - Transform `?foo.bar=baz` to a
  * nested object: `{foo: {bar: 'baz'}}`.
  * @param {Number} [options.arrayLimit=20] - Only transform `?a[$index]=b`
  * to an array if `$index` is less than `arrayLimit`.

--- a/lib/plugins/requestExpiry.js
+++ b/lib/plugins/requestExpiry.js
@@ -26,7 +26,7 @@ var GatewayTimeoutError = require('restify-errors').GatewayTimeoutError;
  *       absolute time in which the request is considered expired
  *
  * #### Using an external storage mechanism for key/bucket mappings.
- * 
+ *
  * By default, the restify throttling plugin uses an in-memory LRU to store
  * mappings between throttling keys (i.e., IP address) to the actual bucket that
  * key is consuming.  If this suits you, you can tune the maximum number of keys

--- a/lib/request.js
+++ b/lib/request.js
@@ -40,14 +40,14 @@ function negotiator(req) {
 ///--- API
 
 /**
-* Patch Request object and extends with extra functionalities
-*
-* @private
-* @function patch
-* @param    {http.IncomingMessage|http2.Http2ServerRequest} Request -
-*                                                           Server Request
-* @returns  {undefined} No return value
-*/
+ * Patch Request object and extends with extra functionalities
+ *
+ * @private
+ * @function patch
+ * @param    {http.IncomingMessage|http2.Http2ServerRequest} Request -
+ *                                                           Server Request
+ * @returns  {undefined} No return value
+ */
 function patch(Request) {
     /**
      * Wraps all of the node

--- a/lib/response.js
+++ b/lib/response.js
@@ -32,14 +32,14 @@ var HEADER_ARRAY_BLACKLIST = {
 ///--- API
 
 /**
-* Patch Response object and extends with extra functionalities
-*
-* @private
-* @function patch
-* @param    {http.ServerResponse|http2.Http2ServerResponse} Response -
-*                                                           Server Response
-* @returns  {undefined} No return value
-*/
+ * Patch Response object and extends with extra functionalities
+ *
+ * @private
+ * @function patch
+ * @param    {http.ServerResponse|http2.Http2ServerResponse} Response -
+ *                                                           Server Response
+ * @returns  {undefined} No return value
+ */
 function patch(Response) {
     /**
      * Wraps all of the node

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "nodeunit": "^0.11.2",
     "nsp": "^2.8.1",
     "pre-commit": "^1.2.2",
-    "prettier": "^1.7.4",
+    "prettier": "^1.8.1",
     "proxyquire": "^1.8.0",
     "restify-clients": "^1.5.2",
     "rimraf": "^2.6.2",

--- a/tools/docsBuild.js
+++ b/tools/docsBuild.js
@@ -74,15 +74,15 @@ var docsConfig = [
 ];
 
 /**
-* @function build
-* @param {Object} options - Options
-* @param {Array} options.files - Array of file paths ["./foo.js"]
-* @param {String} options.config - Path to "config.yaml"
-* @param {String} options.output - Path to output dir
-* @param {String} options.title - Jekyll title
-* @param {String} options.permalink - Jekyll permalink
-* @returns {Promise} - Promise
-*/
+ * @function build
+ * @param {Object} options - Options
+ * @param {Array} options.files - Array of file paths ["./foo.js"]
+ * @param {String} options.config - Path to "config.yaml"
+ * @param {String} options.output - Path to output dir
+ * @param {String} options.title - Jekyll title
+ * @param {String} options.permalink - Jekyll permalink
+ * @returns {Promise} - Promise
+ */
 function build(options) {
     return documentation
         .build(options.files, {


### PR DESCRIPTION
## Pre-Submission Checklist

- [x] Ran the linter and tests via `make prepush`

Update `prettier` to 1.8.1

Prettier 1.8.1 changelog:

```
Force JSON to no trailing comma in multiparser (#3182 by azz)
Don't add trailing commas in JSXAttribute for arrow functions (#3181 by duailibe)
Markdown: Allow more cases that _-style emphasis is available (#3186 by ikatyang)
Markdown: Handle additional spaces before code (#3180 by ikatyang)
Markdown: Do not break on unbreakable place (#3177 by ikatyang)
Markdown: Do not break before special prefix (#3172 by ikatyang)
```

# Changes

- update `prettier` to 1.8.1
- run `make fix-style`
- run `make docs-build`
