### PR TITLE
chore(tests): clear event loop to end tests faster

### DIFF
--- a/test/plugins/cpuUsageThrottle.test.js
+++ b/test/plugins/cpuUsageThrottle.test.js
@@ -134,6 +134,7 @@ describe('cpuUsageThrottle', function() {
             assert.ifError(e);
             assert.isObject(stat);
             assert.isNumber(stat.cpu);
+            pidusage.clear();
             done();
         });
     });


### PR DESCRIPTION
## Pre-Submission Checklist

- [ ] Opened an issue discussing these changes before opening the PR
- [x] Ran the linter and tests via `make prepush`
- [x] Included comprehensive and convincing tests for changes

## Issues

Tests were hanging for 30sec after the runner had completed. Looks like the `pidusage` defaults to a 30s interval so it was waiting for that before the test runner could exit. 

# Changes

Removes the pidusage handler from the test once complete. 
