### PR TITLE
breaking: emit after on uncaught exception with no custom handler

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@
 
 'use strict';
 
+var _ = require('lodash');
 var assert = require('assert-plus');
 var errors = require('restify-errors');
 
@@ -90,8 +91,13 @@ function createServer(options) {
             req,
             res,
             route,
-            e
+            e,
+            cb
         ) {
+            // If there _is_ at least one user-defined 'uncaughtException' event
+            // listener set on the server instance, do not perform the default
+            // handling mechanism for this uncaught exception, and instead leave
+            // that to the user-defined handlers.
             if (
                 this.listeners('uncaughtException').length > 1 ||
                 res.headersSent
@@ -99,7 +105,21 @@ function createServer(options) {
                 return false;
             }
 
-            res.send(new InternalError(e, e.message || 'unexpected error'));
+            if (!res._flushed) {
+                if (!_.isObject(e)) {
+                    res.send(new InternalError(String(e)));
+                } else {
+                    res.send(
+                        new InternalError(e, e.message || 'unexpected error')
+                    );
+                }
+            }
+
+            // Notify that handling of this uncaught exception is done so that
+            // Restify can properly track the lifecycle of the associated
+            // request/response lifecycle (e.g. emitting the 'after' event,
+            // etc.).
+            cb();
             return true;
         });
     }

--- a/lib/server.js
+++ b/lib/server.js
@@ -1402,8 +1402,7 @@ Server.prototype._routeErrorResponse = function _routeErrorResponse(
 
     if (
         isUncaught &&
-        self.handleUncaughtExceptions &&
-        self.listenerCount('uncaughtException') > 1
+        self.handleUncaughtExceptions
     ) {
         self.emit(
             'uncaughtException',

--- a/lib/server.js
+++ b/lib/server.js
@@ -1400,10 +1400,7 @@ Server.prototype._routeErrorResponse = function _routeErrorResponse(
 ) {
     var self = this;
 
-    if (
-        isUncaught &&
-        self.handleUncaughtExceptions
-    ) {
+    if (isUncaught && self.handleUncaughtExceptions) {
         self.emit(
             'uncaughtException',
             req,


### PR DESCRIPTION
<!--
Thank you for taking the time to open an PR for restify! If this is your first
time here, welcome to our community! We are a group of developers who work on
restify in our free-time. Some of us do it as a hobby, others are using restify
at work. When asking for help here, keep in mind most of us are volunteers
contributing our daily work back to the community at no cost (and often for no
reward). Please be respectful!

Below you will find a checklist to help you create the best PR possible. While
the checklist items aren't all _strictly_ required, they dramatically increase
the probability of your PR getting a response and getting merged. Often times,
the least time consuming part of maintaining and open source project is writing
code, its the process and discussions that happen around the code base that
consume a majority of the maintainers' time. By spending a few moments to
adhere to this template, you are not only improve the quality of your PR, you
are also helping save the maintainers a considerable amount of time when trying
to understand and review your changes.

And remember, positive vibes are met with positive vibes. Kindness helps Free
Software go round, pay it forward!
-->

## Pre-Submission Checklist

- [x] Opened an issue discussing these changes before opening the PR
- [x] Ran the linter and tests via `make prepush`
- [x] Included comprehensive and convincing tests for changes

## Issues

Closes:

* Issue #1768

When throwing an error in a route handler and not listening on the `'uncaughtException'` event, the `'after'` event is *not* emitted.

# Changes

The changes in this  PR:
* always emit the `'uncaughtException'` event, even when the application's code does not add a listener for it. This allows the internal `'uncaughtException'` event handler to run. I'm not sure this is a good thing.
* check whether the response is already flushed before sending a default error response. If it is, it forces finishing the request/response lifecycle, as nothing else would do that otherwise.
