### PR TITLE
feat: adds support to http problem details - rfc7807

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ deps/javascriptlint
 deps/jsstyle
 package-lock.json
 benchmark/results
+.idea

--- a/lib/formatters/index.js
+++ b/lib/formatters/index.js
@@ -18,5 +18,6 @@ module.exports = {
     'application/javascript; q=0.1': require('./jsonp'),
     'application/json; q=0.4': require('./json'),
     'text/plain; q=0.3': require('./text'),
-    'application/octet-stream; q=0.2': require('./binary')
+    'application/octet-stream; q=0.2': require('./binary'),
+    'application/problem+json; q=0.5': require('./json')
 };

--- a/lib/response.js
+++ b/lib/response.js
@@ -389,7 +389,7 @@ function patch(Response) {
         // If the body is an error object and we were not given a status code,
         // try to derive it from the error object, otherwise default to 500
         if (!code && body instanceof Error) {
-            code = body.statusCode || 500;
+            code = body.statusCode || body.status || 500;
         }
 
         // Set sane defaults for optional arguments if they were not provided
@@ -441,7 +441,12 @@ function patch(Response) {
             // Set Content-Type to application/json when
             // res.send is called with an Object instead of calling res.json
             if (!type && typeof body === 'object' && !Buffer.isBuffer(body)) {
-                type = 'application/json';
+                // if Error that conforms with rfc7807 use the correct type
+                if (body instanceof Error && body.status && !body.statusCode) {
+                    type = 'application/problem+json';
+                } else {
+                    type = 'application/json';
+                }
             }
 
             // Derive type if not provided by the user

--- a/lib/server.js
+++ b/lib/server.js
@@ -1435,7 +1435,7 @@ Server.prototype._routeErrorResponse = function _routeErrorResponse(
         }
 
         // only automatically send errors that are known (e.g., restify-errors)
-        if (err instanceof Error && _.isNumber(err.statusCode)) {
+        if (err instanceof Error && _.isNumber(err.statusCode || err.status)) {
             res.send(err);
             return;
         }

--- a/test/response.test.js
+++ b/test/response.test.js
@@ -680,3 +680,38 @@ test('GH-1607: should send numbers with explicit status code', function(t) {
         });
     });
 });
+
+test('should handle errors with a status property', function(t) {
+    var notFound = new Error('not found');
+    notFound.status = 404;
+    notFound.title = 'Not Found';
+
+    SERVER.get('/17', function handle(req, res, next) {
+        return next(notFound);
+    });
+
+    CLIENT.get(join(LOCALHOST, '/17'), function(err, _, res, body) {
+        t.equal(res.statusCode, 404);
+        t.equal(res.headers['content-type'], 'application/problem+json');
+        t.equal(body.title, notFound.title);
+        t.end();
+    });
+});
+
+test('should prefer error statusCode property over status', function(t) {
+    var notFound = new Error('not found');
+    notFound.statusCode = 404;
+    notFound.status = 500;
+    notFound.title = 'Not Found';
+
+    SERVER.get('/18', function handle(req, res, next) {
+        return next(notFound);
+    });
+
+    CLIENT.get(join(LOCALHOST, '/18'), function(err, _, res, body) {
+        t.equal(res.statusCode, 404);
+        t.equal(res.headers['content-type'], 'application/json');
+        t.equal(body.title, notFound.title);
+        t.end();
+    });
+});

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -2333,7 +2333,8 @@ test('should show debug information', function(t) {
         'application/javascript',
         'application/json',
         'text/plain',
-        'application/octet-stream'
+        'application/octet-stream',
+        'application/problem+json'
     ]);
     t.equal(debugInfo.server.address, '127.0.0.1');
     t.equal(typeof debugInfo.server.port, 'number');


### PR DESCRIPTION
<!--
Thank you for taking the time to open an PR for restify! If this is your first
time here, welcome to our community! We are a group of developers who work on
restify in our free-time. Some of us do it as a hobby, others are using restify
at work. When asking for help here, keep in mind most of us are volunteers
contributing our daily work back to the community at no cost (and often for no
reward). Please be respectful!

Below you will find a checklist to help you create the best PR possible. While
the checklist items aren't all _strictly_ required, they dramatically increase
the probability of your PR getting a response and getting merged. Often times,
the least time consuming part of maintaining and open source project is writing
code, its the process and discussions that happen around the code base that
consume a majority of the maintainers' time. By spending a few moments to
adhere to this template, you are not only improve the quality of your PR, you
are also helping save the maintainers a considerable amount of time when trying
to understand and review your changes.

And remember, positive vibes are met with positive vibes. Kindness helps Free
Software go round, pay it forward!
-->

## Pre-Submission Checklist

- [ ] Opened an issue discussing these changes before opening the PR
- [x] Ran the linter and tests via `make prepush`
- [x] Included comprehensive and convincing tests for changes

# Changes

> What does this PR do?

adds supports to handle error objects conforming with the [http
problem details spec (rfc7807)](https://tools.ietf.org/html/rfc7807).
 
The spec defines a `status` field (instead of `statusCode`) and a 
`application/problem+json` content type. Code will prefer the current 
behavior of sending `application/json` if `statusCode` is present.
