### PR TITLE
breaking: restify drops Node v4.x and v6.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-   - '6'
    - '8'
    - '10'
    - "lts/*"                # Active LTS release

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 sudo: false
 language: node_js
 node_js:
-   - "4"                    # Maintenance LTS release
+   - '6'
+   - '8'
+   - '10'
    - "lts/*"                # Active LTS release
    - "node"                 # Latest stable release
 env:

--- a/README.md
+++ b/README.md
@@ -82,6 +82,19 @@ client.get('/echo/mark', function (err, req, res, obj) {
 ```bash
 $ npm install restify
 ```
+
+## Supported Node Versions
+
+Restify aims to support the Node.js LTS (Active and Maintenance) versions along with Node.js current stable version.
+
+| Node Release  | Supported | Notes    |
+| :--:     | :---: | :---:       | 
+| 11.x | **Yes**      | Current stable | 
+| 10.x | **Yes**      | Active LTS | 
+| 8.x  | **Yes** | Maintenance LTS  | 
+| 6.x  | **No** | Use restify v7.x, team will backport critical issues only   | 
+| 4.x  | **No** | Use restify v7.x, team will backport critical issues only  | 
+
 ## License
 
 The MIT License (MIT)

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ $ npm install restify
 
 Restify aims to support the Node.js LTS (Active and Maintenance) versions along with Node.js current stable version.
 
-| Node Release  | Supported | Notes    |
+| Node Release  | Supported in Current Version | Notes    |
 | :--:     | :---: | :---:       | 
 | 11.x | **Yes**      | Current stable | 
 | 10.x | **Yes**      | Active LTS | 

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "report-latency": "./bin/report-latency"
   },
   "engines": {
-    "node": ">=4.0"
+    "node": ">=6.0"
   },
   "dependencies": {
     "assert-plus": "^1.0.0",
@@ -98,10 +98,10 @@
     "csv": "^1.1.1",
     "escape-regexp-component": "^1.0.2",
     "ewma": "^2.0.1",
-    "find-my-way": "^1.13.0",
+    "find-my-way": "^2.0.0",
     "formidable": "^1.2.1",
     "http-signature": "^1.2.0",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.11",
     "lru-cache": "^4.1.3",
     "mime": "^1.5.0",
     "negotiator": "^0.6.1",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "report-latency": "./bin/report-latency"
   },
   "engines": {
-    "node": ">=6.0"
+    "node": ">=8.0"
   },
   "dependencies": {
     "assert-plus": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "csv": "^1.1.1",
     "escape-regexp-component": "^1.0.2",
     "ewma": "^2.0.1",
-    "find-my-way": "^2.0.0",
+    "find-my-way": "^2.0.1",
     "formidable": "^1.2.1",
     "http-signature": "^1.2.0",
     "lodash": "^4.17.11",

--- a/test/plugins/jsonBodyParser.test.js
+++ b/test/plugins/jsonBodyParser.test.js
@@ -257,12 +257,9 @@ describe('JSON body parser', function() {
             '\r\n' +
             '{"foo":"bar"}';
 
-        var client = net.connect(
-            { host: '127.0.0.1', port: PORT },
-            function() {
-                client.write(request);
-            }
-        );
+        var client = net.connect({ host: '127.0.0.1', port: PORT }, function() {
+            client.write(request);
+        });
         client.once('data', function(data) {
             client.end();
         });
@@ -293,12 +290,9 @@ describe('JSON body parser', function() {
             '\r\n' +
             '{"foo":"bar"}';
 
-        var client = net.connect(
-            { host: '127.0.0.1', port: PORT },
-            function() {
-                client.write(request);
-            }
-        );
+        var client = net.connect({ host: '127.0.0.1', port: PORT }, function() {
+            client.write(request);
+        });
 
         client.once('data', function(data) {
             client.end();

--- a/test/plugins/static.test.js
+++ b/test/plugins/static.test.js
@@ -321,17 +321,11 @@ describe('static resource plugin', function() {
                     });
                 });
 
-                socket.connect(
-                    { host: '127.0.0.1', port: PORT },
-                    function() {
-                        socket.write(RAW_REQUEST, 'utf-8', function(
-                            err2,
-                            data
-                        ) {
-                            assert.ifError(err2);
-                        });
-                    }
-                );
+                socket.connect({ host: '127.0.0.1', port: PORT }, function() {
+                    socket.write(RAW_REQUEST, 'utf-8', function(err2, data) {
+                        assert.ifError(err2);
+                    });
+                });
             });
         }
     );
@@ -369,18 +363,12 @@ describe('static resource plugin', function() {
                 });
 
                 var socket = new net.Socket();
-                socket.connect(
-                    { host: '127.0.0.1', port: PORT },
-                    function() {
-                        socket.write(RAW_REQUEST, 'utf-8', function(
-                            err2,
-                            data
-                        ) {
-                            assert.ifError(err2);
-                            socket.end();
-                        });
-                    }
-                );
+                socket.connect({ host: '127.0.0.1', port: PORT }, function() {
+                    socket.write(RAW_REQUEST, 'utf-8', function(err2, data) {
+                        assert.ifError(err2);
+                        socket.end();
+                    });
+                });
             });
         }
     );

--- a/test/serverHttp2.test.js
+++ b/test/serverHttp2.test.js
@@ -53,12 +53,9 @@ before(function(cb) {
         });
         SERVER.listen(PORT, '127.0.0.1', function() {
             PORT = SERVER.address().port;
-            CLIENT = http2.connect(
-                'https://127.0.0.1:' + PORT,
-                {
-                    rejectUnauthorized: false
-                }
-            );
+            CLIENT = http2.connect('https://127.0.0.1:' + PORT, {
+                rejectUnauthorized: false
+            });
 
             cb();
         });

--- a/test/upgrade.test.js
+++ b/test/upgrade.test.js
@@ -304,12 +304,7 @@ test('GET with upgrade headers', function(t) {
             t.equal(typeof socket, 'object');
             t.ok(Buffer.isBuffer(head), 'head is Buffer');
             t.doesNotThrow(function() {
-                var shed = WATERSHED.connect(
-                    res,
-                    socket,
-                    head,
-                    wskey
-                );
+                var shed = WATERSHED.connect(res, socket, head, wskey);
                 SHEDLIST.push(shed);
                 shed.end('ok, done');
                 shed.on('error', function(err3) {
@@ -380,12 +375,7 @@ test('GET with some websocket traffic', function(t) {
             t.equal(typeof socket, 'object');
             t.ok(Buffer.isBuffer(head), 'head is Buffer');
             t.doesNotThrow(function() {
-                var shed = WATERSHED.connect(
-                    res,
-                    socket,
-                    head,
-                    wskey
-                );
+                var shed = WATERSHED.connect(res, socket, head, wskey);
                 SHEDLIST.push(shed);
                 shed.on('error', function(err3) {
                     t.ifError(err3);


### PR DESCRIPTION
<!--
Thank you for taking the time to open an PR for restify! If this is your first
time here, welcome to our community! We are a group of developers who work on
restify in our free-time. Some of us do it as a hobby, others are using restify
at work. When asking for help here, keep in mind most of us are volunteers
contributing our daily work back to the community at no cost (and often for no
reward). Please be respectful!

Below you will find a checklist to help you create the best PR possible. While
the checklist items aren't all _strictly_ required, they dramatically increase
the probability of your PR getting a response and getting merged. Often times,
the least time consuming part of maintaining and open source project is writing
code, its the process and discussions that happen around the code base that
consume a majority of the maintainers' time. By spending a few moments to
adhere to this template, you are not only improve the quality of your PR, you
are also helping save the maintainers a considerable amount of time when trying
to understand and review your changes.

And remember, positive vibes are met with positive vibes. Kindness helps Free
Software go round, pay it forward!
-->

## Pre-Submission Checklist

- [ ] Opened an issue discussing these changes before opening the PR
- [x] Ran the linter and tests via `make prepush`
- [ ] Included comprehensive and convincing tests for changes

## Issues

Closes: None

* Issue #
* Issue #
* Issue #

> Summarize the issues that discussed these changes

# Changes

> What does this PR do?
This PR is to upgrade `find-my-way` to  `^2.0.0` which drops support for Node 4.x. This means going forth restify will also drop support for Node 4.x. The changes included in this PR also upgrades `lodash@4.17.11` (4.17.10 had a vulnerability) and marks target engine as Node 6.x or above. Some of the test files were changed by `make fix-style`.

