### PR TITLE
add workaround to fix changed route based on regular expression while…

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1548,6 +1548,9 @@ function serverMethodFactory(method) {
             };
         } else if (typeof opts === 'object') {
             opts = shallowCopy(opts);
+            if(opts.hasOwnProperty('path') && opts.path instanceof RegExp){
+                opts.path = new RegExp(opts.path.source) // FIXME: How opts.path will change at startup initialize process?
+            }
         } else {
             throw new TypeError('path (string) required');
         }


### PR DESCRIPTION
Currently the initialization process seems to change routes based on `RegEx`. I do not expect that you will accept this PR. It is intended to point out the problematic code. I think this code change is only a workaround for #1581 because from my point of view we should not change the initial regular expression passed to `.get`method where

`/\bv?(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[\da-z-]+(?:\.[\da-z-]+)*)?(?:\+[\da-z-]+(?:\.[\da-z-]+)*)?\/?.*\b/` changes to  
`/\bv?(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[\da-z-]+(?:\.[\da-z-]+)*)?(?:\+[\da-z-]+(?:\.[\da-z-]+)*)?\/?.*\b/gi`. I am not a `RegExpert` but I think this should not make a difference and it changes back to original `RegEx` at runtime but it leads to fail [`matchURL`](https://github.com/restify/node-restify/blob/ea563b77d092f7787f9dbf76be2af7335f34618e/lib/router.js#L48)
 
## Pre-Submission Checklist

- [x] Opened an issue discussing these changes before opening the PR
- [ ] Ran the linter and tests via `make prepush`
- [ ] Included comprehensive and convincing tests for changes

## Issues

Closes:

* Issue #1581
 
 
