### PR TITLE
Removes the benchmark folder from the npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -12,3 +12,4 @@ test
 tools
 .vscode
 .idea
+benchmark


### PR DESCRIPTION
This lightens up the bundle by roughly `43.2Mb`

## Issues

Closes:

* Issue #1778 

> Summarize the issues that discussed these changes

# Changes

> Excludes the `becnhmark` folder from the final npm bundle.
