### PR TITLE
fix(benchmark): force latest restify version

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -9,7 +9,7 @@
     "node": ">=0.10"
   },
   "dependencies": {
-    "restify": "*"
+    "restify": "latest"
   },
   "devDependencies": {},
   "license": "MIT",


### PR DESCRIPTION
`*` will match any stable release, which means if there's already a
restify version installed in the benchmarks directory, npm won't try to
update it. `latest` only matches the latest version, which means npm
will always update to the latest stable version (unless it's already
installed). This behavior can be checked with https://semver.npmjs.com/.