### PR TITLE
fix(jsonBodyParser): fix percent sign causing server fail (#1411)

### DIFF
--- a/lib/plugins/jsonBodyParser.js
+++ b/lib/plugins/jsonBodyParser.js
@@ -38,7 +38,10 @@ function jsonBodyParser(options) {
             params = JSON.parse(req.body, opts.reviver);
         } catch (e) {
             return next(
-                new errors.InvalidContentError('Invalid JSON: ' + e.message)
+                new errors.InvalidContentError(
+                    '%s',
+                    'Invalid JSON: ' + e.message
+                )
             );
         }
 

--- a/test/plugins/jsonBodyParser.test.js
+++ b/test/plugins/jsonBodyParser.test.js
@@ -464,4 +464,33 @@ describe('JSON body parser', function() {
 
         CLIENT.post('/body/foo', payload, done);
     });
+
+    it('should not throw uncaught "too few args to sprintf"', function(done) {
+        // https://github.com/restify/node-restify/issues/1411
+        SERVER.use(restify.plugins.bodyParser());
+
+        SERVER.post('/', function(req, res, next) {
+            res.send();
+            next();
+        });
+
+        var opts = {
+            hostname: '127.0.0.1',
+            port: PORT,
+            path: '/',
+            method: 'POST',
+            agent: false,
+            headers: {
+                accept: 'application/json',
+                'content-type': 'application/json'
+            }
+        };
+        var client = http.request(opts, function(res) {
+            assert.equal(res.statusCode, 400);
+            res.once('end', done);
+            res.resume();
+        });
+        client.write('{"malformedJsonWithPercentSign":30%}');
+        client.end();
+    });
 });


### PR DESCRIPTION
This is a fix for https://github.com/restify/node-restify/issues/1411 which seems to be still happening.