### PR TITLE
Fix JSON formatter

### DIFF
--- a/lib/formatters/json.js
+++ b/lib/formatters/json.js
@@ -16,10 +16,8 @@
  * @returns  {String} data
  */
 function formatJSON(req, res, body) {
-    var data = 'null';
-    if (body) {
-        data = body.toJson ? body.toJson() : JSON.stringify(body);
-    }
+    body = body.toJson ? body.toJson() : body;
+    var data = body ? JSON.stringify(body) : 'null';
     // Setting the content-length header is not a formatting feature and should
     // be separated into another module
     res.setHeader('Content-Length', Buffer.byteLength(data));

--- a/lib/formatters/json.js
+++ b/lib/formatters/json.js
@@ -16,7 +16,10 @@
  * @returns  {String} data
  */
 function formatJSON(req, res, body) {
-    var data = body ? JSON.stringify(body) : 'null';
+    var data = 'null';
+    if (body) {
+        data = body.toJson ? body.toJson() : JSON.stringify(body);
+    }
     // Setting the content-length header is not a formatting feature and should
     // be separated into another module
     res.setHeader('Content-Length', Buffer.byteLength(data));


### PR DESCRIPTION
The [method description](https://github.com/restify/node-restify/blob/master/lib/formatters/json.js) says:
> Will look for a toJson() method on the body. If one does not exist then a JSON.stringify will be attempted.

But toJson is actually never used by Restify.

On [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) says that `toJson` is called internally by `JSON.stringify` but this seems to not be true.

For example this code:
```js
const error = new errors.InternalServerError();
error.toJson = () => {
  return 'You should see this';
};
console.log(JSON.stringify(error.toJson()));
console.log(JSON.stringify(error));
```
will output:
```js
"You should see this"
{"code":"InternalServer","message":""}
```

This makes impossible to customize errors as suggested [here](https://github.com/restify/errors/issues/72#issuecomment-320532627).

Another example:
```js
const error = {code: 'InternalError', message: 'Internal server error'};
error.toJson = () => {
  return 'You should see this';
}; 
console.log(JSON.stringify(error.toJson()));
console.log(JSON.stringify(error));
```

This PR should fix the problem