### PR TITLE
Use `Buffer.isBuffer` instead of `util.isBuffer`.

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -5,7 +5,6 @@
 var http = require('http');
 var sprintf = require('util').format;
 var url = require('url');
-var util = require('util');
 
 var assert = require('assert-plus');
 var mime = require('mime');
@@ -446,7 +445,7 @@ function patch(Response) {
 
         // Set Content-Type to application/json when
         // res.send is called with an Object instead of calling res.json
-        if (!type && typeof body === 'object' && !util.isBuffer(body)) {
+        if (!type && typeof body === 'object' && !Buffer.isBuffer(body)) {
             type = 'application/json';
         }
 


### PR DESCRIPTION

## Pre-Submission Checklist

- [ ] Opened an issue discussing these changes before opening the PR
- [x] Ran the linter and tests via `make prepush`
- [ ] Included comprehensive and convincing tests for changes

## Issues

No issues opened for this.

# Changes

Replaced `util.isBuffer` call with `Buffer.isBuffer`.

[`util.isBuffer`](https://nodejs.org/api/util.html#util_util_isbuffer_object) was introduced in Node 0.11 and deprecated in Node 4. [`Buffer.isBuffer`](https://nodejs.org/api/buffer.html#buffer_class_method_buffer_isbuffer_obj) was introduced in Node 0.1 and has not been deprecated. Since Restify supports back to 0.10 according to the package.json `engines` field, `util.isBuffer` cannot be used.
