### PR TITLE
fix(server): address Node v10.x req close event firing order

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1155,6 +1155,8 @@ Server.prototype._setupRequest = function _setupRequest(req, res) {
         var err = new errors.RequestCloseError();
         err.statusCode = 444;
 
+        // For backward compatibility we only set connection state to closed
+        // for RequestCloseError
         req._connectionState = 'close';
 
         // Set status code and _sent for audit

--- a/lib/server.js
+++ b/lib/server.js
@@ -1091,7 +1091,7 @@ Server.prototype._onHandlerError = function _onHandlerError(err, req, res) {
         return;
     }
 
-    // Handlers doesn't continue when error happen
+    // Handlers don't continue when error happen
     res._handlersFinished = true;
 
     // Preserve handler err for finish event
@@ -1178,7 +1178,7 @@ Server.prototype._setupRequest = function _setupRequest(req, res) {
         req._timeUseEnd = req._timeUseEnd || processHrTime;
         req._timeRouteEnd = req._timeRouteEnd || processHrTime;
 
-        // In Node < 10 close didn't fire always
+        // In Node < 10 "close" event dont fire always
         // https://github.com/nodejs/node/pull/20611
         self._finishReqResCycle(req, res);
     }
@@ -1187,7 +1187,7 @@ Server.prototype._setupRequest = function _setupRequest(req, res) {
     function onResClose() {
         res._flushed = true;
 
-        // Finish may already set flushed timer
+        // Finish may already set the req._timeFlushed
         req._timeFlushed = req._timeFlushed || process.hrtime();
 
         self._finishReqResCycle(req, res, res.err);

--- a/lib/server.js
+++ b/lib/server.js
@@ -1139,24 +1139,18 @@ Server.prototype._setupRequest = function _setupRequest(req, res) {
     }
 
     // Request lifecycle events
-    // attach a listener for 'close' events, this will let us set
-    // a flag so that we can stop processing the request if the client closes
+    // attach a listener for 'aborted' events, this will let us set
+    // a flag so that we can stop processing the request if the client aborts
     // the connection (or we lose the connection).
     // we consider a closed request as flushed from metrics point of view
-    function onReqClose() {
-        // Do not handle close if response is already sent (may not flushed yet)
-        // In Node >= 10.4.0 res's close event is always emitted
-        // Introduced in: https://github.com/nodejs/node/pull/20611
-        if (res._sent) {
-            return;
-        }
-
-        // Request was aborted or closed. Override the status code
+    function onReqAborted() {
+        // Request was aborted, override the status code
         var err = new errors.RequestCloseError();
         err.statusCode = 444;
 
-        // For backward compatibility we only set connection state to closed
-        // for RequestCloseError
+        // For backward compatibility we only set connection state to "close"
+        // for RequestCloseError, also aborted is always immediatly followed
+        // by a "close" event
         req._connectionState = 'close';
 
         // Set status code and _sent for audit
@@ -1181,15 +1175,18 @@ Server.prototype._setupRequest = function _setupRequest(req, res) {
 
         self._finishReqResCycle(req, res);
     }
+
+    // Emitted when the response has been sent.
     function onResClose() {
         res._flushed = true;
-        req._timeFlushed = process.hrtime();
+        // Finish may alread set flushed timer
+        req._timeFlushed = req._timeFlushed || process.hrtime();
 
         self._finishReqResCycle(req, res, res.err);
     }
 
     // Request events
-    req.once('close', onReqClose);
+    req.once('aborted', onReqAborted);
 
     // Response events
     res.once('finish', onResFinish);

--- a/lib/server.js
+++ b/lib/server.js
@@ -1151,18 +1151,15 @@ Server.prototype._setupRequest = function _setupRequest(req, res) {
 
         // For backward compatibility we only set connection state to "close"
         // for RequestCloseError, also aborted is always immediatly followed
-        // by a "close" event so we don't change connection state here
+        // by a "close" event.
+        // We don't set _connectionState to "close" in the happy path
+        req._connectionState = 'close';
 
         // Set status code and _sent for audit
         // as req is already closed connection
         res.statusCode = err.statusCode;
         res._sent = true;
         res.err = err;
-    }
-
-    // Indicates that the underlying connection was closed
-    function onReqClose() {
-        req._connectionState = 'close';
     }
 
     // Response lifecycle events
@@ -1183,7 +1180,6 @@ Server.prototype._setupRequest = function _setupRequest(req, res) {
         self._finishReqResCycle(req, res);
     }
 
-    // Emitted when the response has been sent.
     function onResClose() {
         res._flushed = true;
 
@@ -1194,7 +1190,6 @@ Server.prototype._setupRequest = function _setupRequest(req, res) {
     }
 
     // Request events
-    req.once('close', onReqClose);
     req.once('aborted', onReqAborted);
 
     // Response events

--- a/lib/server.js
+++ b/lib/server.js
@@ -1148,8 +1148,8 @@ Server.prototype._setupRequest = function _setupRequest(req, res) {
 
         req._connectionState = 'close';
 
-        // Do no handle close if request is already flushed
-        // In Node >= 10 res's close event is always emitted
+        // Do not handle close if response is already flushed
+        // In Node >= 10.4.0 res's close event is always emitted
         // Introduced in: https://github.com/nodejs/node/pull/20611
         if (res._flushed) {
             return;
@@ -1169,8 +1169,8 @@ Server.prototype._setupRequest = function _setupRequest(req, res) {
     }
 
     // Handle res's close on to the next cycle
-    // Required in Node >= 10:
-    // introduced in: https://github.com/nodejs/node/pull/20941
+    // Required in Node >= 10.4.0:
+    // Introduced in: https://github.com/nodejs/node/pull/20941
     req.once('close', function onReqClose() {
         setImmediate(onClose);
     });

--- a/lib/server.js
+++ b/lib/server.js
@@ -1180,6 +1180,8 @@ Server.prototype._setupRequest = function _setupRequest(req, res) {
         self._finishReqResCycle(req, res);
     }
 
+    // We are handling when connection is being closed prematurely outside of
+    // restify. It's not because the req is aborted.
     function onResClose() {
         res._flushed = true;
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -1091,7 +1091,8 @@ Server.prototype._onHandlerError = function _onHandlerError(err, req, res) {
         return;
     }
 
-    res._handlersFinished = true;
+    // Handlers doesn't continue when error happen
+    self._onHandlerStop(req, res);
 
     // Preserve handler err for finish event
     res.err = res.err || err;
@@ -1142,41 +1143,29 @@ Server.prototype._setupRequest = function _setupRequest(req, res) {
     // a flag so that we can stop processing the request if the client closes
     // the connection (or we lose the connection).
     // we consider a closed request as flushed from metrics point of view
-    function onClose() {
-        res.removeListener('finish', onFinish);
-        res.removeListener('error', onError);
-
+    function onReqClose() {
         req._connectionState = 'close';
 
-        // Do not handle close if response is already flushed
+        // Do not handle close if response is already sent (may not flushed yet)
         // In Node >= 10.4.0 res's close event is always emitted
         // Introduced in: https://github.com/nodejs/node/pull/20611
-        if (res._flushed) {
+        if (res._sent) {
             return;
         }
 
-        // Handle close and return error if request is not flushed yet
-        res._flushed = true;
-        req._timeFlushed = process.hrtime();
-
         // Request was aborted or closed. Override the status code
-        res.statusCode = 444;
-        self._finishReqResCycle(
-            req,
-            res,
-            res.err || new errors.RequestCloseError()
-        );
+        var err = new errors.RequestCloseError();
+        err.statusCode = 444;
+
+        // Set status code and _sent for audit
+        // as req is already closed connection
+        res.statusCode = err.statusCode;
+        res._sent = true;
+        res.err = err;
     }
 
-    // Handle res's close on to the next cycle
-    // Required in Node >= 10.4.0:
-    // Introduced in: https://github.com/nodejs/node/pull/20941
-    req.once('close', function onReqClose() {
-        setImmediate(onClose);
-    });
-
     // Response lifecycle events
-    function onFinish() {
+    function onResFinish() {
         var processHrTime = process.hrtime();
 
         res._flushed = true;
@@ -1188,22 +1177,21 @@ Server.prototype._setupRequest = function _setupRequest(req, res) {
         req._timeUseEnd = req._timeUseEnd || processHrTime;
         req._timeRouteEnd = req._timeRouteEnd || processHrTime;
 
-        req.removeListener('close', onClose);
-        res.removeListener('error', onError);
-
-        // Do not trigger false
         self._finishReqResCycle(req, res);
     }
-    function onError(err) {
+    function onResClose() {
         res._flushed = true;
         req._timeFlushed = process.hrtime();
 
-        req.removeListener('close', onClose);
-        res.removeListener('finish', onFinish);
-        self._finishReqResCycle(req, res, err);
+        self._finishReqResCycle(req, res, res.err);
     }
-    res.once('finish', onFinish);
-    res.once('error', onError);
+
+    // Request events
+    req.once('close', onReqClose);
+
+    // Response events
+    res.once('finish', onResFinish);
+    res.once('close', onResClose);
 
     // attach a listener for the response's 'redirect' event
     res.on('redirect', function onRedirect(redirectLocation) {
@@ -1274,7 +1262,6 @@ Server.prototype._routeErrorResponse = function _routeErrorResponse(
 ) {
     var self = this;
 
-    // if (self.handleUncaughtExceptions) {
     if (self.listenerCount('uncaughtException') > 1) {
         self.emit('uncaughtException', req, res, req.route, err);
         return;

--- a/lib/server.js
+++ b/lib/server.js
@@ -1092,7 +1092,7 @@ Server.prototype._onHandlerError = function _onHandlerError(err, req, res) {
     }
 
     // Handlers doesn't continue when error happen
-    self._onHandlerStop(req, res);
+    res._handlersFinished = true;
 
     // Preserve handler err for finish event
     res.err = res.err || err;
@@ -1139,6 +1139,7 @@ Server.prototype._setupRequest = function _setupRequest(req, res) {
     }
 
     // Request lifecycle events
+
     // attach a listener for 'aborted' events, this will let us set
     // a flag so that we can stop processing the request if the client aborts
     // the connection (or we lose the connection).
@@ -1150,14 +1151,18 @@ Server.prototype._setupRequest = function _setupRequest(req, res) {
 
         // For backward compatibility we only set connection state to "close"
         // for RequestCloseError, also aborted is always immediatly followed
-        // by a "close" event
-        req._connectionState = 'close';
+        // by a "close" event so we don't change connection state here
 
         // Set status code and _sent for audit
         // as req is already closed connection
         res.statusCode = err.statusCode;
         res._sent = true;
         res.err = err;
+    }
+
+    // Indicates that the underlying connection was closed
+    function onReqClose() {
+        req._connectionState = 'close';
     }
 
     // Response lifecycle events
@@ -1173,19 +1178,23 @@ Server.prototype._setupRequest = function _setupRequest(req, res) {
         req._timeUseEnd = req._timeUseEnd || processHrTime;
         req._timeRouteEnd = req._timeRouteEnd || processHrTime;
 
+        // In Node < 10 close didn't fire always
+        // https://github.com/nodejs/node/pull/20611
         self._finishReqResCycle(req, res);
     }
 
     // Emitted when the response has been sent.
     function onResClose() {
         res._flushed = true;
-        // Finish may alread set flushed timer
+
+        // Finish may already set flushed timer
         req._timeFlushed = req._timeFlushed || process.hrtime();
 
         self._finishReqResCycle(req, res, res.err);
     }
 
     // Request events
+    req.once('close', onReqClose);
     req.once('aborted', onReqAborted);
 
     // Response events

--- a/lib/server.js
+++ b/lib/server.js
@@ -1144,8 +1144,6 @@ Server.prototype._setupRequest = function _setupRequest(req, res) {
     // the connection (or we lose the connection).
     // we consider a closed request as flushed from metrics point of view
     function onReqClose() {
-        req._connectionState = 'close';
-
         // Do not handle close if response is already sent (may not flushed yet)
         // In Node >= 10.4.0 res's close event is always emitted
         // Introduced in: https://github.com/nodejs/node/pull/20611
@@ -1156,6 +1154,8 @@ Server.prototype._setupRequest = function _setupRequest(req, res) {
         // Request was aborted or closed. Override the status code
         var err = new errors.RequestCloseError();
         err.statusCode = 444;
+
+        req._connectionState = 'close';
 
         // Set status code and _sent for audit
         // as req is already closed connection

--- a/lib/server.js
+++ b/lib/server.js
@@ -1143,19 +1143,37 @@ Server.prototype._setupRequest = function _setupRequest(req, res) {
     // the connection (or we lose the connection).
     // we consider a closed request as flushed from metrics point of view
     function onClose() {
+        res.removeListener('finish', onFinish);
+        res.removeListener('error', onError);
+
+        req._connectionState = 'close';
+
+        // Do no handle close if request is already flushed
+        // In Node >= 10 res's close event is always emitted
+        // Introduced in: https://github.com/nodejs/node/pull/20611
+        if (res._flushed) {
+            return;
+        }
+
+        // Handle close and return error if request is not flushed yet
         res._flushed = true;
         req._timeFlushed = process.hrtime();
 
-        res.removeListener('finish', onFinish);
-        res.removeListener('error', onError);
-        req._connectionState = 'close';
-
         // Request was aborted or closed. Override the status code
         res.statusCode = 444;
-
-        self._finishReqResCycle(req, res, new errors.RequestCloseError());
+        self._finishReqResCycle(
+            req,
+            res,
+            res.err || new errors.RequestCloseError()
+        );
     }
-    req.once('close', onClose);
+
+    // Handle res's close on to the next cycle
+    // Required in Node >= 10:
+    // introduced in: https://github.com/nodejs/node/pull/20941
+    req.once('close', function onReqClose() {
+        setImmediate(onClose);
+    });
 
     // Response lifecycle events
     function onFinish() {

--- a/lib/server.js
+++ b/lib/server.js
@@ -1155,10 +1155,8 @@ Server.prototype._setupRequest = function _setupRequest(req, res) {
         // We don't set _connectionState to "close" in the happy path
         req._connectionState = 'close';
 
-        // Set status code and _sent for audit
-        // as req is already closed connection
+        // Set status code and err for audit as req is already closed connection
         res.statusCode = err.statusCode;
-        res._sent = true;
         res.err = err;
     }
 

--- a/test/plugins/audit.test.js
+++ b/test/plugins/audit.test.js
@@ -676,16 +676,23 @@ describe('audit logger', function() {
             assert.ok(data);
             assert.ok(data.req_id);
             assert.isNumber(data.latency);
-            assert.equal(444, data.res.statusCode);
+            assert.equal(data.res.statusCode, 444);
             done();
         });
 
         SERVER.get('/audit', function(req, res, next) {
-            req.emit('close');
-            res.send();
-            next();
+            setTimeout(function() {
+                res.send();
+                next();
+            }, 100);
         });
 
-        CLIENT.get('/audit', function(err, req, res) {});
+        CLIENT.get(
+            {
+                path: '/audit',
+                requestTimeout: 50
+            },
+            function(err, req, res) {}
+        );
     });
 });

--- a/test/plugins/metrics.test.js
+++ b/test/plugins/metrics.test.js
@@ -57,60 +57,6 @@ describe('request metrics plugin', function() {
 
                     assert.isObject(metrics, 'metrics');
                     assert.equal(metrics.statusCode, 202);
-                    assert.isAtLeast(metrics.preLatency, 0);
-                    assert.isAtLeast(metrics.useLatency, 0);
-                    assert.isAtLeast(metrics.routeLatency, 0);
-                    assert.isAtLeast(metrics.latency, 0);
-                    assert.isAtLeast(metrics.totalLatency, 0);
-                    assert.equal(metrics.path, '/foo');
-                    assert.equal(metrics.connectionState, undefined);
-                    assert.equal(metrics.method, 'GET');
-                    assert.isNumber(metrics.inflightRequests);
-
-                    assert.isObject(req, 'req');
-                    assert.isObject(res, 'res');
-                    assert.isObject(route, 'route');
-                }
-            )
-        );
-
-        SERVER.pre(function(req, res, next) {
-            return next();
-        });
-
-        SERVER.use(function(req, res, next) {
-            return next();
-        });
-
-        SERVER.get('/foo', function(req, res, next) {
-            res.send(202, 'hello world');
-            return next();
-        });
-
-        CLIENT.get('/foo?a=1', function(err, _, res) {
-            assert.ifError(err);
-            assert.equal(res.statusCode, 202);
-            return done();
-        });
-    });
-
-    it('should return metrics for a given request with work', function(done) {
-        SERVER.on('uncaughtException', function(req, res, route, err) {
-            assert.ifError(err);
-        });
-
-        // with timeouts we are sure that request lifecycle metrics are correct
-        SERVER.on(
-            'after',
-            restify.plugins.metrics(
-                {
-                    server: SERVER
-                },
-                function(err, metrics, req, res, route) {
-                    assert.ifError(err);
-
-                    assert.isObject(metrics, 'metrics');
-                    assert.equal(metrics.statusCode, 202);
                     assert.isAtLeast(metrics.preLatency, 50);
                     assert.isAtLeast(metrics.useLatency, 50);
                     assert.isAtLeast(metrics.routeLatency, 50);

--- a/test/plugins/metrics.test.js
+++ b/test/plugins/metrics.test.js
@@ -3,7 +3,6 @@
 
 // external requires
 var assert = require('chai').assert;
-var semver = require('semver');
 
 var restify = require('../../lib/index.js');
 var restifyClients = require('restify-clients');
@@ -15,8 +14,6 @@ var helper = require('../lib/helper');
 var SERVER;
 var CLIENT;
 var PORT;
-
-var isOlderNode = semver.lte(process.version, 'v10.0.0');
 
 describe('request metrics plugin', function() {
     beforeEach(function(done) {
@@ -67,10 +64,7 @@ describe('request metrics plugin', function() {
                     assert.isAtLeast(metrics.totalLatency, 150);
                     assert.equal(metrics.path, '/foo');
                     // close doesn't always fire in Node < 10
-                    assert.equal(
-                        metrics.connectionState,
-                        isOlderNode ? undefined : 'close'
-                    );
+                    assert.equal(metrics.connectionState, undefined);
                     assert.equal(metrics.method, 'GET');
                     assert.isNumber(metrics.inflightRequests);
 
@@ -288,10 +282,7 @@ describe('request metrics plugin', function() {
                     assert.equal(metrics.path, '/foo');
                     assert.equal(metrics.method, 'GET');
                     // close doesn't always fire in Node < 10
-                    assert.equal(
-                        metrics.connectionState,
-                        isOlderNode ? undefined : 'close'
-                    );
+                    assert.equal(metrics.connectionState, undefined);
                     assert.isNumber(metrics.inflightRequests);
                     return done();
                 }

--- a/test/plugins/metrics.test.js
+++ b/test/plugins/metrics.test.js
@@ -62,7 +62,7 @@ describe('request metrics plugin', function() {
                     assert.isAtLeast(metrics.latency, 150);
                     assert.isAtLeast(metrics.totalLatency, 150);
                     assert.equal(metrics.path, '/foo');
-                    // close in Node >= 10
+                    // close doesn't always fire in Node < 10
                     assert.include(
                         [undefined, 'close'],
                         metrics.connectionState
@@ -283,7 +283,7 @@ describe('request metrics plugin', function() {
                     assert.isNumber(metrics.latency, 200);
                     assert.equal(metrics.path, '/foo');
                     assert.equal(metrics.method, 'GET');
-                    // close in Node >= 10
+                    // close doesn't always fire in Node < 10
                     assert.include(
                         [undefined, 'close'],
                         metrics.connectionState

--- a/test/plugins/metrics.test.js
+++ b/test/plugins/metrics.test.js
@@ -3,6 +3,8 @@
 
 // external requires
 var assert = require('chai').assert;
+var semver = require('semver');
+
 var restify = require('../../lib/index.js');
 var restifyClients = require('restify-clients');
 
@@ -13,6 +15,8 @@ var helper = require('../lib/helper');
 var SERVER;
 var CLIENT;
 var PORT;
+
+var isOlderNode = semver.lte(process.version, 'v10.0.0');
 
 describe('request metrics plugin', function() {
     beforeEach(function(done) {
@@ -63,9 +67,9 @@ describe('request metrics plugin', function() {
                     assert.isAtLeast(metrics.totalLatency, 150);
                     assert.equal(metrics.path, '/foo');
                     // close doesn't always fire in Node < 10
-                    assert.include(
-                        [undefined, 'close'],
-                        metrics.connectionState
+                    assert.equal(
+                        metrics.connectionState,
+                        isOlderNode ? undefined : 'close'
                     );
                     assert.equal(metrics.method, 'GET');
                     assert.isNumber(metrics.inflightRequests);
@@ -284,9 +288,9 @@ describe('request metrics plugin', function() {
                     assert.equal(metrics.path, '/foo');
                     assert.equal(metrics.method, 'GET');
                     // close doesn't always fire in Node < 10
-                    assert.include(
-                        [undefined, 'close'],
-                        metrics.connectionState
+                    assert.equal(
+                        metrics.connectionState,
+                        isOlderNode ? undefined : 'close'
                     );
                     assert.isNumber(metrics.inflightRequests);
                     return done();

--- a/test/plugins/metrics.test.js
+++ b/test/plugins/metrics.test.js
@@ -62,7 +62,11 @@ describe('request metrics plugin', function() {
                     assert.isAtLeast(metrics.latency, 150);
                     assert.isAtLeast(metrics.totalLatency, 150);
                     assert.equal(metrics.path, '/foo');
-                    assert.equal(metrics.connectionState, 'close');
+                    // close in Node >= 10
+                    assert.include(
+                        [undefined, 'close'],
+                        metrics.connectionState
+                    );
                     assert.equal(metrics.method, 'GET');
                     assert.isNumber(metrics.inflightRequests);
 
@@ -267,6 +271,7 @@ describe('request metrics plugin', function() {
                 {
                     server: SERVER
                 },
+                // TODO: test timeouts if any of the following asserts fails
                 function(err, metrics, req, res, route) {
                     assert.ok(err);
                     assert.equal(err.name, 'Error');
@@ -278,7 +283,11 @@ describe('request metrics plugin', function() {
                     assert.isNumber(metrics.latency, 200);
                     assert.equal(metrics.path, '/foo');
                     assert.equal(metrics.method, 'GET');
-                    assert.equal(metrics.connectionState, 'close');
+                    // close in Node >= 10
+                    assert.include(
+                        [undefined, 'close'],
+                        metrics.connectionState
+                    );
                     assert.isNumber(metrics.inflightRequests);
                     return done();
                 }

--- a/test/plugins/metrics.test.js
+++ b/test/plugins/metrics.test.js
@@ -57,13 +57,66 @@ describe('request metrics plugin', function() {
 
                     assert.isObject(metrics, 'metrics');
                     assert.equal(metrics.statusCode, 202);
+                    assert.isAtLeast(metrics.preLatency, 0);
+                    assert.isAtLeast(metrics.useLatency, 0);
+                    assert.isAtLeast(metrics.routeLatency, 0);
+                    assert.isAtLeast(metrics.latency, 0);
+                    assert.isAtLeast(metrics.totalLatency, 0);
+                    assert.equal(metrics.path, '/foo');
+                    assert.equal(metrics.connectionState, undefined);
+                    assert.equal(metrics.method, 'GET');
+                    assert.isNumber(metrics.inflightRequests);
+
+                    assert.isObject(req, 'req');
+                    assert.isObject(res, 'res');
+                    assert.isObject(route, 'route');
+                }
+            )
+        );
+
+        SERVER.pre(function(req, res, next) {
+            return next();
+        });
+
+        SERVER.use(function(req, res, next) {
+            return next();
+        });
+
+        SERVER.get('/foo', function(req, res, next) {
+            res.send(202, 'hello world');
+            return next();
+        });
+
+        CLIENT.get('/foo?a=1', function(err, _, res) {
+            assert.ifError(err);
+            assert.equal(res.statusCode, 202);
+            return done();
+        });
+    });
+
+    it('should return metrics for a given request with work', function(done) {
+        SERVER.on('uncaughtException', function(req, res, route, err) {
+            assert.ifError(err);
+        });
+
+        // with timeouts we are sure that request lifecycle metrics are correct
+        SERVER.on(
+            'after',
+            restify.plugins.metrics(
+                {
+                    server: SERVER
+                },
+                function(err, metrics, req, res, route) {
+                    assert.ifError(err);
+
+                    assert.isObject(metrics, 'metrics');
+                    assert.equal(metrics.statusCode, 202);
                     assert.isAtLeast(metrics.preLatency, 50);
                     assert.isAtLeast(metrics.useLatency, 50);
                     assert.isAtLeast(metrics.routeLatency, 50);
                     assert.isAtLeast(metrics.latency, 150);
                     assert.isAtLeast(metrics.totalLatency, 150);
                     assert.equal(metrics.path, '/foo');
-                    // close doesn't always fire in Node < 10
                     assert.equal(metrics.connectionState, undefined);
                     assert.equal(metrics.method, 'GET');
                     assert.isNumber(metrics.inflightRequests);
@@ -281,7 +334,6 @@ describe('request metrics plugin', function() {
                     assert.isNumber(metrics.latency, 200);
                     assert.equal(metrics.path, '/foo');
                     assert.equal(metrics.method, 'GET');
-                    // close doesn't always fire in Node < 10
                     assert.equal(metrics.connectionState, undefined);
                     assert.isNumber(metrics.inflightRequests);
                     return done();

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1999,6 +1999,7 @@ test(
         SERVER.on('after', function(req, res, route, err) {
             t.ok(err);
             t.equal(req.connectionState(), 'close');
+            t.equal(res.statusCode, 444);
             t.equal(err.name, 'RequestCloseError');
             t.end();
         });

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1924,6 +1924,25 @@ test("should emit 'after' on successful request", function(t) {
     });
 
     SERVER.get('/foobar', function(req, res, next) {
+        res.send('hello world');
+        next();
+    });
+
+    CLIENT.get('/foobar', function(err, _, res) {
+        t.ifError(err);
+        t.equal(res.statusCode, 200);
+    });
+});
+
+test("should emit 'after' on successful request with work", function(t) {
+    SERVER.on('after', function(req, res, route, err) {
+        t.ifError(err);
+        t.end();
+    });
+
+    SERVER.get('/foobar', function(req, res, next) {
+        // with timeouts we are testing that request lifecycle
+        // events are firing in the correct order
         setTimeout(function() {
             res.send('hello world');
             setTimeout(function() {

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1924,8 +1924,12 @@ test("should emit 'after' on successful request", function(t) {
     });
 
     SERVER.get('/foobar', function(req, res, next) {
-        res.send('hello world');
-        next();
+        setTimeout(function() {
+            res.send('hello world');
+            setTimeout(function() {
+                next();
+            }, 500);
+        }, 500);
     });
 
     CLIENT.get('/foobar', function(err, _, res) {


### PR DESCRIPTION
Req close always fires in Node 10 and fires in a process.nextTick
This PR handles the close event in restify in a way that we only return an error if the response is not flushed yet.

Related changes in Node:

- https://github.com/nodejs/node/pull/20611
- https://github.com/nodejs/node/pull/20941