### PR TITLE
docs(guides): path must start with / in 7.x

### DIFF
--- a/docs/guides/6to7guide.md
+++ b/docs/guides/6to7guide.md
@@ -31,6 +31,14 @@ Strict routing is the new default.
 Use `ignoreTrailingSlash: true` server option if you don't want to differentiate
 them from each other.
 
+### Path must to start with `/`
+
+In restify 7.x path must start with a `/`.
+For example `server.get('foo')` is invalid, change it to `server.get('/foo')`.
+
+If you use [enroute](https://github.com/restify/enroute) be sure
+that you updated it to the latest version.
+
 ### Different `RegExp` usage in router path and wildcards
 
 restify's new router backend


### PR DESCRIPTION
Extend migration guide: path must start with `/` in 7.x