### PR TITLE
docs: Mark options object as optional in createServer

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,7 @@ require('./errorTypes');
  *
  * @public
  * @function createServer
- * @param {Object} options  - an options object
+ * @param {Object} [options]  - an options object
  * @param {String} [options.name="restify"] - Name of the server.
  * @param {Router} [options.router=new Router(opts)] - Router
  * @param {Object} [options.log=bunyan.createLogger(options.name || "restify")]


### PR DESCRIPTION
> What does this PR do?

This change corrects the JSDoc annotation and removes errors from
linters and checkers like built-in into VSCode when using the
createMethod without an option object.

Thanks!