### PR TITLE
feat: remove re-routing from handler

### DIFF
--- a/lib/chain.js
+++ b/lib/chain.js
@@ -169,10 +169,13 @@ function call(handler, err, req, res, _next) {
     function resolve(value) {
         if (value && req.log) {
             // logs resolved value
-            req.log.debug({ value }, 'Async handler resolved with a value');
+            req.log.warn(
+                { value },
+                'Discarded returned value from async handler'
+            );
         }
 
-        return next(value);
+        return next();
     }
 
     function reject(error) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -1242,27 +1242,6 @@ Server.prototype._onHandlerError = function _onHandlerError(
 ) {
     var self = this;
 
-    // Call route by name
-    if (!isUncaught && _.isString(err)) {
-        var routeName = err;
-        var routeHandler = self.router.lookupByName(routeName, req, res);
-
-        // Cannot find route by name, called when next('route-name') doesn't
-        // find any route, it's a 5xx error as it's a programatic error
-        if (!routeHandler) {
-            var routeByNameErr = new customErrorTypes.RouteMissingError(
-                "Route by name doesn't exist"
-            );
-            routeByNameErr.code = 'ENOEXIST';
-            self._afterRoute(routeByNameErr, req, res);
-            return;
-        }
-        routeHandler(req, res, function afterRouter(routeErr) {
-            self._afterRoute(routeErr, req, res);
-        });
-        return;
-    }
-
     // Handlers don't continue when error happen
     res._handlersFinished = true;
 


### PR DESCRIPTION
**BREAKING CHANGE**: deprecates and removes re-routing when passing a `string` parameter to `next()`

## Pre-Submission Checklist

- [x] Opened an issue discussing these changes before opening the PR
- [x] Ran the linter and tests via `make prepush`
- [x] Included comprehensive and convincing tests for changes

## Issues

* Issue #1845

# Changes

Assumes the standard node.js callback API: `cb(err, value)` and treats `next()` as a callback. This way:

1. deprecates and removes re-routing;
2. `next('foo')` will be considered an error;
3. the returned value from an async function is ignored (as it would for `next(null, 'foo')`);

