### PR TITLE
fix(cpuUsageThrottle): support breaking change in pidusage module

### DIFF
--- a/lib/plugins/cpuUsageThrottle.js
+++ b/lib/plugins/cpuUsageThrottle.js
@@ -130,14 +130,14 @@ function cpuUsageThrottlePlugin(opts) {
     // plugin._timeoutDelta represents the amount of time between when we
     // _should_ have run updateReject and the actual time it was invoked.
     // This allows us to monitor lag caused by both the event loop
-    // and pidusage.stat
+    // and pidusage
     plugin._timeoutDelta = 0;
     plugin._timeoutStart = Date.now();
 
     // updateReject should be called on an interval, it checks the average CPU
     // usage between two invocations of updateReject.
     function updateReject() {
-        pidusage.stat(process.pid, function pidusageStat(e, stat) {
+        pidusage(process.pid, function pidusageStat(e, stat) {
             // Requeue an updateReject irrespective of whether or not pidusage
             // encountered an error
             plugin._timeout = setTimeout(updateReject, plugin._interval);
@@ -164,7 +164,7 @@ function cpuUsageThrottlePlugin(opts) {
 
             // Calculate how long it took between when our interval should have
             // updated the _reject value and how long it actually took. This
-            // metric accounts for the misbehaviour of pidusage.stat
+            // metric accounts for the misbehaviour of pidusage
             var now = Date.now();
             plugin._timeoutDelta =
                 now - plugin._timeoutStart - plugin._interval;

--- a/test/plugins/cpuUsageThrottle.test.js
+++ b/test/plugins/cpuUsageThrottle.test.js
@@ -5,15 +5,14 @@ var assert = require('chai').assert;
 var proxyquire = require('proxyquire');
 var restify = require('../../lib/index.js');
 var restifyClients = require('restify-clients');
+var pidusage = require('pidusage');
 
 // Allow tests to set the CPU usage returned by pidUsage
 var CPU = 50;
 
 var cpuUsageThrottle = proxyquire('../../lib/plugins/cpuUsageThrottle.js', {
-    pidusage: {
-        stat: function(pid, cb) {
-            return cb(null, { cpu: CPU });
-        }
+    pidusage: function(pid, cb) {
+        return cb(null, { cpu: CPU });
     }
 });
 
@@ -126,6 +125,16 @@ describe('cpuUsageThrottle', function() {
                 server.close();
                 done();
             });
+        });
+    });
+
+    it('Integration: pidusage should report CPU usage', function(done) {
+        assert.isFunction(pidusage, 'pidusage can be invoked');
+        pidusage(process.pid, function(e, stat) {
+            assert.ifError(e);
+            assert.isObject(stat);
+            assert.isNumber(stat.cpu);
+            done();
         });
     });
 


### PR DESCRIPTION
A commit semver major upgraded the `pidusage` module.

https://github.com/restify/node-restify/pull/1755/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R109

The cpuUsageThrottle tests `proxyquire`d out the entire module, preventing them from failing even though the module changed it's API.

https://github.com/restify/node-restify/blob/e4007cf69053c12d3c2919db96a0f5d0a0358310/test/plugins/cpuUsageThrottle.test.js#L12-L18

This PR:

* Updates the plugin to use the new API for the `pidusage` module
* Adds a test which validates the API for the `pidusage` module