### PR TITLE
fix(plugins): do not include user-input in UnsupportedMediaTypeError

### DIFF
--- a/lib/plugins/bodyReader.js
+++ b/lib/plugins/bodyReader.js
@@ -95,7 +95,7 @@ function bodyReader(options) {
         var hash;
         var md5;
 
-        var unsupportedCompression;
+        var unsupportedContentEncoding;
 
         if ((md5 = req.headers['content-md5'])) {
             hash = crypto.createHash('md5');
@@ -104,9 +104,17 @@ function bodyReader(options) {
         function done() {
             bodyWriter.end();
 
-            if (unsupportedCompression) {
-                var error = unsupportedCompression + ' not supported';
-                next(new UnsupportedMediaTypeError(error));
+            if (unsupportedContentEncoding) {
+                next(
+                    new UnsupportedMediaTypeError(
+                        {
+                            info: {
+                                contentEncoding: unsupportedContentEncoding
+                            }
+                        },
+                        'content encoding not supported'
+                    )
+                );
                 return;
             }
 
@@ -149,7 +157,7 @@ function bodyReader(options) {
             gz.once('end', done);
             req.once('end', gz.end.bind(gz));
         } else {
-            unsupportedCompression = req.headers['content-encoding'];
+            unsupportedContentEncoding = req.headers['content-encoding'];
             res.setHeader('Accept-Encoding', 'gzip');
             req.once('end', done);
         }


### PR DESCRIPTION
User input in `VError` based errors (`restify-errors`) can cause the process to crash as `VError` uses the `sprintf` library internally which expects additional arguments for formatting symbols liek `%s`.

For example, a `content-type` `%s` would crash restify without this change.
