### PR TITLE
fix(request): date() and time() methods return value

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -241,14 +241,9 @@ function patch(Request) {
      * @memberof Request
      * @instance
      * @function date
-     * @returns  {Date} date
+     * @returns  {Date} date when request began being processed
      */
     Request.prototype.date = function date() {
-        if (this._date !== undefined) {
-            return this._date;
-        }
-
-        this._date = new Date(this._time);
         return this._date;
     };
 
@@ -410,10 +405,12 @@ function patch(Request) {
      * @memberof Request
      * @instance
      * @function time
-     * @returns  {Number} time
+     * @returns  {Number} time when request began being processed in epoch:
+     *                    ellapsed milliseconds since
+     *                    January 1, 1970, 00:00:00 UTC
      */
     Request.prototype.time = function time() {
-        return this._time;
+        return this._date.getTime();
     };
 
     /**

--- a/lib/server.js
+++ b/lib/server.js
@@ -1210,6 +1210,7 @@ Server.prototype._run = function _run(req, res, route, chain, cb) {
 Server.prototype._setupRequest = function _setupRequest(req, res) {
     var self = this;
     req.log = res.log = self.log;
+    req._date = new Date();
     req._time = process.hrtime();
     req.serverName = self.name;
 

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -191,3 +191,35 @@ test('should provide route object', function(t) {
         t.end();
     });
 });
+
+test('should provide time when request started', function(t) {
+    SERVER.get('/ping/:name', function(req, res, next) {
+        t.equal(typeof req.time(), 'number');
+        t.ok(req.time() > Date.now() - 1000);
+        t.ok(req.time() <= Date.now());
+        res.send('ok');
+        return next();
+    });
+
+    CLIENT.get('/ping/lagavulin', function(err, _, res) {
+        t.ifError(err);
+        t.equal(res.statusCode, 200);
+        t.end();
+    });
+});
+
+test('should provide date when request started', function(t) {
+    SERVER.get('/ping/:name', function(req, res, next) {
+        t.ok(req.date() instanceof Date);
+        t.ok(req.date().getTime() > Date.now() - 1000);
+        t.ok(req.date().getTime() <= Date.now());
+        res.send('ok');
+        return next();
+    });
+
+    CLIENT.get('/ping/lagavulin', function(err, _, res) {
+        t.ifError(err);
+        t.equal(res.statusCode, 200);
+        t.end();
+    });
+});


### PR DESCRIPTION
## Pre-Submission Checklist

- [x] Opened an issue discussing these changes before opening the PR
- [x] Ran the linter and tests via `make prepush`
- [x] Included comprehensive and convincing tests for changes

## Issues

Closes:

* https://github.com/restify/node-restify/issues/1574
* Caused by: https://github.com/restify/node-restify/pull/1507

Fix  fix `req.time()` and `req.date()` return value.

# Changes

- fix `req.time()` and `req.date()`
- cover with tests
