### PR TITLE
docs(index): Remove restify.errors from examples

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -581,9 +581,11 @@ which will catch errors of all types.
 An example of sending a 404:
 
 ```js
+var errs = require('restify-errors');
+
 server.get('/hello/:foo', function(req, res, next) {
   // resource not found error
-  var err = new restify.errors.NotFoundError('oh noes!');
+  var err = new errs.NotFoundError('oh noes!');
   return next(err);
 });
 
@@ -600,9 +602,11 @@ server.on('NotFound', function (req, res, err, cb) {
 For customizing the error being sent back to the client:
 
 ```js
+var errs = require('restify-errors');
+
 server.get('/hello/:name', function(req, res, next) {
   // some internal unrecoverable error
-  var err = new restify.errors.InternalServerError('oh noes!');
+  var err = new errs.InternalServerError('oh noes!');
   return next(err);
 });
 


### PR DESCRIPTION
The restify.errors object was removed long ago but still used here.
This seems to cause some confusion to users that copy paste the code to try it.

<!--
Thank you for taking the time to open an PR for restify! If this is your first
time here, welcome to our community! We are a group of developers who work on
restify in our free-time. Some of us do it as a hobby, others are using restify
at work. When asking for help here, keep in mind most of us are volunteers
contributing our daily work back to the community at no cost (and often for no
reward). Please be respectful!

Below you will find a checklist to help you create the best PR possible. While
the checklist items aren't all _strictly_ required, they dramatically increase
the probability of your PR getting a response and getting merged. Often times,
the least time consuming part of maintaining and open source project is writing
code, its the process and discussions that happen around the code base that
consume a majority of the maintainers' time. By spending a few moments to
adhere to this template, you are not only improve the quality of your PR, you
are also helping save the maintainers a considerable amount of time when trying
to understand and review your changes.

And remember, positive vibes are met with positive vibes. Kindness helps Free
Software go round, pay it forward!
-->

## Pre-Submission Checklist

- [X] Opened an issue discussing these changes before opening the PR
- [X] Ran the linter and tests via `make prepush`
- [ ] Included comprehensive and convincing tests for changes

## Issues

Closes:

* Issue #1830 (partially)
* Issue #1806 

> Summarize the issues that discussed these changes

# Changes

> What does this PR do?
Remove `restify.errors` from a couple of examples.