### PR TITLE
Update response.send() to check HTTP status code length

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -297,7 +297,7 @@ function patch(Response) {
         var self = this;
         var sendArgs;
 
-        if (typeof code === 'number') {
+        if (typeof code === 'number' && String(code).length === 3) {
             sendArgs = {
                 code: code,
                 body: body,


### PR DESCRIPTION
I updated line 300 which checks that the HTTP status code passed into the Response.send() function is of type "number" to also check that the length of the status code is equal to three since all HTTP status codes are three digits. This allows for the Response.send() function to send ordinary numbers of any length ( other than three ) as response if need be, instead of throwing.

<!--
Thank you for taking the time to open an PR for restify! If this is your first
time here, welcome to our community! We are a group of developers who work on
restify in our free-time. Some of us do it as a hobby, others are using restify
at work. When asking for help here, keep in mind most of us are volunteers
contributing our daily work back to the community at no cost (and often for no
reward). Please be respectful!

Below you will find a checklist to help you create the best PR possible. While
the checklist items aren't all _strictly_ required, they dramatically increase
the probability of your PR getting a response and getting merged. Often times,
the least time consuming part of maintaining and open source project is writing
code, its the process and discussions that happen around the code base that
consume a majority of the maintainers' time. By spending a few moments to
adhere to this template, you are not only improve the quality of your PR, you
are also helping save the maintainers a considerable amount of time when trying
to understand and review your changes.

And remember, positive vibes are met with positive vibes. Kindness helps Free
Software go round, pay it forward!
-->

## Pre-Submission Checklist

- [ ] Opened an issue discussing these changes before opening the PR
- [ ] Ran the linter and tests via `make prepush`
- [ ] Included comprehensive and convincing tests for changes

## Issues

Closes:

* Issue #
* Issue #
* Issue #

> Summarize the issues that discussed these changes

# Changes

> What does this PR do?
