### PR TITLE
feat(chain): use nextTick instead of setImmediate

### DIFF
--- a/lib/chain.js
+++ b/lib/chain.js
@@ -112,7 +112,9 @@ Chain.prototype.run = function run(req, res, done) {
 
         // all done or request closed
         if (!handler || req.closed()) {
-            setImmediate(done, err, req, res);
+            process.nextTick(function nextTick() {
+                return done(err, req, res);
+            });
             return;
         }
 

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -227,15 +227,14 @@ test('should provide date when request started', function(t) {
 // restifyDone is emitted at the same time when server's after event is emitted,
 // you can find more comprehensive testing for `after` lives in server tests.
 test('should emit restifyDone event when request is fully served', function(t) {
-    var clientDone = false;
+    var restifyDoneCalled = false;
 
     SERVER.get('/', function(req, res, next) {
         req.on('restifyDone', function(route, err) {
             t.ifError(err);
             t.ok(route);
             setImmediate(function() {
-                t.ok(clientDone);
-                t.end();
+                restifyDoneCalled = true;
             });
         });
 
@@ -246,7 +245,8 @@ test('should emit restifyDone event when request is fully served', function(t) {
     CLIENT.get('/', function(err, _, res) {
         t.ifError(err);
         t.equal(res.statusCode, 200);
-        clientDone = true;
+        t.ok(restifyDoneCalled);
+        t.end();
     });
 });
 

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1820,7 +1820,7 @@ test('calling next(false) should early exit from use handlers', function(t) {
 
     SERVER.on('after', function() {
         steps++;
-        t.equal(steps, 2);
+        t.equal(steps, 1);
         t.end();
     });
 
@@ -2111,7 +2111,7 @@ test('should increment/decrement inflight request count', function(t) {
     CLIENT.get('/foo', function(err, _, res) {
         t.ifError(err);
         t.equal(res.statusCode, 200);
-        t.equal(SERVER.inflightRequests(), 1);
+        t.equal(SERVER.inflightRequests(), 0);
     });
 });
 
@@ -2135,14 +2135,14 @@ test('should increment/decrement inflight request count for concurrent reqs', fu
     CLIENT.get('/foo1', function(err, _, res) {
         t.ifError(err);
         t.equal(res.statusCode, 200);
-        t.equal(SERVER.inflightRequests(), 1);
+        t.equal(SERVER.inflightRequests(), 0);
         t.end();
     });
 
     CLIENT.get('/foo2', function(err, _, res) {
         t.ifError(err);
         t.equal(res.statusCode, 200);
-        t.equal(SERVER.inflightRequests(), 2);
+        t.equal(SERVER.inflightRequests(), 1);
     });
 });
 
@@ -2174,7 +2174,7 @@ test('should cleanup inflight requests count for 404s', function(t) {
     CLIENT.get('/foo1', function(err, _, res) {
         t.ifError(err);
         t.equal(res.statusCode, 200);
-        t.equal(SERVER.inflightRequests(), 1);
+        t.equal(SERVER.inflightRequests(), 0);
 
         CLIENT.get('/doesnotexist', function(err2, _2, res2) {
             t.ok(err2);
@@ -2219,7 +2219,7 @@ test('should cleanup inflight requests count for timeouts', function(t) {
     CLIENT.get('/foo2', function(err, _, res) {
         t.ifError(err);
         t.equal(res.statusCode, 200);
-        t.equal(SERVER.inflightRequests(), 2);
+        t.equal(SERVER.inflightRequests(), 1);
     });
 });
 
@@ -2862,7 +2862,7 @@ test('inflightRequest accounting stable with firstChain', function(t) {
         for (var i = 0; i < results.length; i++) {
             // The shed request should always be returned first, since it isn't
             // handled by SERVER.get
-            if (i === 0) {
+            if (i === 1) {
                 t.equal(
                     results[i].statusCode,
                     413,


### PR DESCRIPTION
BREAKING CHANGE: Using setImmediate has more overhead than nextTick on
Node.js v12. Benchmarks show improvements of >20% when changing
setImmediate to nextTick:

```
  response-json throughput:
  {
      "significant": "***",
      "equal": false,
      "wins": "head",
      "diff": "28.62%"
  }

  ---- response-text ----
  ✔ Results saved for head/response-text
  ✔ Results saved for stable/response-text
  response-text throughput:
  {
      "significant": "***",
      "equal": false,
      "wins": "head",
      "diff": "43.45%"
  }

  ---- router-heavy ----
  ✔ Results saved for head/router-heavy
  ✔ Results saved for stable/router-heavy
  router-heavy throughput:
  {
      "significant": "***",
      "equal": false,
      "wins": "head",
      "diff": "30.02%"
  }

  ---- middleware ----
  ✔ Results saved for head/middleware
  ✔ Results saved for stable/middleware
  middleware throughput:
  {
      "significant": "***",
      "equal": false,
      "wins": "head",
      "diff": "20.78%"
  }
```

This changes the order some events are processed (nextTick is processed
earlier than setImmediate), thus this can be considered a breaking
change as some edge cases will notice this (as we can see in the test
changes).

<!--
Thank you for taking the time to open an PR for restify! If this is your first
time here, welcome to our community! We are a group of developers who work on
restify in our free-time. Some of us do it as a hobby, others are using restify
at work. When asking for help here, keep in mind most of us are volunteers
contributing our daily work back to the community at no cost (and often for no
reward). Please be respectful!

Below you will find a checklist to help you create the best PR possible. While
the checklist items aren't all _strictly_ required, they dramatically increase
the probability of your PR getting a response and getting merged. Often times,
the least time consuming part of maintaining and open source project is writing
code, its the process and discussions that happen around the code base that
consume a majority of the maintainers' time. By spending a few moments to
adhere to this template, you are not only improve the quality of your PR, you
are also helping save the maintainers a considerable amount of time when trying
to understand and review your changes.

And remember, positive vibes are met with positive vibes. Kindness helps Free
Software go round, pay it forward!
-->

## Pre-Submission Checklist

- [ ] Opened an issue discussing these changes before opening the PR
- [x] Ran the linter and tests via `make prepush`
- [ ] Included comprehensive and convincing tests for changes