### PR TITLE
feat: provide callback to uncaughtException handler

### DIFF
--- a/docs/api/server-events.md
+++ b/docs/api/server-events.md
@@ -107,15 +107,21 @@ server.get('/', function(req, res, next) {
     return next();
 });
 
-server.on('uncaughtException', function(req, res, route, err) {
+server.on('uncaughtException', function(req, res, route, err, callback) {
     // this event will be fired, with the error object from above:
     // ReferenceError: x is not defined
+    res.send(504, 'boom');
+    callback();
 });
 ```
 
-If you listen to this event, you __must__ send a response to the client. This
-behavior is different from the standard error events. If you do not listen to
-this event, restify's default behavior is to call `res.send()` with the error
+If you listen to this event, you __must__:
+
+1. send a response to the client _and_
+2. call the callback function passed as the fourth argument of the event listener
+
+This behavior is different from the standard error events. If you do not listen
+to this event, restify's default behavior is to call `res.send()` with the error
 that was thrown.
 
 The signature is for the after event is as follows:

--- a/lib/server.js
+++ b/lib/server.js
@@ -1412,6 +1412,16 @@ Server.prototype._routeErrorResponse = function _routeErrorResponse(
             req.route,
             err,
             function uncaughtExceptionCompleted() {
+                // We provide a callback to listeners of the 'uncaughtException'
+                // event and we call _finishReqResCycle when that callback is
+                // called so that, in case the actual request/response lifecycle
+                // was completed _before_ the error was thrown or emitted, and
+                // thus _before_ route handlers were marked as "finished", we
+                // can still mark the req/res lifecycle as complete.
+                // This edge case can occur when e.g. a client aborts a request
+                // and the route handler that handles that request throws an
+                // uncaught exception _after_ the request was aborted and the
+                // response was closed.
                 self._finishReqResCycle(req, res, err);
             }
         );

--- a/lib/server.js
+++ b/lib/server.js
@@ -1405,7 +1405,16 @@ Server.prototype._routeErrorResponse = function _routeErrorResponse(
         self.handleUncaughtExceptions &&
         self.listenerCount('uncaughtException') > 1
     ) {
-        self.emit('uncaughtException', req, res, req.route, err);
+        self.emit(
+            'uncaughtException',
+            req,
+            res,
+            req.route,
+            err,
+            function uncaughtExceptionCompleted() {
+                self._finishReqResCycle(req, res, err);
+            }
+        );
         return;
     }
 

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -2051,31 +2051,48 @@ test(
     }
 );
 
+// This test reproduces https://github.com/restify/node-restify/issues/1765. It
+// specifically tests the edge case of an exception being thrown from a route
+// handler _after_ the response is considered to be "flushed" (for instance when
+// the request is aborted before a response is sent and an exception is thrown).
 // eslint-disable-next-line max-len
-test("should emit 'after' on client closed request with an uncaughtException", function(t) {
+test("should emit 'after' on uncaughtException after response closed with custom uncaughtException listener", function(t) {
+    var ERR_MSG = 'foo';
+    var gotAfter = false;
+    var gotReqCallback = false;
+
     SERVER.on('after', function(req, res, route, err) {
+        gotAfter = true;
         t.ok(err);
         t.equal(req.connectionState(), 'close');
         t.equal(res.statusCode, 444);
         t.equal(err.name, 'Error');
-        t.end();
+        t.equal(err.message, ERR_MSG);
+        if (gotReqCallback) {
+            t.end();
+        }
     });
 
-    SERVER.on('uncaughtException', function(req, res, route, err, next) {
-        next();
+    SERVER.on('uncaughtException', function(req, res, route, err, callback) {
+        callback();
     });
 
     SERVER.get('/foobar', function(req, res, next) {
-        // fast client times out at 500ms, wait for 800ms which should cause
-        // client to timeout
-        setTimeout(function() {
-            throw new Error('foo');
-        }, 800);
+        res.on('close', function onResClose() {
+            // We throw this error in the response's close event handler on
+            // purpose to exercise the code path where we mark the route
+            // handlers as finished _after_ the response is marked as flushed.
+            throw new Error(ERR_MSG);
+        });
     });
 
     FAST_CLIENT.get('/foobar', function(err, _, res) {
+        gotReqCallback = true;
         t.ok(err);
         t.equal(err.name, 'RequestTimeoutError');
+        if (gotAfter) {
+            t.end();
+        }
     });
 });
 


### PR DESCRIPTION
## Pre-Submission Checklist

- [x] Opened an issue discussing these changes before opening the PR
- [x] Ran the linter and tests via `make prepush`
- [x] Included comprehensive and convincing tests for changes

## Issues

Closes:

* Issue https://github.com/restify/node-restify/issues/1765

> Summarize the issues that discussed these changes

The 'after' event is not called when a request has an uncaught exception (using `handleUncaughtExceptions`) if the request has been aborted before the exception.

# Changes

> What does this PR do?

This PR is a proposal for a mechanism to fix the issue by adding a continuation function to the `uncaughtException` handler.  If this continuation function isn't called, then restify can never know that a request has completed all work and call the 'after' handler (because `aborted` is triggered on the request object before work has completed, so neither `finish` nor `close` ever get triggered on the response and thus we have no other signal that work has completed).  This is actually consistent with how middlewares work--if `next` isn't called then the accounting will leak--so I believe the tradeoff is acceptable.

This pattern also allows for a fix without making a breaking API change.