### PR TITLE
docs(index): sync createServer and Server constructor docs

### DIFF
--- a/docs/_api/server.md
+++ b/docs/_api/server.md
@@ -64,15 +64,17 @@ routes and handlers for incoming requests.
     -   `options.handleUpgrades` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Hook the `upgrade` event
         from the node HTTP server, pushing `Connection: Upgrade` requests through the
          regular request handling chain. (optional, default `false`)
+    -   `options.onceNext` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Prevents calling next multiple
+         times (optional, default `false`)
+    -   `options.strictNext` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Throws error when next() is
+         called more than once, enabled onceNext option (optional, default `false`)
     -   `options.httpsServerOptions` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** Any options accepted by
         [node-https Server](http://nodejs.org/api/https.html#https_https).
         If provided the following restify server options will be ignored:
         spdy, ca, certificate, key, passphrase, rejectUnauthorized, requestCert and
         ciphers; however these can all be specified on httpsServerOptions.
-    -   `options.onceNext` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Prevents calling next multiple
-         times (optional, default `false`)
-    -   `options.strictNext` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Throws error when next() is
-         called more than once, enabled onceNext option (optional, default `false`)
+    -   `options.noWriteContinue` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** prevents
+         `res.writeContinue()` in `server.on('checkContinue')` when proxing (optional, default `false`)
     -   `options.ignoreTrailingSlash` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** ignore trailing slash
         on paths (optional, default `false`)
 

--- a/docs/guides/server.md
+++ b/docs/guides/server.md
@@ -307,13 +307,14 @@ function sendV1(req, res, next) {
 }
 
 function sendV2(req, res, next) {
-  res.send({hello: req.params.name});
+  res.send({ hello: req.params.name });
   return next();
 }
 
-var PATH = '/hello/:name';
-server.get({path: PATH, version: '1.1.3'}, sendV1);
-server.get({path: PATH, version: '2.0.0'}, sendV2);
+server.get('/hello/:name', restify.plugins.conditionalHandler([
+  { version: '1.1.3', handler: sendV1 },
+  { version: '2.0.0', handler: sendV2 }
+]));
 
 server.listen(8080);
 ```
@@ -347,7 +348,9 @@ creation time.  Lastly, you can support multiple versions in the API by using
 an array:
 
 ```js
-server.get({path: PATH, version: ['2.0.0', '2.1.0', '2.2.0']}, sendV2);
+server.get('/hello/:name' restify.plugins.conditionalHandler([
+  { version: ['2.0.0', '2.1.0', '2.2.0'], handler: sendV2 }
+]));
 ```
 
 In this case you may need to know more information such as what the original
@@ -355,17 +358,18 @@ requested version string was, and what the matching version from the routes
 supported version array was. Two methods make this info available:
 
 ```js
-var PATH = '/version/test';
-server.get({
-  path: PATH,
-  version: ['2.0.0', '2.1.0', '2.2.0']
-}, function (req, res, next) {
-  res.send(200, {
-    requestedVersion: req.version(),
-    matchedVersion: req.matchedVersion()
-  });
-  return next();
-});
+server.get('/version/test', restify.plugins.conditionalHandler([
+  {
+    version: ['2.0.0', '2.1.0', '2.2.0'],
+    handler: function (req, res, next) {
+      res.send(200, {
+        requestedVersion: req.version(),
+        matchedVersion: req.matchedVersion()
+      });
+      return next();
+    }
+  }
+]));
 ```
 
 Hitting this route will respond as below:

--- a/docs/index.md
+++ b/docs/index.md
@@ -317,7 +317,7 @@ function sendV1(req, res, next) {
 }
 
 function sendV2(req, res, next) {
-  res.send({hello: req.params.name});
+  res.send({ hello: req.params.name });
   return next();
 }
 
@@ -368,7 +368,6 @@ requested version string was, and what the matching version from the routes
 supported version array was. Two methods make this info available:
 
 ```js
-var PATH = '/version/test';
 server.get('/version/test', restify.plugins.conditionalHandler([
   {
     version: ['2.0.0', '2.1.0', '2.2.0'],

--- a/lib/index.js
+++ b/lib/index.js
@@ -46,15 +46,17 @@ require('./errorTypes');
  * @param {Boolean} [options.handleUpgrades=false] - Hook the `upgrade` event
  * from the node HTTP server, pushing `Connection: Upgrade` requests through the
  *  regular request handling chain.
+ * @param {Boolean} [options.onceNext=false] - Prevents calling next multiple
+ *  times
+ * @param {Boolean} [options.strictNext=false] - Throws error when next() is
+ *  called more than once, enabled onceNext option
  * @param {Object} [options.httpsServerOptions] - Any options accepted by
  * [node-https Server](http://nodejs.org/api/https.html#https_https).
  * If provided the following restify server options will be ignored:
  * spdy, ca, certificate, key, passphrase, rejectUnauthorized, requestCert and
  * ciphers; however these can all be specified on httpsServerOptions.
- * @param {Boolean} [options.onceNext=false] - Prevents calling next multiple
- *  times
- * @param {Boolean} [options.strictNext=false] - Throws error when next() is
- *  called more than once, enabled onceNext option
+ * @param {Boolean} [options.noWriteContinue=false] - prevents
+ *  `res.writeContinue()` in `server.on('checkContinue')` when proxing
  * @param {Boolean} [options.ignoreTrailingSlash=false] - ignore trailing slash
  * on paths
  * @example


### PR DESCRIPTION
- Sync `createServer` and `Server` constructor docs
- update seever.md route versioning part

# Closes

https://github.com/restify/node-restify/issues/1666
