### PR TITLE
update dedupeSlashes() invocation in docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -110,7 +110,7 @@ incoming request before routing it.
 
 ```js
 // dedupe slashes in URL before routing
-server.pre(restify.plugins.dedupeSlashes());
+server.pre(restify.plugins.pre.dedupeSlashes());
 ```
 
 


### PR DESCRIPTION
## Pre-Submission Checklist

- [ ] Opened an issue discussing these changes before opening the PR
- [ ] Ran the linter and tests via `make prepush`
- [ ] Included comprehensive and convincing tests for changes

## Issues

Closes:

* Issue #
* Issue #
* Issue #

> Summarize the issues that discussed these changes

# Changes

> What does this PR do?

This updates a documentation bug. `restify.plugins.dedupeSlashes()` does not exist, but `restify.plugins.pre.dedupeSlashes()` does.