### PR TITLE
fix: bodyReader works with gunzip and maxBodySize

### DIFF
--- a/lib/plugins/bodyReader.js
+++ b/lib/plugins/bodyReader.js
@@ -15,6 +15,8 @@ var BadDigestError = errors.BadDigestError;
 var RequestEntityTooLargeError = errors.RequestEntityTooLargeError;
 var PayloadTooLargeError = errors.PayloadTooLargeError;
 var UnsupportedMediaTypeError = errors.UnsupportedMediaTypeError;
+var BadRequestError = errors.BadRequestError;
+var InternalServerError = errors.InternalServerError;
 
 var MD5_MSG = "Content-MD5 '%s' didn't match '%s'";
 
@@ -96,12 +98,16 @@ function bodyReader(options) {
         var md5;
 
         var unsupportedContentEncoding;
+        var gzError;
 
         if ((md5 = req.headers['content-md5'])) {
             hash = crypto.createHash('md5');
         }
 
         function done() {
+            var err;
+            var msg;
+
             bodyWriter.end();
 
             if (unsupportedContentEncoding) {
@@ -119,8 +125,7 @@ function bodyReader(options) {
             }
 
             if (maxBodySize && bytesReceived > maxBodySize) {
-                var msg = 'Request body size exceeds ' + maxBodySize;
-                var err;
+                msg = 'Request body size exceeds ' + maxBodySize;
 
                 // Between Node 0.12 and 4 http status code messages changed
                 // RequestEntityTooLarge was changed to PayloadTooLarge
@@ -131,6 +136,21 @@ function bodyReader(options) {
                     err = new RequestEntityTooLargeError(msg);
                 }
 
+                next(err);
+                return;
+            }
+
+            if (gzError) {
+                if (
+                    gzError.errno === zlib.Z_DATA_ERROR ||
+                    gzError.errno === zlib.Z_STREAM_ERROR
+                ) {
+                    msg = 'Request body is not a valid gzip';
+                    err = new BadRequestError(msg);
+                } else {
+                    msg = 'Failed to gunzip request body';
+                    err = new InternalServerError(msg);
+                }
                 next(err);
                 return;
             }
@@ -155,6 +175,10 @@ function bodyReader(options) {
             gz = zlib.createGunzip();
             gz.on('data', bodyWriter.write);
             gz.once('end', done);
+            gz.once('error', function onGzError(err) {
+                gzError = err;
+                done();
+            });
             req.once('end', gz.end.bind(gz));
         } else {
             unsupportedContentEncoding = req.headers['content-encoding'];


### PR DESCRIPTION
<!--
Thank you for taking the time to open an PR for restify! If this is your first
time here, welcome to our community! We are a group of developers who work on
restify in our free-time. Some of us do it as a hobby, others are using restify
at work. When asking for help here, keep in mind most of us are volunteers
contributing our daily work back to the community at no cost (and often for no
reward). Please be respectful!

Below you will find a checklist to help you create the best PR possible. While
the checklist items aren't all _strictly_ required, they dramatically increase
the probability of your PR getting a response and getting merged. Often times,
the least time consuming part of maintaining and open source project is writing
code, its the process and discussions that happen around the code base that
consume a majority of the maintainers' time. By spending a few moments to
adhere to this template, you are not only improve the quality of your PR, you
are also helping save the maintainers a considerable amount of time when trying
to understand and review your changes.

And remember, positive vibes are met with positive vibes. Kindness helps Free
Software go round, pay it forward!
-->

## Pre-Submission Checklist

- [X] Opened an issue discussing these changes before opening the PR
- [X] Ran the linter and tests via `make prepush`
- [X] Included comprehensive and convincing tests for changes

## Issues

Closes:

* https://github.com/restify/node-restify/issues/1785

# Changes

Adds error handling for Gunzip errors so node process does not die.
Fixes handling "413 Payload Too Large" for gzip encoded content.