### PR TITLE
Passing 'server' instance as param to handler

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1122,7 +1122,7 @@ Server.prototype._run = function _run(req, res, route, chain, cb) {
             if (self.handleUncaughtExceptions === true) {
                 n.ifError = ifError(n);
             }
-            return chain[i].call(self, req, res, n);
+            return chain[i].call(self, req, res, n, self);
         }
 
         // if we have reached this last section of next(), then we are 'done'


### PR DESCRIPTION
## Pre-Submission Checklist

- [x] Opened an issue discussing these changes before opening the PR
- [x] Ran the linter and tests via `make prepush`
- [ ] Included comprehensive and convincing tests for changes

## Issues

Closes:

* Issue #1595

This pass 'server' instance as param to handlers. Developer can use arrow function and also has an access to 'server' instance.

# Changes

Adding 4th param to handlers