### PR TITLE
upgrade: autocannon-compare@0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
   },
   "devDependencies": {
     "autocannon": "^2.2.0",
-    "autocannon-compare": "^0.3.0",
+    "autocannon-compare": "^0.4.0",
     "chai": "^4.1.2",
     "cover": "^0.2.9",
     "coveralls": "^3.0.3",


### PR DESCRIPTION
## Pre-Submission Checklist

- [x] Opened an issue discussing these changes before opening the PR
- [x] Ran the linter and tests via `make prepush`
- [ ] Included comprehensive and convincing tests for changes

## Issues

This fixes `make benchmark`.

# Changes

Upgrades autocannon-compare. Autocannon is actually on 3.x now, which we might want to look into. We might have to do some work though since autocannon-compare [does not yet support 3.x format](https://github.com/mcollina/autocannon-compare/pull/1). 
