### PR TITLE
docs: remove bithound badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@
 [![Build Status](https://travis-ci.org/restify/node-restify.svg?branch=master)](https://travis-ci.org/restify/node-restify)
 [![Dependency Status](https://david-dm.org/restify/node-restify.svg)](https://david-dm.org/restify/node-restify)
 [![devDependency Status](https://david-dm.org/restify/node-restify/dev-status.svg)](https://david-dm.org/restify/node-restify#info=devDependencies)
-[![bitHound Score](https://www.bithound.io/github/restify/node-restify/badges/score.svg)](https://www.bithound.io/github/restify/node-restify/master)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 
 [restify](http://restify.com) is a framework, utilizing


### PR DESCRIPTION
bithound is shut down, and the badge is also broken

> Note, this is such a small thing, I didn't think there is a need to follow the PR checklist and open up an issue to discuss first :heart: 