### PR TITLE
fix: fix flaky static.test.js

### DIFF
--- a/test/plugins/static.test.js
+++ b/test/plugins/static.test.js
@@ -365,14 +365,16 @@ describe('static resource plugin', function() {
                     }
 
                     // closed before serve
-                    if (req.closed) {
+                    if (req.closed()) {
                         doServe();
                     } else {
                         req.on('close', doServe);
                     }
                 });
                 SERVER.on('after', function(req, res, route, afterErr) {
-                    assert(afterErr.name, 'RequestCloseError');
+                    if (afterErr) {
+                        assert(afterErr.name, 'RequestCloseError');
+                    }
                     done();
                 });
 

--- a/test/plugins/static.test.js
+++ b/test/plugins/static.test.js
@@ -357,11 +357,19 @@ describe('static resource plugin', function() {
                 });
 
                 SERVER.get('/index.html', function(req, res, next) {
+                    function doServe() {
+                        serve(req, res, function(nextRoute) {
+                            assert.strictEqual(nextRoute, false);
+                            done();
+                        });
+                    }
+
                     // closed before serve
-                    serve(req, res, function(nextRoute) {
-                        assert.strictEqual(nextRoute, false);
-                        done();
-                    });
+                    if (req.closed) {
+                        doServe();
+                    } else {
+                        req.on('close', doServe);
+                    }
                 });
                 SERVER.on('after', function(req, res, route, afterErr) {
                     assert(afterErr.name, 'RequestCloseError');

--- a/test/plugins/static.test.js
+++ b/test/plugins/static.test.js
@@ -365,11 +365,7 @@ describe('static resource plugin', function() {
                     }
 
                     // closed before serve
-                    if (req.closed()) {
-                        doServe();
-                    } else {
-                        req.on('close', doServe);
-                    }
+                    req.on('close', doServe);
                 });
                 SERVER.on('after', function(req, res, route, afterErr) {
                     if (afterErr) {


### PR DESCRIPTION
<!--
Thank you for taking the time to open an PR for restify! If this is your first
time here, welcome to our community! We are a group of developers who work on
restify in our free-time. Some of us do it as a hobby, others are using restify
at work. When asking for help here, keep in mind most of us are volunteers
contributing our daily work back to the community at no cost (and often for no
reward). Please be respectful!

Below you will find a checklist to help you create the best PR possible. While
the checklist items aren't all _strictly_ required, they dramatically increase
the probability of your PR getting a response and getting merged. Often times,
the least time consuming part of maintaining and open source project is writing
code, its the process and discussions that happen around the code base that
consume a majority of the maintainers' time. By spending a few moments to
adhere to this template, you are not only improve the quality of your PR, you
are also helping save the maintainers a considerable amount of time when trying
to understand and review your changes.

And remember, positive vibes are met with positive vibes. Kindness helps Free
Software go round, pay it forward!
-->

## Pre-Submission Checklist

- [x] Opened an issue discussing these changes before opening the PR
- [x] Ran the linter and tests via `make prepush`
- [x] Included comprehensive and convincing tests for changes

## Issues

Closes:

* Issue #1726

> Summarize the issues that discussed these changes

The `static.test.js` tests suite is flakey because it incorrectly relies on a specific order of events that is not the only one possible.

# Changes

> What does this PR do?

This PR makes the test actually wait for the request to be marked as closed before running the `static` middleware. I believe this was the original intention when writing this test.

Without that additional check, it is possible for the server to receive and handle the request _before_ it actually handles the event that closes the connection.

@koute I'd like to get your thoughts on this since you're the original author of that test.
