### PR TITLE
fix NotAuthorized error when serving static files while directory var…

### DIFF
--- a/lib/plugins/static.js
+++ b/lib/plugins/static.js
@@ -89,9 +89,6 @@ function serveStatic(options) {
     assert.optionalString(opts.file, 'options.file');
     assert.bool(opts.appendRequestPath, 'options.appendRequestPath');
 
-    var p = path.normalize(opts.directory).replace(/\\/g, '/');
-    var re = new RegExp('^' + escapeRE(p) + '/?.*');
-
     function serveFileFromStats(file, err, stats, isGzip, req, res, next) {
         if (typeof req.closed === 'function' && req.closed()) {
             next(false);
@@ -185,6 +182,9 @@ function serveStatic(options) {
                 );
             }
         }
+
+        var p = path.normalize(file).replace(/\\/g, '/');
+        var re = new RegExp('^' + escapeRE(p) + '/?.*');
 
         if (req.method !== 'GET' && req.method !== 'HEAD') {
             next(new MethodNotAllowedError('%s', req.method));


### PR DESCRIPTION
## Pre-Submission Checklist

- [x] Opened an issue discussing these changes before opening the PR
- [x] Ran the linter and tests via `make prepush`
- [x] Included comprehensive and convincing tests for changes

## Issues

Closes:

* Issue 549

# Changes

This is to resolve issue #549, so I did not create a new issue for this pull request.

The serveStatic function sets the appendRequestPath option to true by default. This works the majority of the time, but if the directory option is set to "./", then the regex test ("re.test(file.replace(/\\/g, '/'))" on line 194 -- https://github.com/restify/node-restify/blob/e663699c8c5383eb6affad16ac2eb14fcd66a858/lib/plugins/static.js#L194) fails, which results in NotAuthorizedError. This test fails, as it is trying to compare a slash, against a full path. By moving the "p", and "re" variable declarations to the serve function, after the file path is joined with opts.directory, we are then able to normalize the path, run that output through escapeRE, and test the expected expression.

The "p", and "re" variables are not used anywhere else in this file -- only within the serve function.

I tested this solution with the following routes:

        server.get("/firsttest", restify.plugins.serveStatic({
            directory: "./app",
            file: "firsttest.html",
            appendRequestPath: false,
        }));

        server.get("/secondtest", restify.plugins.serveStatic({
            directory: "./app",
            file: "secondtest().html",
            appendRequestPath: false,
        }));

        server.get("/docs/*", restify.plugins.serveStatic({
            directory: "./",
            default: "index.html",
            appendRequestPath: true,
        }));

My folder structure for the tests was something along the lines of:
  /
    docs/
      v1/
        index.html
      v2/
        index.html
    app/
      firsttest.html
      secondtest().html
      (contains source code)
    dist/
      contains typescript build output

I had the first/second test routes set to serve files from the ./app directory, as they just didn't want to serve from there (kept getting a not found event). I'm assuming that has something to do with the wild card route taking precedence for some reason.