### PR TITLE
Bugfix + Improvement

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -357,8 +357,7 @@ Router.prototype.defaultRoute = function defaultRoute(req, res, next) {
 Router.prototype._getRouteName = function _getRouteName(name, method, path) {
     // Generate name
     if (!name) {
-        name = method + '-' + path;
-        name = name.replace(/\W/g, '').toLowerCase();
+        name = (method + ' ' + path).toLowerCase();
     }
 
     // Avoid name conflict: GH-401


### PR DESCRIPTION
Currently there is a hyphen "-" that is added between the method & path, however it is removed by the next line with the regex replace that replaces/removes all non-word characters:

```
    if (!name) {
        name = method + '-' + path;  // adds hypen
        name = name.replace(/\W/g, '').toLowerCase(); // removes hyphen
    }
```
I don't think you should force users to create a new object in order to allow them to name a route when they can specify the route explicitly. The improvement I added basically allows anyone to use `next('<method> <path>');` to call an existing route within another route without having to name a route explicitly.

Currently this works:

```
server.get('/user', (req, res, next) => {
  res.json({ user: 'ascari' });
  next();
});

server.get('/user', (req, res, next) => {
  next('getuser');
});
```

The improvement makes the default/auto-name of a route dev-friendly

```
server.get('/user', (req, res, next) => {
  res.json({ user: 'ascari' });
  next();
});

server.get('/user', (req, res, next) => {
  next('get /user');
});
```

This way, for non-dupe routes, you can call another existing route without having to name it.

<!--
Thank you for taking the time to open an PR for restify! If this is your first
time here, welcome to our community! We are a group of developers who work on
restify in our free-time. Some of us do it as a hobby, others are using restify
at work. When asking for help here, keep in mind most of us are volunteers
contributing our daily work back to the community at no cost (and often for no
reward). Please be respectful!

Below you will find a checklist to help you create the best PR possible. While
the checklist items aren't all _strictly_ required, they dramatically increase
the probability of your PR getting a response and getting merged. Often times,
the least time consuming part of maintaining and open source project is writing
code, its the process and discussions that happen around the code base that
consume a majority of the maintainers' time. By spending a few moments to
adhere to this template, you are not only improve the quality of your PR, you
are also helping save the maintainers a considerable amount of time when trying
to understand and review your changes.

And remember, positive vibes are met with positive vibes. Kindness helps Free
Software go round, pay it forward!
-->

## Pre-Submission Checklist

- [ ] Opened an issue discussing these changes before opening the PR
- [ ] Ran the linter and tests via `make prepush`
- [ ] Included comprehensive and convincing tests for changes

## Issues

Closes:

* Issue #
* Issue #
* Issue #

> Summarize the issues that discussed these changes

# Changes

> What does this PR do?
