### PR TITLE
fix jsdoc for response.sendRaw

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -327,7 +327,7 @@ function patch(Response) {
      * @instance
      * @function sendRaw
      * @param    {Number} [code] - http status code
-     * @param    {Object | Buffer | Error} [body] - the content to send
+     * @param    {string | Buffer} [body] - the content to send
      * @param    {Object} [headers] - any add'l headers to set
      * @returns  {Object} the response object
      */


### PR DESCRIPTION
The jsdoc now matches the required/supported types, as checked by the assertion in the function body.