### PR TITLE
Fix the link for Error Handling section in docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -195,7 +195,7 @@ The difference between the two is that invoking `next()` with an Error object
 allows you to leverage the server's [event
 emitter](/components/server.md#errors). This enables you to handle all
 occurrences of an error type using a common handler. See the [error
-handling](#error handling) section for more details.
+handling](#error-handling) section for more details.
 
 
 Lastly, you can call `next.ifError(err)` with an Error object to cause restify


### PR DESCRIPTION
<!--
Thank you for taking the time to open an PR for restify! If this is your first
time here, welcome to our community! We are a group of developers who work on
restify in our free-time. Some of us do it as a hobby, others are using restify
at work. When asking for help here, keep in mind most of us are volunteers
contributing our daily work back to the community at no cost (and often for no
reward). Please be respectful!

Below you will find a checklist to help you create the best PR possible. While
the checklist items aren't all _strictly_ required, they dramatically increase
the probability of your PR getting a response and getting merged. Often times,
the least time consuming part of maintaining and open source project is writing
code, its the process and discussions that happen around the code base that
consume a majority of the maintainers' time. By spending a few moments to
adhere to this template, you are not only improve the quality of your PR, you
are also helping save the maintainers a considerable amount of time when trying
to understand and review your changes.

And remember, positive vibes are met with positive vibes. Kindness helps Free
Software go round, pay it forward!
-->

## Pre-Submission Checklist

- [x] Opened an issue discussing these changes before opening the PR
- [x] Ran the linter and tests via `make prepush`
- [ ] Included comprehensive and convincing tests for changes

## Issues

Closes:

* Issue #1804 

# Changes
Changes `#error%20handling` to the correct id `#error-handling` in the link.
