### PR TITLE
plugins.md - metrics requires an opt structure

### DIFF
--- a/docs/_api/plugins.md
+++ b/docs/_api/plugins.md
@@ -1052,7 +1052,7 @@ about that request.
 **Examples**
 
 ```javascript
-server.on('after', plugins.metrics(function onMetrics(err, metrics) {
+server.on('after', restify.plugins.metrics({ server: server }, function (err, metrics, req, res, route) {
      // metrics is an object containing information about the request
 }));
 ```


### PR DESCRIPTION
Documentation improvement.

The call example for plugins.metrics didn't include the required first parameter (which itself requires a `server` key to be set). Compare to https://github.com/restify/node-restify/blob/master/test/plugins/metrics.test.js

Closes no issue(s).
