### PR TITLE
breaking: restify-errors@6.x

### DIFF
--- a/lib/errorTypes.js
+++ b/lib/errorTypes.js
@@ -2,5 +2,7 @@
 
 var errors = require('restify-errors');
 
-errors.makeConstructor('RequestCloseError');
-errors.makeConstructor('RouteMissingError');
+module.exports = {
+    RequestCloseError: errors.makeConstructor('RequestCloseError'),
+    RouteMissingError: errors.makeConstructor('RouteMissingError')
+};

--- a/lib/plugins/cpuUsageThrottle.js
+++ b/lib/plugins/cpuUsageThrottle.js
@@ -189,7 +189,7 @@ function cpuUsageThrottlePlugin(opts) {
         }
 
         var err = new errors.ServiceUnavailableError({
-            context: {
+            info: {
                 plugin: 'cpuUsageThrottle',
                 cpuUsage: plugin._cpu,
                 limit: plugin._limit,

--- a/lib/plugins/requestExpiry.js
+++ b/lib/plugins/requestExpiry.js
@@ -107,13 +107,15 @@ function requestExpiry(opts) {
         if (req.isExpired()) {
             // The request has expired
             return next(
-                new GatewayTimeoutError({
-                    message: 'Request has expired',
-                    context: {
-                        expiryTime: req._expiryTime,
-                        mode: opts.absoluteHeader ? 'absolute' : 'relative'
-                    }
-                })
+                new GatewayTimeoutError(
+                    {
+                        info: {
+                            expiryTime: req._expiryTime,
+                            mode: opts.absoluteHeader ? 'absolute' : 'relative'
+                        }
+                    },
+                    'Request has expired'
+                )
             );
         } else {
             // Happy case

--- a/lib/server.js
+++ b/lib/server.js
@@ -21,6 +21,7 @@ var formatters = require('./formatters');
 var shallowCopy = require('./utils').shallowCopy;
 var upgrade = require('./upgrade');
 var deprecationWarnings = require('./deprecationWarnings');
+var errorTypes = require('./errorTypes');
 
 // Ensure these are loaded
 var patchRequest = require('./request');
@@ -1078,7 +1079,7 @@ Server.prototype._onHandlerError = function _onHandlerError(err, req, res) {
         // Cannot find route by name, called when next('route-name') doesn't
         // find any route, it's a 5xx error as it's a programatic error
         if (!routeHandler) {
-            var routeByNameErr = new errors.RouteMissingError(
+            var routeByNameErr = new errorTypes.RouteMissingError(
                 "Route by name doesn't exist"
             );
             routeByNameErr.code = 'ENOEXIST';
@@ -1146,7 +1147,7 @@ Server.prototype._setupRequest = function _setupRequest(req, res) {
     // we consider a closed request as flushed from metrics point of view
     function onReqAborted() {
         // Request was aborted, override the status code
-        var err = new errors.RequestCloseError();
+        var err = new errorTypes.RequestCloseError();
         err.statusCode = 444;
 
         // For backward compatibility we only set connection state to "close"

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "once": "^1.4.0",
     "pidusage": "^1.2.0",
     "qs": "^6.5.2",
-    "restify-errors": "^5.0.0",
+    "restify-errors": "^6.1.1",
     "semver": "^5.4.1",
     "spdy": "^3.4.7",
     "uuid": "^3.1.0",

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -2454,3 +2454,25 @@ test('should have proxy event handlers as instance', function(t) {
         t.end();
     });
 });
+
+test('should respond with VError and serialized error body', function(t) {
+    SERVER.on('after', function(req, res, route, err) {
+        // ensure this is an instance of VError
+        assert.ok(err.jse_info);
+        assert.ok(err.jse_shortmsg);
+    });
+
+    CLIENT.get(
+        {
+            headers: { connection: 'close' },
+            path: '/foo'
+        },
+        function(err, req, res, data) {
+            t.ok(err);
+            t.equal(data.code, 'ResourceNotFound');
+            SERVER.close(function() {
+                t.end();
+            });
+        }
+    );
+});


### PR DESCRIPTION
The primary change in restify-errors@6.x is that all errors generated by restify and plugins (BadRequest, InternalServer, GatewayTimeout, etc) now derive from VError base classes now. Folks interact with these errors via the event listeners, like the server's `after` event, or the `uncaughtException` event. 

While the API provided by the Error instances [is not breaking](https://github.com/restify/errors#migration-from-5x-to-6x), any class or prototype interrogation will definitely fail because the base classes have changed. 