### PR TITLE
chore: use release-please-action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,14 @@
+on:
+  push:
+    branches:
+      - master
+name: release-please
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: GoogleCloudPlatform/release-please-action@v1.3.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          release-type: node
+          package-name: restify


### PR DESCRIPTION
Maintainance: use GitHub actions instead of relying on manually using `unleash`.

It uses GCP's release-please-action to generate an automated release PR with CHANGELOG and automated version bumping.

