### PR TITLE
fix: properly handle non-errors thrown in domains

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1303,25 +1303,24 @@ Server.prototype._routeErrorResponse = function _routeErrorResponse(
         return;
     }
 
-    self._emitErrorEvents(req, res, null, err, function emitError(emitErr) {
+    self._emitErrorEvents(req, res, null, err, function emitError() {
         // Prevent double handling
         if (res._sent) {
             return;
         }
 
         // only automatically send errors that are known (e.g., restify-errors)
-        if (err && _.isNumber(err.statusCode)) {
+        if (err instanceof Error && _.isNumber(err.statusCode)) {
             res.send(err);
             return;
         }
 
-        var finalErr = emitErr || err;
-        if (!(finalErr instanceof Error)) {
-            // if user land domain threw a string or number or any other
-            // non-error object, handle it here as best we can.
-            finalErr = (finalErr && finalErr.toString()) || '';
-        }
-        res.send(new errors.InternalError(finalErr));
+        // if the thrown exception is not really an Error object, e.g.,
+        //    "throw 'foo';"
+        // try to do best effort here to pass on that value by casting it to a
+        // string. This should work even for falsy values like 0, false, null,
+        // or undefined.
+        res.send(new errors.InternalError(String(err)));
     });
 };
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -1309,13 +1309,19 @@ Server.prototype._routeErrorResponse = function _routeErrorResponse(
             return;
         }
 
-        // Expose only knonw errors
-        if (_.isNumber(err.statusCode)) {
+        // only automatically send errors that are known (e.g., restify-errors)
+        if (err && _.isNumber(err.statusCode)) {
             res.send(err);
             return;
         }
 
-        res.send(new errors.InternalError(emitErr || err));
+        var finalErr = emitErr || err;
+        if (!(finalErr instanceof Error)) {
+            // if user land domain threw a string or number or any other
+            // non-error object, handle it here as best we can.
+            finalErr = (finalErr && finalErr.toString()) || '';
+        }
+        res.send(new errors.InternalError(finalErr));
     });
 };
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -1390,10 +1390,9 @@ Server.prototype._emitErrorEvents = function _emitErrorEvents(
             }
         },
         // eslint-disable-next-line handle-callback-err
-        function onResult(nullErr, results) {
-            // vasync will never return error here. callback with the original
-            // error to pass it on.
-            return cb(err);
+        function onResult(__, results) {
+            // vasync will never return error here since we throw them away.
+            return cb();
         }
     );
 };

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -2505,9 +2505,10 @@ test('uncaughtException should handle thrown undefined literal', function(t) {
         }
     );
 
-    CLIENT.get('/foo', function(err, _, res) {
+    CLIENT.get('/foo', function(err, _, res, data) {
         t.ok(err);
         t.equal(res.statusCode, 500);
+        t.equal(data.message, '');
         t.end();
     });
 });
@@ -2535,8 +2536,9 @@ test('uncaughtException should handle thrown Number', function(t) {
         }
     );
 
-    CLIENT.get('/foo', function(err, _, res) {
+    CLIENT.get('/foo', function(err, _, res, data) {
         t.ok(err);
+        t.equal(data.message, '1');
         t.equal(res.statusCode, 500);
         t.end();
     });

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -2482,6 +2482,37 @@ test('uncaughtException should not trigger named routeHandler', function(t) {
     });
 });
 
+test('uncaughtException should handle thrown null', function(t) {
+    SERVER.get(
+        {
+            name: 'foo',
+            path: '/foo'
+        },
+        function(req, res, next) {
+            throw null; //eslint-disable-line no-throw-literal
+        }
+    );
+
+    SERVER.get(
+        {
+            name: 'bar',
+            path: '/bar'
+        },
+        function(req, res, next) {
+            // This code should not run, but we can test against the status code
+            res.send(200);
+            next();
+        }
+    );
+
+    CLIENT.get('/foo', function(err, _, res, data) {
+        t.ok(err);
+        t.equal(res.statusCode, 500);
+        t.equal(data.message, 'null');
+        t.end();
+    });
+});
+
 test('uncaughtException should handle thrown undefined literal', function(t) {
     SERVER.get(
         {
@@ -2508,12 +2539,43 @@ test('uncaughtException should handle thrown undefined literal', function(t) {
     CLIENT.get('/foo', function(err, _, res, data) {
         t.ok(err);
         t.equal(res.statusCode, 500);
-        t.equal(data.message, '');
+        t.equal(data.message, 'undefined');
         t.end();
     });
 });
 
-test('uncaughtException should handle thrown Number', function(t) {
+test('uncaughtException should handle thrown falsy number', function(t) {
+    SERVER.get(
+        {
+            name: 'foo',
+            path: '/foo'
+        },
+        function(req, res, next) {
+            throw 0; //eslint-disable-line no-throw-literal
+        }
+    );
+
+    SERVER.get(
+        {
+            name: 'bar',
+            path: '/bar'
+        },
+        function(req, res, next) {
+            // This code should not run, but we can test against the status code
+            res.send(200);
+            next();
+        }
+    );
+
+    CLIENT.get('/foo', function(err, _, res, data) {
+        t.ok(err);
+        t.equal(data.message, '0');
+        t.equal(res.statusCode, 500);
+        t.end();
+    });
+});
+
+test('uncaughtException should handle thrown non falsy number', function(t) {
     SERVER.get(
         {
             name: 'foo',
@@ -2539,6 +2601,68 @@ test('uncaughtException should handle thrown Number', function(t) {
     CLIENT.get('/foo', function(err, _, res, data) {
         t.ok(err);
         t.equal(data.message, '1');
+        t.equal(res.statusCode, 500);
+        t.end();
+    });
+});
+
+test('uncaughtException should handle thrown boolean', function(t) {
+    SERVER.get(
+        {
+            name: 'foo',
+            path: '/foo'
+        },
+        function(req, res, next) {
+            throw true; //eslint-disable-line no-throw-literal
+        }
+    );
+
+    SERVER.get(
+        {
+            name: 'bar',
+            path: '/bar'
+        },
+        function(req, res, next) {
+            // This code should not run, but we can test against the status code
+            res.send(200);
+            next();
+        }
+    );
+
+    CLIENT.get('/foo', function(err, _, res, data) {
+        t.ok(err);
+        t.equal(data.message, 'true');
+        t.equal(res.statusCode, 500);
+        t.end();
+    });
+});
+
+test('uncaughtException should handle thrown falsy boolean', function(t) {
+    SERVER.get(
+        {
+            name: 'foo',
+            path: '/foo'
+        },
+        function(req, res, next) {
+            throw false; //eslint-disable-line no-throw-literal
+        }
+    );
+
+    SERVER.get(
+        {
+            name: 'bar',
+            path: '/bar'
+        },
+        function(req, res, next) {
+            // This code should not run, but we can test against the status code
+            res.send(200);
+            next();
+        }
+    );
+
+    CLIENT.get('/foo', function(err, _, res, data) {
+        t.ok(err);
+        t.equal(data.message, 'false');
         t.equal(res.statusCode, 500);
         t.end();
     });


### PR DESCRIPTION
## Pre-Submission Checklist

- [ ] Opened an issue discussing these changes before opening the PR
- [X] Ran the linter and tests via `make prepush`
- [X] Included comprehensive and convincing tests for changes

## Issues

Restify doesn't properly handle non-errors being thrown inside the domain. The two tests augmented in this PR are currently passing unintentionally. When you dump the response sent back from restify, they actually show restify blowing up while attempting to handle the domain, and not the original non-error value thrown in the domain: `TypeError: Cannot read property \'statusCode\' of undefined` and `AssertionError [ERR_ASSERTION]: first argument to VError, SError, or WError constructor must be a string, object, or Error (string) is required'`. 

I think this behavior is unintentional. @misterdjules I'm not sure if this is related to your previous domain findings, but it appears the domain is able to re-catch the secondary exception thrown by restify code attempting to handle the original user land exception. 

# Changes

This PR fixes the restify code and does best effort at trying to proxy the non-error values thrown by the domain back to the client. 