### PR TITLE
fix: emit after event with proper error param for node versions >= 11.4.0

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1258,8 +1258,14 @@ Server.prototype._finishReqResCycle = function _finishReqResCycle(
         // after event has signature of function(req, res, route, err) {...}
         self.emit('after', req, res, route, err || res.err);
     } else {
-        // preserve error for actual finish
-        res.err = err;
+        // Store error for when the response is flushed and we actually emit the
+        // 'after' event. The "err" object passed to this method takes
+        // precedence, but in case it's not set, "res.err" may have been already
+        // set by another code path and we want to preserve it. The caveat thus
+        // is that the 'after' event will be emitted with the latest error that
+        // was set before the response is fully flushed. While not ideal, this
+        // is on purpose and accepted as a reasonable trade-off for now.
+        res.err = err || res.err;
     }
 };
 


### PR DESCRIPTION


<!--
Thank you for taking the time to open an PR for restify! If this is your first
time here, welcome to our community! We are a group of developers who work on
restify in our free-time. Some of us do it as a hobby, others are using restify
at work. When asking for help here, keep in mind most of us are volunteers
contributing our daily work back to the community at no cost (and often for no
reward). Please be respectful!

Below you will find a checklist to help you create the best PR possible. While
the checklist items aren't all _strictly_ required, they dramatically increase
the probability of your PR getting a response and getting merged. Often times,
the least time consuming part of maintaining and open source project is writing
code, its the process and discussions that happen around the code base that
consume a majority of the maintainers' time. By spending a few moments to
adhere to this template, you are not only improve the quality of your PR, you
are also helping save the maintainers a considerable amount of time when trying
to understand and review your changes.

And remember, positive vibes are met with positive vibes. Kindness helps Free
Software go round, pay it forward!
-->

## Pre-Submission Checklist

- [x] Opened an issue discussing these changes before opening the PR
- [x] Ran the linter and tests via `make prepush`
- [x] Included comprehensive and convincing tests for changes

## Issues

Closes:

* Issue #1731

> Summarize the issues that discussed these changes

Restify currently relies on specific timing of the response's 'close' event to emit the 'after' event with the correct error parameter in case the request is aborted by the client.

# Changes

> What does this PR do?

This PR makes Restify _not_ overwrite any error previously set as `res.err` so that it is passed as the first parameter when emitting the `'after'` event once the req/res lifecycle is finished.