### PR TITLE
feat: add support for requiredResponseHeaders flag

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -9,6 +9,7 @@ var url = require('url');
 var assert = require('assert-plus');
 var mime = require('mime');
 var errors = require('restify-errors');
+var VError = require('verror');
 
 var httpDate = require('./http_date');
 var utils = require('./utils');
@@ -835,6 +836,8 @@ function patch(Response) {
  * @returns {Response} response
  */
 function flush(res, body) {
+    var missingHeaders;
+
     assert.ok(
         body === null ||
             body === undefined ||
@@ -842,6 +845,31 @@ function flush(res, body) {
             Buffer.isBuffer(body),
         'body must be a string or a Buffer instance'
     );
+
+    assert.optionalArrayOfString(
+        res._requiredResponseHeaders,
+        'res._requiredResponseHeaders'
+    );
+
+    if (
+        res._requiredResponseHeaders &&
+        res._requiredResponseHeaders.length > 0
+    ) {
+        missingHeaders = res._requiredResponseHeaders.filter(
+            function missingHeader(header) {
+                return !Object.prototype.hasOwnProperty.call(
+                    res.getHeaders(),
+                    header
+                );
+            }
+        );
+
+        if (missingHeaders.length > 0) {
+            throw new VError(
+                'Missing required headers: ' + missingHeaders.join(', ')
+            );
+        }
+    }
 
     res._data = body;
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -87,6 +87,10 @@ var sprintf = util.format;
  * not found, the response's content-type is automatically set to
  * 'application/octet-stream'. If a formatter for that content-type is not
  * found, sending the response errors.
+ * @param {Array} [options.requiredResponseHeaders=[]] -  allows to
+ * specify which headers are required to be set on every response before
+ * responses are sent. If any of those headers is missing, an exception is
+ * thrown.
  * @example
  * var restify = require('restify');
  * var server = restify.createServer();
@@ -109,6 +113,10 @@ function Server(options) {
     assert.optionalBool(options.onceNext, 'options.onceNext');
     assert.optionalBool(options.strictNext, 'options.strictNext');
     assert.optionalBool(options.strictFormatters, 'options.strictFormatters');
+    assert.optionalArrayOfString(
+        options.requiredResponseHeaders,
+        'options.requiredResponseHeaders'
+    );
 
     var self = this;
 
@@ -137,6 +145,8 @@ function Server(options) {
     if (options.strictFormatters !== undefined) {
         this.strictFormatters = options.strictFormatters;
     }
+
+    this.requiredResponseHeaders = options.requiredResponseHeaders || [];
 
     var fmt = mergeFormatters(options.formatters);
     this.acceptable = fmt.acceptable;
@@ -1150,6 +1160,7 @@ Server.prototype._setupRequest = function _setupRequest(req, res) {
     res._handlersFinished = false;
     res._flushed = false;
     res._strictFormatters = this.strictFormatters;
+    res._requiredResponseHeaders = this.requiredResponseHeaders;
 
     // set header only if name isn't empty string
     if (self.name !== '') {

--- a/test/requiredResponseHeaders.test.js
+++ b/test/requiredResponseHeaders.test.js
@@ -1,0 +1,126 @@
+'use strict';
+/* eslint-disable func-names */
+
+var restifyClients = require('restify-clients');
+
+var restify = require('../lib');
+
+if (require.cache[__dirname + '/lib/helper.js']) {
+    delete require.cache[__dirname + '/lib/helper.js'];
+}
+var helper = require('./lib/helper.js');
+
+///--- Globals
+
+var after = helper.after;
+var before = helper.before;
+var test = helper.test;
+
+var JSON_CLIENT;
+var LOCALHOST;
+var PORT = process.env.UNIT_TEST_PORT || 0;
+var SERVER;
+
+///--- Tests
+
+before(function(callback) {
+    try {
+        SERVER = restify.createServer({
+            handleUncaughtExceptions: true,
+            log: helper.getLog('server'),
+            requiredResponseHeaders: ['content-type']
+        });
+        SERVER.listen(PORT, '127.0.0.1', function() {
+            PORT = SERVER.address().port;
+            JSON_CLIENT = restifyClients.createJsonClient({
+                url: 'http://127.0.0.1:' + PORT,
+                dtrace: helper.dtrace,
+                retry: false
+            });
+            LOCALHOST = 'http://' + '127.0.0.1:' + PORT;
+            callback();
+        });
+    } catch (e) {
+        console.error(e.stack);
+        process.exit(1);
+    }
+});
+
+after(function(callback) {
+    try {
+        SERVER.close(callback);
+        JSON_CLIENT.close();
+    } catch (e) {
+        console.error(e.stack);
+        process.exit(1);
+    }
+});
+
+test('sendRaw throws when no content-type set on response', function(t) {
+    /*
+     * In this case, res.sendRaw does not go through content type negotiation
+     * and as a result does not set any content-type header. Since we also don't
+     * set that header manually and the set of required headers includes
+     * 'content-type', we expect res.sendRaw to throw.
+     */
+    SERVER.get('/foo', function handle(req, res, next) {
+        res.sendRaw(200, JSON.stringify({ foo: 'bar' }));
+    });
+
+    SERVER.on('uncaughtException', function onUncaught(req, res, route, err) {
+        t.ok(err, 'res.send threw expectedly');
+        t.equal(err.message, 'Missing required headers: content-type');
+        t.end();
+    });
+
+    JSON_CLIENT.get(LOCALHOST + '/foo', function onRes(err) {
+        t.ok(err);
+    });
+});
+
+test('sendRaw does not throw when content-type set on response', function(t) {
+    /*
+     * In this case, res.sendRaw does not go through content type negotiation
+     * and as a result does not set any content-type header. However, we do set
+     * the content-type header manually and as a result even though the set of
+     * required headers includes 'content-type', we don't expect res.sendRaw to
+     * throw.
+     */
+    SERVER.get('/foo', function handle(req, res, next) {
+        res.header('content-type', 'application/json');
+        res.sendRaw(200, JSON.stringify({ foo: 'bar' }));
+    });
+
+    SERVER.on('uncaughtException', function onUncaught(req, res, route, err) {
+        t.ifError(err, 'res.send threw unexpectedly');
+    });
+
+    JSON_CLIENT.get(LOCALHOST + '/foo', function onRes(err, req, res, body) {
+        t.ifError(err);
+        t.equal(res.statusCode, 200);
+        t.deepEqual(body, { foo: 'bar' });
+        t.end();
+    });
+});
+
+test('send does not throw when content-type inferred', function(t) {
+    /*
+     * In this case, the response's content-type is inferred by res.send because
+     * the negotiated content-type is 'application/json' and the set of built-in
+     * formatters includes that content-type.
+     */
+    SERVER.get('/foo', function handle(req, res, next) {
+        res.send(200, { foo: 'bar' });
+    });
+
+    SERVER.on('uncaughtException', function onUncaught(req, res, route, err) {
+        t.ifError(err, 'res.send threw unexpectedly');
+    });
+
+    JSON_CLIENT.get(LOCALHOST + '/foo', function onRes(err, req, res, body) {
+        t.ifError(err);
+        t.equal(res.statusCode, 200);
+        t.deepEqual(body, { foo: 'bar' });
+        t.end();
+    });
+});


### PR DESCRIPTION
<!--
Thank you for taking the time to open an PR for restify! If this is your first
time here, welcome to our community! We are a group of developers who work on
restify in our free-time. Some of us do it as a hobby, others are using restify
at work. When asking for help here, keep in mind most of us are volunteers
contributing our daily work back to the community at no cost (and often for no
reward). Please be respectful!

Below you will find a checklist to help you create the best PR possible. While
the checklist items aren't all _strictly_ required, they dramatically increase
the probability of your PR getting a response and getting merged. Often times,
the least time consuming part of maintaining and open source project is writing
code, its the process and discussions that happen around the code base that
consume a majority of the maintainers' time. By spending a few moments to
adhere to this template, you are not only improve the quality of your PR, you
are also helping save the maintainers a considerable amount of time when trying
to understand and review your changes.

And remember, positive vibes are met with positive vibes. Kindness helps Free
Software go round, pay it forward!
-->

## Pre-Submission Checklist

- [x] Opened an issue discussing these changes before opening the PR
- [x] Ran the linter and tests via `make prepush`
- [x] Included comprehensive and convincing tests for changes

# Changes

> What does this PR do?

This PR implements the second part of the changes discussed at https://github.com/restify/node-restify/pull/1728#issuecomment-460477205. It allows users of restify to turn missing response headers (like missing `'content-type'` headers) into programmer errors.

The goal is to help programmers spot those errors more easily by making the failure mode more obvious. We think this will be less time consuming than the previous failure mode when 406 responses would be sent instead of the intended response.

/cc @cprussin @mridgway @jdarren