### PR TITLE
Added ignoreTrailingSlash router option

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -33,12 +33,18 @@ var ResourceNotFoundError = errors.ResourceNotFoundError;
  * @param {Boolean} [options.strictNext=false] - Throws error when next() is
  *  called more than once, enabled onceNext option
  * @param {Object} [options.registry] - route registry
+ * @param {Object} [options.ignoreTrailingSlash] - ignore trailing slash on
+ *  paths
  */
 function Router(options) {
     assert.object(options, 'options');
     assert.object(options.log, 'options.log');
     assert.optionalBool(options.onceNext, 'options.onceNext');
     assert.optionalBool(options.strictNext, 'options.strictNext');
+    assert.optionalBool(
+        options.ignoreTrailingSlash,
+        'options.ignoreTrailingSlash'
+    );
 
     EventEmitter.call(this);
 

--- a/lib/routerRegistryRadix.js
+++ b/lib/routerRegistryRadix.js
@@ -9,9 +9,12 @@ var Chain = require('./chain');
  *
  * @class RouterRegistryRadix
  * @public
+ * @param  {Object} options - an options object
+ * @param {Object} [options.ignoreTrailingSlash] - ignore trailing slash on
+ *  paths
  */
-function RouterRegistryRadix() {
-    this._findMyWay = new FindMyWay();
+function RouterRegistryRadix(options) {
+    this._findMyWay = new FindMyWay(options);
     this._routes = {};
 }
 

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -346,3 +346,28 @@ test('toString()', function(t) {
     );
     t.end();
 });
+
+test('toString() with ignoreTrailingSlash', function(t) {
+    function handler(req, res, next) {
+        res.send('Hello world');
+    }
+
+    var router = new Router({
+        log: {},
+        ignoreTrailingSlash: true
+    });
+    router.mount({ method: 'GET', path: '/' }, [handler]);
+    router.mount({ method: 'GET', path: '/a' }, [handler]);
+    router.mount({ method: 'GET', path: '/a/b' }, [handler]);
+    router.mount({ method: 'POST', path: '/' }, [handler]);
+
+    t.deepEqual(
+        router.toString(),
+        '└── / (GET|POST)\n' +
+            '    └── a (GET)\n' +
+            '        └── / (GET)\n' +
+            '            └── b (GET)\n' +
+            '                └── / (GET)\n'
+    );
+    t.end();
+});

--- a/test/routerRegistryRadix.test.js
+++ b/test/routerRegistryRadix.test.js
@@ -99,3 +99,21 @@ test('toString()', function(t) {
     );
     t.end();
 });
+
+test('toString() with ignoreTrailingSlash', function(t) {
+    var registry = new RouterRegistryRadix({ ignoreTrailingSlash: true });
+    registry.add(getTestRoute({ method: 'GET', path: '/' }));
+    registry.add(getTestRoute({ method: 'GET', path: '/a' }));
+    registry.add(getTestRoute({ method: 'GET', path: '/a/b' }));
+    registry.add(getTestRoute({ method: 'POST', path: '/' }));
+
+    t.deepEqual(
+        registry.toString(),
+        '└── / (GET|POST)\n' +
+            '    └── a (GET)\n' +
+            '        └── / (GET)\n' +
+            '            └── b (GET)\n' +
+            '                └── / (GET)\n'
+    );
+    t.end();
+});

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -46,7 +46,8 @@ before(function(cb) {
             dtrace: helper.dtrace,
             handleUncaughtExceptions: true,
             log: helper.getLog('server'),
-            version: ['2.0.0', '0.5.4', '1.4.3']
+            version: ['2.0.0', '0.5.4', '1.4.3'],
+            ignoreTrailingSlash: true
         });
         SERVER.listen(PORT, '127.0.0.1', function() {
             PORT = SERVER.address().port;
@@ -154,6 +155,85 @@ test('get (path only)', function(t) {
         t.equal(res.statusCode, 200);
 
         if (++count === 2) {
+            t.end();
+        }
+    });
+});
+
+test('get (path only - with trailing slash)', function(t) {
+    SERVER.get('/foo/', function echoId(req, res, next) {
+        res.send();
+        next();
+    });
+
+    var count = 0;
+
+    CLIENT.get('/foo/', function(err, _, res) {
+        t.ifError(err);
+        t.equal(res.statusCode, 200);
+
+        if (++count === 2) {
+            t.end();
+        }
+    });
+
+    CLIENT.get('/foo', function(err, _, res) {
+        t.ifError(err);
+        t.equal(res.statusCode, 200);
+
+        if (++count === 2) {
+            t.end();
+        }
+    });
+});
+
+test('get (path only - with trailing slash and nested route)', function(t) {
+    SERVER.get('/foo/', function echoId(req, res, next) {
+        res.statusCode = 200;
+        res.send();
+        next();
+    });
+
+    SERVER.get('/foo/bar', function echoId(req, res, next) {
+        res.statusCode = 201;
+        res.send();
+        next();
+    });
+
+    var count = 0;
+
+    CLIENT.get('/foo/', function(err, _, res) {
+        t.ifError(err);
+        t.equal(res.statusCode, 200);
+
+        if (++count === 4) {
+            t.end();
+        }
+    });
+
+    CLIENT.get('/foo', function(err, _, res) {
+        t.ifError(err);
+        t.equal(res.statusCode, 200);
+
+        if (++count === 4) {
+            t.end();
+        }
+    });
+
+    CLIENT.get('/foo/bar/', function(err, _, res) {
+        t.ifError(err);
+        t.equal(res.statusCode, 201);
+
+        if (++count === 4) {
+            t.end();
+        }
+    });
+
+    CLIENT.get('/foo/bar', function(err, _, res) {
+        t.ifError(err);
+        t.equal(res.statusCode, 201);
+
+        if (++count === 4) {
             t.end();
         }
     });


### PR DESCRIPTION
<!--
Thank you for taking the time to open an PR for restify! If this is your first
time here, welcome to our community! We are a group of developers who work on
restify in our free-time. Some of us do it as a hobby, others are using restify
at work. When asking for help here, keep in mind most of us are volunteers
contributing our daily work back to the community at no cost (and often for no
reward). Please be respectful!

Below you will find a checklist to help you create the best PR possible. While
the checklist items aren't all _strictly_ required, they dramatically increase
the probability of your PR getting a response and getting merged. Often times,
the least time consuming part of maintaining and open source project is writing
code, its the process and discussions that happen around the code base that
consume a majority of the maintainers' time. By spending a few moments to
adhere to this template, you are not only improve the quality of your PR, you
are also helping save the maintainers a considerable amount of time when trying
to understand and review your changes.

And remember, positive vibes are met with positive vibes. Kindness helps Free
Software go round, pay it forward!
-->

## Pre-Submission Checklist

- [ ] Opened an issue discussing these changes before opening the PR
- [x] Ran the linter and tests via `make prepush`
- [x] Included comprehensive and convincing tests for changes

## Issues

Closes:

* Issue #1631

> Summarize the issues that discussed these changes

*This is my first pr in this project and I didn't know the rule "Opened an issue discussing these changes before opening the PR". Since I've already did all the work I hope it is ok if I open it anyway. Sorry for the inconvenience.*

# Changes

Added [ignoreTrailingSlash](https://github.com/delvedor/find-my-way#api) router option.

> What does this PR do?

[`find-my-way`](https://github.com/delvedor/find-my-way) does not support by default trailing slash in routes, so `/path` and `/path/` are not the same thing (and the one with the trailing slash will be a 404).

If a user need this specific behaviour it can pass `{ ignoreTrailingSlash: true }` to `find-my-way`. The result will be that internally `find-my-way` will register two routes `/path` and `/path/`, this will be seen in the debug log.

This pr add the possibility to pass this option (and possibly more) to `find-my-way`.

@hekike can you review? Thanks.