### PR TITLE
feat(response): set content-type charset default to utf-8 #1416

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -491,6 +491,8 @@ function patch(Response) {
 
         if (self._charSet) {
             type = type + '; charset=' + self._charSet;
+        } else {
+            type = type + '; charset=utf-8';
         }
 
         // Update header to the derived content type for our formatter

--- a/test/response.test.js
+++ b/test/response.test.js
@@ -514,7 +514,10 @@ test('should fail to set header due to missing formatter', function(t) {
     CLIENT.get(join(LOCALHOST, '/11'), function(err, _, res) {
         t.ifError(err);
         t.equal(res.statusCode, 200);
-        t.equal(res.headers['content-type'], 'application/octet-stream');
+        t.equal(
+            res.headers['content-type'],
+            'application/octet-stream; charset=utf-8'
+        );
         t.end();
     });
 });
@@ -617,6 +620,33 @@ test('GH-1429: setting code with res.status not respected', function(t) {
 
     CLIENT.get(join(LOCALHOST, '/404'), function(err, _, res) {
         t.equal(res.statusCode, 404);
+        t.end();
+    });
+});
+
+test('should default Response content-type to charset=utf-8', function(t) {
+    SERVER.get('/200', function(req, res, next) {
+        res.status(200);
+        res.send(null);
+    });
+
+    CLIENT.get(join(LOCALHOST, '/200'), function(err, _, res) {
+        t.equal(res.headers['content-type'], 'application/json; charset=utf-8');
+        t.end();
+    });
+});
+
+test('should not overwrite setting response content-type charset', function(t) {
+    SERVER.get('/200', function(req, res, next) {
+        res.charSet('ISO-8859-1');
+        res.send(null);
+    });
+
+    CLIENT.get(join(LOCALHOST, '/200'), function(err, _, res) {
+        t.equal(
+            res.headers['content-type'],
+            'application/json; charset=ISO-8859-1'
+        );
         t.end();
     });
 });


### PR DESCRIPTION
<!--
Thank you for taking the time to open an PR for restify! If this is your first
time here, welcome to our community! We are a group of developers who work on
restify in our free-time. Some of us do it as a hobby, others are using restify
at work. When asking for help here, keep in mind most of us are volunteers
contributing our daily work back to the community at no cost (and often for no
reward). Please be respectful!

Below you will find a checklist to help you create the best PR possible. While
the checklist items aren't all _strictly_ required, they dramatically increase
the probability of your PR getting a response and getting merged. Often times,
the least time consuming part of maintaining and open source project is writing
code, its the process and discussions that happen around the code base that
consume a majority of the maintainers' time. By spending a few moments to
adhere to this template, you are not only improve the quality of your PR, you
are also helping save the maintainers a considerable amount of time when trying
to understand and review your changes.

And remember, positive vibes are met with positive vibes. Kindness helps Free
Software go round, pay it forward!
-->

## Pre-Submission Checklist

- [x] Opened an issue discussing these changes before opening the PR
- [x] Ran the linter and tests via `make prepush`
- [x] Included comprehensive and convincing tests for changes

## Issues

Closes:

* Issue #1416 
* Issue #
* Issue #

> Summarize the issues that discussed these changes

# Changes

> What does this PR do?

Makes a Response's content-type to default to charset=utf-8, if charSet() not specifically called
