### PR TITLE
Gracefully handle formatters throwing restify errors.

### DIFF
--- a/lib/formatters/json.js
+++ b/lib/formatters/json.js
@@ -23,7 +23,10 @@ function formatJSON(req, res, body) {
         try {
             data = JSON.stringify(body);
         } catch (e) {
-            throw new errors.InternalServerError(e);
+            throw new errors.InternalServerError(
+                { cause: e, info: { formatter: 'json' } },
+                'could not format response body'
+            );
         }
     }
 

--- a/lib/formatters/json.js
+++ b/lib/formatters/json.js
@@ -2,6 +2,8 @@
 
 'use strict';
 
+var errors = require('restify-errors');
+
 ///--- Exports
 
 /**
@@ -16,7 +18,15 @@
  * @returns  {String} data
  */
 function formatJSON(req, res, body) {
-    var data = body ? JSON.stringify(body) : 'null';
+    var data = 'null';
+    if (body) {
+        try {
+            data = JSON.stringify(body);
+        } catch (e) {
+            throw new errors.InternalServerError(e);
+        }
+    }
+
     // Setting the content-length header is not a formatting feature and should
     // be separated into another module
     res.setHeader('Content-Length', Buffer.byteLength(data));

--- a/lib/response.js
+++ b/lib/response.js
@@ -506,7 +506,22 @@ function patch(Response) {
                 // Finally, invoke the formatter and flush the request with it's
                 // results
 
-                return flush(self, formatter(self.req, self, body));
+                var formattedBody;
+                try {
+                    formattedBody = formatter(self.req, self, body);
+                } catch (e) {
+                    if (
+                        e instanceof errors.RestError ||
+                        e instanceof errors.HttpError
+                    ) {
+                        e.message =
+                            'could not format response body: ' + e.message;
+                        var res = formatterError(self, e);
+                        return res;
+                    }
+                    throw e;
+                }
+                return flush(self, formattedBody);
             }
         }
 

--- a/lib/response.js
+++ b/lib/response.js
@@ -516,8 +516,6 @@ function patch(Response) {
                         e instanceof errors.RestError ||
                         e instanceof errors.HttpError
                     ) {
-                        e.message =
-                            'could not format response body: ' + e.message;
                         var res = formatterError(
                             self,
                             e,

--- a/lib/response.js
+++ b/lib/response.js
@@ -494,6 +494,8 @@ function patch(Response) {
                 );
             }
 
+            var formatterType = type;
+
             if (self._charSet) {
                 type = type + '; charset=' + self._charSet;
             }
@@ -516,7 +518,13 @@ function patch(Response) {
                     ) {
                         e.message =
                             'could not format response body: ' + e.message;
-                        var res = formatterError(self, e);
+                        var res = formatterError(
+                            self,
+                            e,
+                            'error in formatter (' +
+                                formatterType +
+                                ') formatting response body'
+                        );
                         return res;
                     }
                     throw e;
@@ -888,9 +896,10 @@ function flush(res, body) {
  * @function formatterError
  * @param {Response} res - response
  * @param {Error} err - error
+ * @param {String} [msg] - custom log message
  * @returns {Response} response
  */
-function formatterError(res, err) {
+function formatterError(res, err, msg) {
     // If the user provided a non-success error code, we don't want to
     // mess with it since their error is probably more important than
     // our inability to format their message.
@@ -898,12 +907,16 @@ function formatterError(res, err) {
         res.statusCode = err.statusCode;
     }
 
+    if (typeof msg !== 'string') {
+        msg = 'error retrieving formatter';
+    }
+
     res.log.warn(
         {
             req: res.req,
             err: err
         },
-        'error retrieving formatter'
+        msg
     );
 
     return flush(res);

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "proxyquire": "^1.8.0",
     "restify-clients": "^2.6.6",
     "rimraf": "^2.6.3",
+    "sinon": "^7.5.0",
     "validator": "^7.2.0",
     "watershed": "^0.4.0"
   },

--- a/test/formatter.test.js
+++ b/test/formatter.test.js
@@ -152,6 +152,7 @@ test('sync formatter should handle expected errors gracefully', function(t) {
             t.ok(req);
             t.ok(res);
             t.equal(res.statusCode, 500);
+            SERVER.removeAllListeners('uncaughtException');
             t.end();
         }
     );
@@ -294,6 +295,7 @@ test('default json formatter should wrap & throw InternalServer error on unseria
 
     CLIENT.get('/badJSON', function(err, req, res, data) {
         SERVER.rm('badJSON');
+        SERVER.removeAllListeners('uncaughtException');
         t.end();
     });
 });


### PR DESCRIPTION
Summary: Don't always blowup (uncaughtException) when we can avoid it, like in scenarios where a JSON payload does not properly parse or serialize.

Details:

When a formatter throws an error that is an instanceof restify-errors' `HttpError` or `RestError`, handle it gracefully by catching & passing to `formatterErrors`.