### PR TITLE
Update example to allow downgrading to http1

### DIFF
--- a/examples/http2/http2.js
+++ b/examples/http2/http2.js
@@ -7,7 +7,8 @@ var srv = restify.createServer({
     http2: {
         cert: fs.readFileSync(path.join(__dirname, './keys/http2-cert.pem')),
         key: fs.readFileSync(path.join(__dirname, './keys/http2-key.pem')),
-        ca: fs.readFileSync(path.join(__dirname, 'keys/http2-csr.pem'))
+        ca: fs.readFileSync(path.join(__dirname, 'keys/http2-csr.pem')),
+        allowHTTP1: true //allow incoming connections that do not support HTTP/2 to be downgraded to HTTP/1.x
     }
 });
 


### PR DESCRIPTION
# Issues

When following the example, many connections don't work. e.g. curl returned:
>Unknown ALPN Protocol, expected `h2` to be available.
>If this is a HTTP request: The server was not configured with the `allowHTTP1` option or a listener for the `unknownProtocol` event.

# What does this PR do?

Allows automatic downgrade to http1. Node's http2 module allows https or http2 with the same code.