### PR TITLE
feat: Added export for Chain

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -108,3 +108,4 @@ module.exports.createServer = createServer;
 module.exports.formatters = require('./formatters');
 module.exports.plugins = require('./plugins');
 module.exports.pre = require('./plugins').pre;
+module.exports.chain = require('./chain');


### PR DESCRIPTION
Added an export for Chain so that it can be used in libraries such as enroute. 
Specifically, this will be used in enroute to add a development mode that support hot reloading of routes. To be able to do this the chain logic needs to be available in enroute, hence the extra export in restify.

Although the code change itself is trivial, it does imply that Chain becomes part of the API.