### PR TITLE
fix(server): address domain performance regression with Node v12.x

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-var domain = require('domain');
 var EventEmitter = require('events').EventEmitter;
 var http = require('http');
 var https = require('https');
@@ -27,6 +26,7 @@ var customErrorTypes = require('./errorTypes');
 var patchRequest = require('./request');
 var patchResponse = require('./response');
 
+var domain;
 var http2;
 
 patchResponse(http.ServerResponse);
@@ -930,6 +930,14 @@ Server.prototype._onRequest = function _onRequest(req, res) {
     // It has significant negative performance impact
     // Warning: this feature depends on the deprecated domains module
     if (self.handleUncaughtExceptions) {
+        // In Node v12.x requiring the domain module has a negative performance
+        // impact. As using domains in restify is optional and only required
+        // with the `handleUncaughtExceptions` options, we apply a singleton
+        // pattern to avoid any performance regression in the default scenario.
+        if (!domain) {
+            domain = require('domain');
+        }
+
         var handlerDomain = domain.create();
         handlerDomain.add(req);
         handlerDomain.add(res);

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "once": "^1.4.0",
     "pidusage": "^2.0.17",
     "qs": "^6.7.0",
-    "restify-errors": "^8.0.0",
+    "restify-errors": "^8.0.2",
     "semver": "^6.1.1",
     "send": "^0.16.2",
     "spdy": "^4.0.0",


### PR DESCRIPTION
```
$ node -v
v12.13.1
$ make benchmark 
? Do you want to track progress? No
? Do you want to compare HEAD with the stable release (7.2.0)? Yes
? Do you want to run all benchmark tests? Yes
? How many connections do you need? 100
? How many pipelining do you need? 10
? How long does it take? 30
---- response-json ----
✔ Results saved for head/response-json
✔ Results saved for stable/response-json
response-json throughput:
{
    "significant": "***",
    "equal": false,
    "wins": "head",
    "diff": "235.59%"
}

---- response-text ----
✔ Results saved for head/response-text
✔ Results saved for stable/response-text
response-text throughput:
{
    "significant": "***",
    "equal": false,
    "wins": "head",
    "diff": "204.37%"
}

---- router-heavy ----
✔ Results saved for head/router-heavy
✔ Results saved for stable/router-heavy
router-heavy throughput:
{
    "significant": "***",
    "equal": false,
    "wins": "head",
    "diff": "197.09%"
}

---- middleware ----
✔ Results saved for head/middleware
✔ Results saved for stable/middleware
middleware throughput:
{
    "significant": "***",
    "equal": false,
    "wins": "head",
    "diff": "157.24%"
}
```

cc thanks @mmarchini and @daviande for the finding!