### PR TITLE
Update metrics plugin example

### DIFF
--- a/docs/_api/plugins.md
+++ b/docs/_api/plugins.md
@@ -1038,7 +1038,7 @@ Returns **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Ref
 ### metrics
 
 The module includes the following plugins to be used with restify's `after`
-event, e.g., `server.on('after', plugins.metrics());`:
+event, e.g., `server.on('after', restify.plugins.metrics());`:
 
 A plugin that listens to the server's after event and emits information
 about that request.
@@ -1052,8 +1052,9 @@ about that request.
 **Examples**
 
 ```javascript
-server.on('after', plugins.metrics(function onMetrics(err, metrics) {
-     // metrics is an object containing information about the request
+server.on('after', restify.plugins.metrics({ server: server },
+    function (err, metrics, req, res, route) {
+        // metrics is an object containing information about the request
 }));
 ```
 

--- a/lib/plugins/metrics.js
+++ b/lib/plugins/metrics.js
@@ -7,7 +7,7 @@ var hrTimeDurationInMs = require('./utils/hrTimeDurationInMs');
 
 /**
  * The module includes the following plugins to be used with restify's `after`
- * event, e.g., `server.on('after', plugins.metrics());`:
+ * event, e.g., `server.on('after', restify.plugins.metrics());`:
  *
  * A plugin that listens to the server's after event and emits information
  * about that request.
@@ -20,8 +20,9 @@ var hrTimeDurationInMs = require('./utils/hrTimeDurationInMs');
  * @returns {Function} returns a function suitable to be used
  *   with restify server's `after` event
  * @example
- * server.on('after', plugins.metrics(function onMetrics(err, metrics) {
- *      // metrics is an object containing information about the request
+ * server.on('after', restify.plugins.metrics({ server: server },
+ *     function (err, metrics, req, res, route) {
+ *         // metrics is an object containing information about the request
  * }));
  */
 function createMetrics(opts, callback) {


### PR DESCRIPTION
Documentation improvement.

The call example for plugins.metrics didn't include the required first parameter (which itself requires a server key to be set). Compare to https://github.com/restify/node-restify/blob/master/test/plugins/metrics.test.js

Replaces https://github.com/restify/node-restify/pull/1598. Closes no issue(s).