### PR TITLE
fix: proxy events into instance var and add test script

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -187,7 +187,7 @@ function Server(options) {
 
     this.router.on('mount', this.emit.bind(this, 'mount'));
 
-    if (!options.handleUpgrades && this.proxyEvents.indexOf('upgrade') === -1) {
+    if (!options.handleUpgrades) {
         this.proxyEvents.push('upgrade');
     }
     this.proxyEvents.forEach(function forEach(e) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -34,14 +34,6 @@ patchRequest(http.IncomingMessage);
 ///--- Globals
 
 var sprintf = util.format;
-var PROXY_EVENTS = [
-    'clientError',
-    'close',
-    'connection',
-    'error',
-    'listening',
-    'secureConnection'
-];
 
 ///--- API
 
@@ -138,6 +130,14 @@ function Server(options) {
     var fmt = mergeFormatters(options.formatters);
     this.acceptable = fmt.acceptable;
     this.formatters = fmt.formatters;
+    this.proxyEvents = [
+        'clientError',
+        'close',
+        'connection',
+        'error',
+        'listening',
+        'secureConnection'
+    ];
 
     if (options.spdy) {
         this.spdy = true;
@@ -187,10 +187,10 @@ function Server(options) {
 
     this.router.on('mount', this.emit.bind(this, 'mount'));
 
-    if (!options.handleUpgrades && PROXY_EVENTS.indexOf('upgrade') === -1) {
-        PROXY_EVENTS.push('upgrade');
+    if (!options.handleUpgrades && this.proxyEvents.indexOf('upgrade') === -1) {
+        this.proxyEvents.push('upgrade');
     }
-    PROXY_EVENTS.forEach(function forEach(e) {
+    this.proxyEvents.forEach(function forEach(e) {
         self.server.on(e, self.emit.bind(self, e));
     });
 

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -2430,3 +2430,19 @@ test('should emit error with multiple next calls with strictNext', function(t) {
         });
     });
 });
+
+test('should have proxy event handlers as instance', function(t) {
+    var server = restify.createServer({
+        handleUpgrades: false
+    });
+    t.equal(server.proxyEvents.length, 7);
+
+    server = restify.createServer({
+        handleUpgrades: true
+    });
+
+    t.equal(server.proxyEvents.length, 6);
+    server.close(function() {
+        t.end();
+    });
+});


### PR DESCRIPTION
<!--
Thank you for taking the time to open an PR for restify! If this is your first
time here, welcome to our community! We are a group of developers who work on
restify in our free-time. Some of us do it as a hobby, others are using restify
at work. When asking for help here, keep in mind most of us are volunteers
contributing our daily work back to the community at no cost (and often for no
reward). Please be respectful!

Below you will find a checklist to help you create the best PR possible. While
the checklist items aren't all _strictly_ required, they dramatically increase
the probability of your PR getting a response and getting merged. Often times,
the least time consuming part of maintaining and open source project is writing
code, its the process and discussions that happen around the code base that
consume a majority of the maintainers' time. By spending a few moments to
adhere to this template, you are not only improve the quality of your PR, you
are also helping save the maintainers a considerable amount of time when trying
to understand and review your changes.

And remember, positive vibes are met with positive vibes. Kindness helps Free
Software go round, pay it forward!
-->

## Pre-Submission Checklist

- [ x] Opened an issue discussing these changes before opening the PR
- [ x] Ran the linter and tests via `make prepush`
- [ x] Included comprehensive and convincing tests for changes

## Issues
#1348 
Closes:

* Issue #1348
* Issue #
* Issue #

> Summarize the issues that discussed these changes
Since PROXY_EVENTS are shared between every instance of a restify server, and upgrade is added but never removed, all future instances of Server will have the upgrade event proxied.

# Changes

> What does this PR do?
update PROXY_EVENTS to an instance variable.