### PR TITLE
Fix server.param with false values

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -527,7 +527,7 @@ Server.prototype.use = function use() {
  */
 Server.prototype.param = function param(name, fn) {
     this.use(function _param(req, res, next) {
-        if (req.params && req.params[name]) {
+        if (req.params && req.params.hasOwnProperty(name)) {
             fn.call(this, req, res, next, req.params[name], name);
         } else {
             next();

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1611,6 +1611,60 @@ test('gh-193 route ENOEXIST', function(t) {
     });
 });
 
+test('run param only with existing req.params', function(t) {
+    var count = 0;
+
+    SERVER.param('name', function(req, res, next) {
+        count++;
+        next();
+    });
+
+    SERVER.param('userId', function(req, res, next, param, name) {
+        t.equal(param, '1');
+        t.equal(name, 'userId');
+        count++;
+        next();
+    });
+
+    SERVER.get('/users/:userId', function(req, res, next) {
+        res.send(200);
+    });
+
+    CLIENT.get('/users/1', function(err, _, res) {
+        t.ifError(err);
+        t.equal(res.statusCode, 200);
+        t.equal(count, 1);
+        t.end();
+    });
+});
+
+test('run param with false value', function(t) {
+    var count = 0;
+
+    SERVER.param('name', function(req, res, next) {
+        count++;
+        next();
+    });
+
+    SERVER.param('userId', function(req, res, next, param, name) {
+        t.equal(param, '');
+        t.equal(name, 'userId');
+        count++;
+        next();
+    });
+
+    SERVER.get('/users/:userId', function(req, res, next) {
+        res.send(200);
+    });
+
+    CLIENT.get('/users//', function(err, _, res) {
+        t.ifError(err);
+        t.equal(res.statusCode, 200);
+        t.equal(count, 1);
+        t.end();
+    });
+});
+
 test('gh-193 route only run use once', function(t) {
     var count = 0;
 


### PR DESCRIPTION
Earlier `server.param` didn't run with false values like an empty string.

# Changes

- handle false values
- cover with tests
