### PR TITLE
Document change from req.route to req.route.spec

### DIFF
--- a/docs/guides/6to7guide.md
+++ b/docs/guides/6to7guide.md
@@ -39,6 +39,10 @@ For example `server.get('foo')` is invalid, change it to `server.get('/foo')`.
 If you use [enroute](https://github.com/restify/enroute) be sure
 that you updated it to the latest version.
 
+### Route properties available differently
+
+When an object is provided as an argument to a server method, the properties are now available under `req.route.spec` instead of `req.route`
+
 ### Different `RegExp` usage in router path and wildcards
 
 restify's new router backend


### PR DESCRIPTION
This PR documents a breaking change in newer Restify versions. 

Many packages and middleware depend on `req.route`, and this has been changed to `req.route.spec` since v7.