### PR TITLE
Dynamic maxBodySize for bodyReader plugin

### DIFF
--- a/lib/plugins/bodyParser.js
+++ b/lib/plugins/bodyParser.js
@@ -42,7 +42,9 @@ var UnsupportedMediaTypeError = errors.UnsupportedMediaTypeError;
  * @throws   {UnsupportedMediaTypeError}
  * @param {Object} [options] - an option object
  * @param {Number} [options.maxBodySize] - The maximum size in bytes allowed in
- * the HTTP body. Useful for limiting clients from hogging server memory.
+ * the HTTP body. Useful for limiting clients from hogging server memory. This
+ * value is dynamic, you can update this on the options object at any time and
+ * this plugin will honor the new values.
  * @param {Boolean} [options.mapParams] - if `req.params` should be filled with
  * parsed parameters from HTTP body.
  * @param {Boolean} [options.mapFiles] - if `req.params` should be filled with

--- a/lib/plugins/bodyReader.js
+++ b/lib/plugins/bodyReader.js
@@ -66,8 +66,6 @@ function bodyReader(options) {
     var opts = options || {};
     assert.object(opts, 'opts');
 
-    var maxBodySize = opts.maxBodySize || 0;
-
     function readBody(req, res, originalNext) {
         var next = once(originalNext);
 
@@ -118,8 +116,8 @@ function bodyReader(options) {
                 return;
             }
 
-            if (maxBodySize && bytesReceived > maxBodySize) {
-                var msg = 'Request body size exceeds ' + maxBodySize;
+            if (opts.maxBodySize && bytesReceived > opts.maxBodySize) {
+                var msg = 'Request body size exceeds ' + opts.maxBodySize;
                 var err;
 
                 // Between Node 0.12 and 4 http status code messages changed
@@ -163,10 +161,10 @@ function bodyReader(options) {
         }
 
         req.on('data', function onRequestData(chunk) {
-            if (maxBodySize) {
+            if (opts.maxBodySize) {
                 bytesReceived += chunk.length;
 
-                if (bytesReceived > maxBodySize) {
+                if (bytesReceived > opts.maxBodySize) {
                     return;
                 }
             }


### PR DESCRIPTION
Instead of caching the value for `opts.maxBodySize` in memory, we read it off the configuration object whenever we need it. This allows the caller to update the value at runtime.