### PR TITLE
feat: send 500s for unhandled requests

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1352,7 +1352,10 @@ Server.prototype._finishReqResCycle = function _finishReqResCycle(
     var self = this;
     var route = req.route; // can be undefined when 404 or error
 
-    if (res._finished) {
+    // if the returned err value was a string, then we're handling the
+    // next('foo') case where we redirect to another middleware stack. don't
+    // do anything here because we're not done yet.
+    if (res._finished || _.isString(err)) {
         return;
     }
 
@@ -1366,6 +1369,22 @@ Server.prototype._finishReqResCycle = function _finishReqResCycle(
         var finalErr = err || res.err;
         req.emit('restifyDone', route, finalErr);
         self.emit('after', req, res, route, finalErr);
+    } else if (
+        res._handlersFinished === true &&
+        res.headersSent === false &&
+        !res.err
+    ) {
+        // if we reached the end of the handler chain and headers haven't been
+        // sent AND there isn't an existing res.err (e.g., req abort/close),
+        // it's possible it's a user error and a response was never written.
+        // send a 500.
+        res.send(
+            new errors.InternalServerError(
+                'reached the end of the handler chain without ' +
+                    'writing a response!'
+            )
+        );
+        return;
     } else {
         // Store error for when the response is flushed and we actually emit the
         // 'after' event. The "err" object passed to this method takes


### PR DESCRIPTION
## Pre-Submission Checklist

- [X] Opened an issue discussing these changes before opening the PR
- [X] Ran the linter and tests via `make prepush`
- [X] Included comprehensive and convincing tests for changes

## Issues

Closes:

* Issue #1774 

# Changes

If we reach the end of a handler chain and the headers haven't been sent yet, send a 500 back to the client. 