### PR TITLE
fix appendRequestPath = false scenarios

### DIFF
--- a/lib/plugins/static.js
+++ b/lib/plugins/static.js
@@ -87,6 +87,7 @@ function serveStatic(options) {
     assert.optionalObject(opts.match, 'options.match');
     assert.optionalString(opts.charSet, 'options.charSet');
     assert.optionalString(opts.file, 'options.file');
+    assert.optionalString(opts.file, 'options.default');
     assert.bool(opts.appendRequestPath, 'options.appendRequestPath');
 
     var p = path.normalize(opts.directory).replace(/\\/g, '/');
@@ -170,19 +171,19 @@ function serveStatic(options) {
         } else if (opts.appendRequestPath) {
             file = path.join(opts.directory, decodeURIComponent(req.path()));
         } else {
-            var dirBasename = path.basename(opts.directory);
-            var reqpathBasename = path.basename(req.path());
-
-            if (
-                path.extname(req.path()) === '' &&
-                dirBasename === reqpathBasename
-            ) {
+            if (path.extname(req.path()) === '') {
                 file = opts.directory;
             } else {
-                file = path.join(
-                    opts.directory,
-                    decodeURIComponent(path.basename(req.path()))
-                );
+                var fileName = decodeURIComponent(path.basename(req.path()));
+                // test for requested file, if it doesn't exist we send the directory as path since appendRequestPath = false
+                if (!fs.existsSync(path.join(opts.directory, fileName))) {
+                    file = opts.directory;
+                } else {
+                    file = path.join(
+                        opts.directory,
+                        decodeURIComponent(path.basename(req.path()))
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
## Pre-Submission Checklist

- [x] Opened an issue discussing these changes before opening the PR
- [x] Ran the linter and tests via `make prepush`
- [x] Included comprehensive and convincing tests for changes

## Issues

Closes: 

* Issue # https://github.com/restify/node-restify/issues/1604

Restify.plugins.serverStatic option "appendRequestPath" is not working properly.
According to documentation, when appendRequestPath = false, the file we are requesting should be served directly from `directory`, this wasn't the case.

# Changes

With this PR when the user is setting appendRequestPath = false, the server will serve the requested resource specified in the endpoint (or the default static resource) which is located directly on `directory`.
Now the behavior adequates with what's described on http://restify.com/docs/plugins-api/#servestatic

Also we are modifying the function `testNoAppendPath` used by the tests which was passing as false positive so it catches this errors. And we are adding more tests to increase the coverage of Restify.plugins.serverStatic function.