### PR TITLE
test(server): do not run IPv6 related tests with TEST_SKIP_IP_V6 env.…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ node_js:
    - "4"
    - "6"
    - "stable"
+env:
+  - TEST_SKIP_IP_V6=true
 notifications:
   webhooks:
     urls:

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -24,10 +24,14 @@ var after = helper.after;
 var before = helper.before;
 var test = helper.test;
 
+var SKIP_IP_V6 = (process.env.TEST_SKIP_IP_V6 === 'true');
 var PORT = process.env.UNIT_TEST_PORT || 0;
 var CLIENT;
 var SERVER;
 
+if (SKIP_IP_V6) {
+    console.warning('IPv6 tests are skipped: No IPv6 network is available');
+}
 
 ///--- Tests
 
@@ -100,18 +104,21 @@ test('listen and close (socketPath)', function (t) {
 });
 
 
-test('gh-751 IPv4/IPv6 server URL', function (t) {
-    t.equal(SERVER.url, 'http://127.0.0.1:' + PORT, 'ipv4 url');
+// Run IPv6 tests only if IPv6 network is available
+if (!SKIP_IP_V6) {
+    test('gh-751 IPv4/IPv6 server URL', function (t) {
+        t.equal(SERVER.url, 'http://127.0.0.1:' + PORT, 'ipv4 url');
 
-    var server = restify.createServer();
-    server.listen(PORT + 1, '::1', function () {
-        t.equal(server.url, 'http://[::1]:' + (PORT + 1), 'ipv6 url');
+        var server = restify.createServer();
+        server.listen(PORT + 1, '::1', function () {
+            t.equal(server.url, 'http://[::1]:' + (PORT + 1), 'ipv6 url');
 
-        server.close(function () {
-            t.end();
+            server.close(function () {
+                t.end();
+            });
         });
     });
-});
+}
 
 
 test('get (path only)', function (t) {


### PR DESCRIPTION
Fixes failures in travis. Meant to do one for 5.x as well but accidentally committed directly to 5.x directly. 