### PR TITLE
Preserve original error when there is no fallback formatter

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -529,6 +529,19 @@ function patch(Response) {
                 }
                 return flush(self, formattedBody);
             }
+            // Preserve original error when
+            // Content-type is set, _strictFormatters=false, no formatter found
+            if (body instanceof Error) {
+                return formatterError(
+                    self,
+                    new errors.InternalServerError(
+                        { cause: body, info: { 'content-type': type } },
+                        'could not format Error for content-type: "' +
+                            type +
+                            '"'
+                    )
+                );
+            }
         }
 
         return flush(self, body);


### PR DESCRIPTION
## Pre-Submission Checklist

- [x] Ran the linter and tests via `make prepush`
- [x] Included comprehensive and convincing tests for changes

## Issues

> Summarize the issues that discussed these changes
There is an edge case where `strictFormatters=true`, `content-type` is set without a supported formatter, and an error is passed. Right now the error will fall through to a raw serialization (`res.write`), which fails to serialize the error object.

# Changes

> What does this PR do?

Ensures the original error is preserved with an `InternalServerError`, instead of falling through to `res.write`.