### PR TITLE
[Restify 7] Fix uncaught exceptions triggering route lookups

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1322,22 +1322,26 @@ Server.prototype._emitErrorEvents = function _emitErrorEvents(
     cb
 ) {
     var self = this;
-    var errName = errEvtNameFromError(err);
+    // Error can be of any type: undefined, Error, Number, etc. so we need
+    // to protect ourselves from trying to resolve names from non Error objects
+    var errName = err && err.name;
+    var normalizedErrName = errName && errEvtNameFromError(err);
 
     req.log.trace(
         {
             err: err,
-            errName: errName
+            errName: normalizedErrName
         },
         'entering emitErrorEvents',
-        err.name
+        errName
     );
 
     var errEvtNames = [];
 
     // if we have listeners for the specific error, fire those first.
-    if (self.listeners(errName).length > 0) {
-        errEvtNames.push(errName);
+    // if there's no error name, we should not emit an event
+    if (errName && self.listeners(normalizedErrName).length > 0) {
+        errEvtNames.push(normalizedErrName);
     }
 
     // or if we have a generic error listener. always fire generic error event
@@ -1485,6 +1489,7 @@ function errEvtNameFromError(err) {
     } else if (err.name) {
         return err.name.replace(/Error$/, '');
     }
+    // If the err is not an Error, then just return an empty string
     return '';
 }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -1340,7 +1340,7 @@ Server.prototype._emitErrorEvents = function _emitErrorEvents(
 
     // if we have listeners for the specific error, fire those first.
     // if there's no error name, we should not emit an event
-    if (errName && self.listeners(normalizedErrName).length > 0) {
+    if (normalizedErrName && self.listeners(normalizedErrName).length > 0) {
         errEvtNames.push(normalizedErrName);
     }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -1077,7 +1077,7 @@ Server.prototype._onHandlerError = function _onHandlerError(
     var self = this;
 
     // Call route by name
-    if (_.isString(err)) {
+    if (!isUncaught && _.isString(err)) {
         var routeName = err;
         var routeHandler = self.router.lookupByName(routeName, req, res);
 
@@ -1482,9 +1482,10 @@ function errEvtNameFromError(err) {
     } else if (err.name === 'InvalidVersionError') {
         // remap the name for router errors
         return 'VersionNotAllowed';
-    } else {
+    } else if (err.name) {
         return err.name.replace(/Error$/, '');
     }
+    return '';
 }
 
 /**

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -2507,6 +2507,66 @@ test('uncaughtException should not trigger named routeHandler', function(t) {
     });
 });
 
+test('uncaughtException should handle thrown undefined literal', function(t) {
+    SERVER.get(
+        {
+            name: 'foo',
+            path: '/foo'
+        },
+        function(req, res, next) {
+            throw undefined; //eslint-disable-line no-throw-literal
+        }
+    );
+
+    SERVER.get(
+        {
+            name: 'bar',
+            path: '/bar'
+        },
+        function(req, res, next) {
+            // This code should not run, but we can test against the status code
+            res.send(200);
+            next();
+        }
+    );
+
+    CLIENT.get('/foo', function(err, _, res) {
+        t.ok(err);
+        t.equal(res.statusCode, 500);
+        t.end();
+    });
+});
+
+test('uncaughtException should handle thrown Number', function(t) {
+    SERVER.get(
+        {
+            name: 'foo',
+            path: '/foo'
+        },
+        function(req, res, next) {
+            throw 1; //eslint-disable-line no-throw-literal
+        }
+    );
+
+    SERVER.get(
+        {
+            name: 'bar',
+            path: '/bar'
+        },
+        function(req, res, next) {
+            // This code should not run, but we can test against the status code
+            res.send(200);
+            next();
+        }
+    );
+
+    CLIENT.get('/foo', function(err, _, res) {
+        t.ok(err);
+        t.equal(res.statusCode, 500);
+        t.end();
+    });
+});
+
 test('should have proxy event handlers as instance', function(t) {
     var server = restify.createServer({
         handleUpgrades: false

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -2477,6 +2477,36 @@ test('should emit error with multiple next calls with strictNext', function(t) {
     });
 });
 
+test('uncaughtException should not trigger named routeHandler', function(t) {
+    SERVER.get(
+        {
+            name: 'foo',
+            path: '/foo'
+        },
+        function(req, res, next) {
+            throw 'bar'; //eslint-disable-line no-throw-literal
+        }
+    );
+
+    SERVER.get(
+        {
+            name: 'bar',
+            path: '/bar'
+        },
+        function(req, res, next) {
+            // This code should not run, but we can test against the status code
+            res.send(200);
+            next();
+        }
+    );
+
+    CLIENT.get('/foo', function(err, _, res) {
+        t.ok(err);
+        t.equal(res.statusCode, 500);
+        t.end();
+    });
+});
+
 test('should have proxy event handlers as instance', function(t) {
     var server = restify.createServer({
         handleUpgrades: false


### PR DESCRIPTION
## Pre-Submission Checklist

- [ ] Opened an issue discussing these changes before opening the PR
- [x] Ran the linter and tests via `make prepush`
- [x] Included comprehensive and convincing tests for changes

## Issues

The current `uncaughtException` handler attempts to do route lookup if a string is thrown. This behavior is undesirable because it prevents the application from handling the exceptions itself (it never makes it to the user's `uncaughtException` handler.

# Changes

This PR adds a check to the route lookup logic which is typically used when calling `next('myString')`. It bypasses this code if it handling an uncaught exception.

The test demonstrates how this could be triggered before these code changes: `throw 'bar'`. I also had to add a check for `err.name` since that would throw another error in the case of a string being passed to the `errEvtNameFromError` function. I made the default an empty string, but could use some feedback on whether that makes sense or not.
