### PR TITLE
Use Regex to validate extended JSON content types

### DIFF
--- a/lib/plugins/bodyParser.js
+++ b/lib/plugins/bodyParser.js
@@ -161,8 +161,12 @@ function bodyParser(options) {
 
         var parser;
         var type = req.contentType().toLowerCase().split(';')[0];
-        
+        var jsonPatternMatcher = new RegExp("^application\/[a-zA-Z.]+\\+json");
+
         switch (true) {
+            case jsonPatternMatcher.test(type):
+                parser = parseJson[0];
+                break;
             case type === 'application/json':
                 parser = parseJson[0];
                 break;

--- a/lib/plugins/bodyParser.js
+++ b/lib/plugins/bodyParser.js
@@ -160,25 +160,25 @@ function bodyParser(options) {
         }
 
         var parser;
-        var type = req.contentType().toLowerCase();
-
-        switch (type) {
-            case 'application/json':
+        var type = req.contentType().toLowerCase().split(';');
+        
+        switch (true) {
+            case type === 'application/json':
                 parser = parseJson[0];
                 break;
-            case 'application/x-www-form-urlencoded':
+            case type === 'application/x-www-form-urlencoded':
                 parser = parseForm[0];
                 break;
-            case 'multipart/form-data':
+            case type === 'multipart/form-data':
                 parser = parseMultipart;
                 break;
-            case 'text/tsv':
+            case type === 'text/tsv':
                 parser = parseFieldedText;
                 break;
-            case 'text/tab-separated-values':
+            case type === 'text/tab-separated-values':
                 parser = parseFieldedText;
                 break;
-            case 'text/csv':
+            case type === 'text/csv':
                 parser = parseFieldedText;
                 break;
 

--- a/lib/plugins/bodyParser.js
+++ b/lib/plugins/bodyParser.js
@@ -160,7 +160,7 @@ function bodyParser(options) {
         }
 
         var parser;
-        var type = req.contentType().toLowerCase().split(';');
+        var type = req.contentType().toLowerCase().split(';')[0];
         
         switch (true) {
             case type === 'application/json':

--- a/lib/plugins/bodyParser.js
+++ b/lib/plugins/bodyParser.js
@@ -160,8 +160,11 @@ function bodyParser(options) {
         }
 
         var parser;
-        var type = req.contentType().toLowerCase().split(';')[0];
-        var jsonPatternMatcher = new RegExp("^application\/[a-zA-Z.]+\\+json");
+        var type = req
+                    .contentType()
+                    .toLowerCase()
+                    .split(';')[0];
+        var jsonPatternMatcher = new RegExp('^application\/[a-zA-Z.]+\\+json');
 
         switch (true) {
             case jsonPatternMatcher.test(type):

--- a/lib/plugins/jsonBodyParser.js
+++ b/lib/plugins/jsonBodyParser.js
@@ -27,9 +27,13 @@ function jsonBodyParser(options) {
     function parseJson(req, res, next) {
         // save original body on req.rawBody and req._body
         req.rawBody = req._body = req.body;
+        var jsonPatternMatcher = new RegExp("^application\/[a-zA-Z.]+\\+json");
+        var contentType = req.getContentType().split(';')[0]
 
-        if (req.getContentType().split(';')[0] !== 'application/json' || !req.body) {
-            return next();
+        if (contentType !== 'application/json' || !req.body) {
+            if(!jsonPatternMatcher.test(contentType) ) {
+                return next();
+            }
         }
 
         var params;

--- a/lib/plugins/jsonBodyParser.js
+++ b/lib/plugins/jsonBodyParser.js
@@ -28,7 +28,7 @@ function jsonBodyParser(options) {
         // save original body on req.rawBody and req._body
         req.rawBody = req._body = req.body;
 
-        if (req.getContentType() !== 'application/json' || !req.body) {
+        if (req.getContentType().split(';')[0] !== 'application/json' || !req.body) {
             return next();
         }
 

--- a/lib/plugins/jsonBodyParser.js
+++ b/lib/plugins/jsonBodyParser.js
@@ -27,7 +27,7 @@ function jsonBodyParser(options) {
     function parseJson(req, res, next) {
         // save original body on req.rawBody and req._body
         req.rawBody = req._body = req.body;
-        var jsonPatternMatcher = new RegExp("^application\/[a-zA-Z.]+\\+json");
+        var jsonPatternMatcher = new RegExp('^application\/[a-zA-Z.]+\\+json');
         var contentType = req.getContentType().split(';')[0];
 
         if (contentType !== 'application/json' || !req.body) {

--- a/lib/plugins/jsonBodyParser.js
+++ b/lib/plugins/jsonBodyParser.js
@@ -28,10 +28,10 @@ function jsonBodyParser(options) {
         // save original body on req.rawBody and req._body
         req.rawBody = req._body = req.body;
         var jsonPatternMatcher = new RegExp("^application\/[a-zA-Z.]+\\+json");
-        var contentType = req.getContentType().split(';')[0]
+        var contentType = req.getContentType().split(';')[0];
 
         if (contentType !== 'application/json' || !req.body) {
-            if(!jsonPatternMatcher.test(contentType) ) {
+            if (!jsonPatternMatcher.test(contentType)) {
                 return next();
             }
         }


### PR DESCRIPTION
## Issues

Closes:

* Issue #1442 

# Changes

Uses regex to validate the json content types according to the specification in https://www.iana.org/assignments/media-types/media-types.xhtml