### PR TITLE
feat(audit): Support overriding default serializers

### DIFF
--- a/lib/plugins/audit.js
+++ b/lib/plugins/audit.js
@@ -237,7 +237,7 @@ function auditLogger(opts) {
      * @private
      * @function auditResponseSerializer
      * @param {http.ServerResponse} res - outgoing server response
-     * @returns {object} Serialized request
+     * @returns {object} Serialized response
      */
     function auditResponseSerializer(res) {
         if (!res) {

--- a/lib/plugins/audit.js
+++ b/lib/plugins/audit.js
@@ -196,10 +196,81 @@ function auditLogger(opts) {
     if (typeof printLog === 'undefined') {
         printLog = true;
     }
-    var errSerializer = bunyan.stdSerializers.err;
 
-    if (opts.log.serializers && opts.log.serializers.err) {
-        errSerializer = opts.log.serializers.err;
+    /**
+     * Serialize the HTTP Request into a plain object, for logging
+     *
+     * @private
+     * @function auditRequestSerializer
+     * @param {http.ClientRequest} req - Incoming request
+     * @returns {object} Serialized request
+     */
+    function auditRequestSerializer(req) {
+        if (!req) {
+            return false;
+        }
+
+        var timers = {};
+        (req.timers || []).forEach(function forEach(time) {
+            var t = time.time;
+            var _t = Math.floor(1000000 * t[0] + t[1] / 1000);
+            timers[time.name] = (timers[time.name] || 0) + _t;
+        });
+        return {
+            // account for native and queryParser plugin usage
+            query: typeof req.query === 'function' ? req.query() : req.query,
+            method: req.method,
+            url: req.url,
+            headers: req.headers,
+            httpVersion: req.httpVersion,
+            trailers: req.trailers,
+            version: req.version(),
+            body: opts.body === true ? req.body : undefined,
+            timers: timers,
+            connectionState: req.connectionState && req.connectionState()
+        };
+    }
+
+    /**
+     * Serialize the HTTP Response into a plain object, for logging
+     *
+     * @private
+     * @function auditResponseSerializer
+     * @param {http.ServerResponse} res - outgoing server response
+     * @returns {object} Serialized request
+     */
+    function auditResponseSerializer(res) {
+        if (!res) {
+            return false;
+        }
+
+        var body;
+
+        if (opts.body === true) {
+            if (res._body instanceof HttpError) {
+                body = res._body.body;
+            } else {
+                body = res._body;
+            }
+        }
+
+        return {
+            statusCode: res.statusCode,
+            headers: getResponseHeaders(res),
+            trailer: res._trailer || false,
+            body: body
+        };
+    }
+
+    var errSerializer = bunyan.stdSerializers.err;
+    var reqSerializer = auditRequestSerializer;
+    var resSerializer = auditResponseSerializer;
+
+    // Allow override of serializers
+    if (opts.log.serializers) {
+        reqSerializer = opts.log.serializers.req || reqSerializer;
+        resSerializer = opts.log.serializers.res || resSerializer;
+        errSerializer = opts.log.serializers.err || errSerializer;
     }
 
     var log = opts.log.child({
@@ -207,57 +278,8 @@ function auditLogger(opts) {
         component: opts.event,
         serializers: {
             err: errSerializer,
-            req: function auditRequestSerializer(req) {
-                if (!req) {
-                    return false;
-                }
-
-                var timers = {};
-                (req.timers || []).forEach(function forEach(time) {
-                    var t = time.time;
-                    var _t = Math.floor(1000000 * t[0] + t[1] / 1000);
-                    timers[time.name] = (timers[time.name] || 0) + _t;
-                });
-                return {
-                    // account for native and queryParser plugin usage
-                    query:
-                        typeof req.query === 'function'
-                            ? req.query()
-                            : req.query,
-                    method: req.method,
-                    url: req.url,
-                    headers: req.headers,
-                    httpVersion: req.httpVersion,
-                    trailers: req.trailers,
-                    version: req.version(),
-                    body: opts.body === true ? req.body : undefined,
-                    timers: timers,
-                    connectionState:
-                        req.connectionState && req.connectionState()
-                };
-            },
-            res: function auditResponseSerializer(res) {
-                if (!res) {
-                    return false;
-                }
-
-                var body;
-
-                if (opts.body === true) {
-                    if (res._body instanceof HttpError) {
-                        body = res._body.body;
-                    } else {
-                        body = res._body;
-                    }
-                }
-
-                return {
-                    statusCode: res.statusCode,
-                    headers: getResponseHeaders(res),
-                    trailer: res._trailer || false,
-                    body: body
-                };
-            }
+            req: reqSerializer,
+            res: resSerializer
         }
     });
 

--- a/test/plugins/audit.test.js
+++ b/test/plugins/audit.test.js
@@ -695,4 +695,63 @@ describe('audit logger', function() {
             function(err, req, res) {}
         );
     });
+
+    it('allow overriding serializers', function(done) {
+        var MOCK_REQ = 'REQ';
+        var MOCK_RES = 'RES';
+        var MOCK_ERR = 'ERR';
+
+        var ringbuffer = new bunyan.RingBuffer({ limit: 100 });
+
+        SERVER.once(
+            'after',
+            restify.plugins.auditLogger({
+                log: bunyan.createLogger({
+                    name: 'audit',
+                    streams: [
+                        {
+                            level: 'info',
+                            stream: ringbuffer
+                        }
+                    ],
+                    serializers: {
+                        req: function() {
+                            return MOCK_REQ;
+                        },
+                        res: function() {
+                            return MOCK_RES;
+                        },
+                        err: function() {
+                            return MOCK_ERR;
+                        }
+                    }
+                }),
+                server: SERVER,
+                event: 'after'
+            })
+        );
+
+        SERVER.once('audit', function(data) {
+            var log = JSON.parse(ringbuffer.records[0]);
+
+            assert.ok(log);
+            assert.equal(log.req, MOCK_REQ);
+            assert.equal(log.res, MOCK_RES);
+            assert.equal(log.err, MOCK_ERR);
+
+            done();
+        });
+
+        SERVER.get('/audit', function(req, res, next) {
+            res.send();
+            next(new Error('This does not get logged'));
+        });
+
+        CLIENT.get(
+            {
+                path: '/audit'
+            },
+            function(err, req, res) {}
+        );
+    });
 });

--- a/test/plugins/audit.test.js
+++ b/test/plugins/audit.test.js
@@ -696,7 +696,7 @@ describe('audit logger', function() {
         );
     });
 
-    it('allow overriding serializers', function(done) {
+    it('should allow overriding serializers', function(done) {
         var MOCK_REQ = 'REQ';
         var MOCK_RES = 'RES';
         var MOCK_ERR = 'ERR';


### PR DESCRIPTION
<!--
Thank you for taking the time to open an PR for restify! If this is your first
time here, welcome to our community! We are a group of developers who work on
restify in our free-time. Some of us do it as a hobby, others are using restify
at work. When asking for help here, keep in mind most of us are volunteers
contributing our daily work back to the community at no cost (and often for no
reward). Please be respectful!

Below you will find a checklist to help you create the best PR possible. While
the checklist items aren't all _strictly_ required, they dramatically increase
the probability of your PR getting a response and getting merged. Often times,
the least time consuming part of maintaining and open source project is writing
code, its the process and discussions that happen around the code base that
consume a majority of the maintainers' time. By spending a few moments to
adhere to this template, you are not only improve the quality of your PR, you
are also helping save the maintainers a considerable amount of time when trying
to understand and review your changes.

And remember, positive vibes are met with positive vibes. Kindness helps Free
Software go round, pay it forward!
-->

## Pre-Submission Checklist

- [x] Opened an issue discussing these changes before opening the PR **(existing issue)**
- [x] Ran the linter and tests via `make prepush`
- [x] Included comprehensive and convincing tests for changes

## Issues

Closes:

* Issue #1601

> Similar to @ekristen, I have a use-case to override the existing req/res serializers that are passed by the Restify Audit plugin. As discussed in the issue #1601, when a child logger is derrived from the passed in logger, the serializers of the parent are overwritten by the child's.

# Changes

> This PR gives consumers the ability to pass their own serializers for req, res and err objects.
