### PR TITLE
passing maxFileSize option to formidable

### DIFF
--- a/lib/plugins/multipartBodyParser.js
+++ b/lib/plugins/multipartBodyParser.js
@@ -69,7 +69,7 @@ function multipartBodyParser(options) {
         if (opts.maxFieldsSize) {
             form.maxFieldsSize = opts.maxFieldsSize;
         }
-        
+
         if (opts.maxFileSize) {
             form.maxFileSize = opts.maxFileSize;
         }

--- a/lib/plugins/multipartBodyParser.js
+++ b/lib/plugins/multipartBodyParser.js
@@ -33,6 +33,7 @@ function multipartBodyParser(options) {
     assert.optionalBool(opts.keepExtensions, 'opts.keepExtensions');
     assert.optionalString(opts.uploadDir, 'opts.uploadDir');
     assert.optionalNumber(opts.maxFieldsSize, 'opts.maxFieldsSize');
+    assert.optionalNumber(opts.maxFileSize, 'opts.maxFileSize');
     assert.optionalString(opts.hash, 'opts.hash');
     assert.optionalFunc(opts.multipartFileHandler, 'opts.multipartFileHandler');
     assert.optionalFunc(opts.multipartHandler, 'opts.multipartHandler');
@@ -67,6 +68,10 @@ function multipartBodyParser(options) {
 
         if (opts.maxFieldsSize) {
             form.maxFieldsSize = opts.maxFieldsSize;
+        }
+        
+        if (opts.maxFileSize) {
+            form.maxFileSize = opts.maxFileSize;
         }
 
         if (opts.hash) {


### PR DESCRIPTION
## Pre-Submission Checklist

- [ ] Opened an issue discussing these changes before opening the PR
- [ ] Ran the linter and tests via `make prepush`
- [ ] Included comprehensive and convincing tests for changes

## Issues

Closes:

* Issue https://github.com/restify/node-restify/issues/1620

Unable to set `maxFileSize` of formidable dependency

# Changes

pass `maxFileSize` option to formidable when it was set by user.


