### PR TITLE
Use restify-errors 8.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "once": "^1.4.0",
     "pidusage": "^2.0.17",
     "qs": "^6.7.0",
-    "restify-errors": "^8.0.0",
+    "restify-errors": "^8.0.1",
     "semver": "^6.1.1",
     "send": "^0.16.2",
     "spdy": "^4.0.0",


### PR DESCRIPTION
Yarn audit still shows restify-errors using lodash <4.17.12 which has a vuln.

I would have thought that your last release (8.4.0) would have used 8.0.1 because of the ^. But, I admit to not fully understanding how that works.

I didn't open an issue, as it seemed small enough to not warrant one, but I will if you'd like.

<!--
Thank you for taking the time to open an PR for restify! If this is your first
time here, welcome to our community! We are a group of developers who work on
restify in our free-time. Some of us do it as a hobby, others are using restify
at work. When asking for help here, keep in mind most of us are volunteers
contributing our daily work back to the community at no cost (and often for no
reward). Please be respectful!

Below you will find a checklist to help you create the best PR possible. While
the checklist items aren't all _strictly_ required, they dramatically increase
the probability of your PR getting a response and getting merged. Often times,
the least time consuming part of maintaining and open source project is writing
code, its the process and discussions that happen around the code base that
consume a majority of the maintainers' time. By spending a few moments to
adhere to this template, you are not only improve the quality of your PR, you
are also helping save the maintainers a considerable amount of time when trying
to understand and review your changes.

And remember, positive vibes are met with positive vibes. Kindness helps Free
Software go round, pay it forward!
-->

## Pre-Submission Checklist

- [ ] Opened an issue discussing these changes before opening the PR
- [ ] Ran the linter and tests via `make prepush`
- [ ] Included comprehensive and convincing tests for changes

## Issues

Closes:

* Issue #
* Issue #
* Issue #

> Summarize the issues that discussed these changes

# Changes

> What does this PR do?

Use restify-errors 8.0.1