### PR TITLE
feat: bump dtrace-provider version to avoid MacOS errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "verror": "^1.10.0"
   },
   "optionalDependencies": {
-    "dtrace-provider": "^0.8.1"
+    "dtrace-provider": "~0.8"
   },
   "devDependencies": {
     "autocannon": "^2.2.0",


### PR DESCRIPTION
## Issues

Resolves:

* https://github.com/trentm/node-bunyan/issues/502
* https://github.com/trentm/node-bunyan/issues/525
* https://github.com/trentm/node-bunyan/issues/502
* https://github.com/react-community/create-react-native-app/issues/135

> The installed version of DTrace-provider was 0.8.1 instead of the newest with resolved problem "could not find module". This change provides installation of the correct version of DTrace-provider with these problems fixed.

# Changes

> Bump up an optional dependency to DTrace-provider package
