### PR TITLE
feat(chain): schedule handlers to the next tick

### DIFF
--- a/lib/chain.js
+++ b/lib/chain.js
@@ -161,7 +161,9 @@ function call(handler, err, req, res, _next) {
         return;
     } else if (!hasError && arity < 4) {
         // request-handling middleware
-        handler(req, res, next);
+        process.nextTick(function nextTick() {
+            handler(req, res, next);
+        });
         return;
     }
 


### PR DESCRIPTION
Schedule handlers to nextTick for cleaner Flamegraphs.
Shouldn't have an effect on performance:

```
? Do you want to track progress? No
? Do you want to compare HEAD with the stable release (7.2.0)? Yes
? Do you want to run all benchmark tests? Yes
? How many connections do you need? 100
? How many pipelining do you need? 10
? How long does it take? 30
---- response-json ----
⠋ Started head/response-json
✔ Results saved for head/response-json
✔ Results saved for stable/response-json
response-json throughput:
{
    "significant": "",
    "equal": true
}

---- response-text ----
✔ Results saved for head/response-text
✔ Results saved for stable/response-text
response-text throughput:
{
    "significant": "",
    "equal": true
}

---- router-heavy ----
✔ Results saved for head/router-heavy
✔ Results saved for stable/router-heavy
router-heavy throughput:
{
    "significant": "***",
    "equal": true
}

---- middleware ----
✔ Results saved for head/middleware
✔ Results saved for stable/middleware
middleware throughput:
{
    "significant": "",
    "equal": true
}

```