### PR TITLE
fix: use more reliable close event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
           - 10.x
           - 12.x
           - 14.x
+          - 16.x
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v2

--- a/lib/plugins/bodyReader.js
+++ b/lib/plugins/bodyReader.js
@@ -186,7 +186,7 @@ function bodyReader(options) {
         // add 'close and 'aborted' event handlers so that requests (and their
         // corresponding memory) don't leak if client stops sending data half
         // way through a POST request
-        req.once('close', next);
+        req.socket.once('close', next);
         req.once('aborted', next);
         req.resume();
     }

--- a/test/plugins/static.test.js
+++ b/test/plugins/static.test.js
@@ -350,11 +350,14 @@ describe('static resource plugin', function() {
                     directory: TMP_PATH
                 });
 
+                var socket = new net.Socket();
                 SERVER.get('/index.html', function(req, res, next) {
                     // closed before serve
-                    serve(req, res, function(nextRoute) {
-                        assert.strictEqual(nextRoute, false);
-                        done();
+                    socket.on('end', () => {
+                        serve(req, res, function(nextRoute) {
+                            assert.strictEqual(nextRoute, false);
+                            done();
+                        });
                     });
                 });
                 SERVER.on('after', function(req, res, route, afterErr) {
@@ -362,7 +365,6 @@ describe('static resource plugin', function() {
                     done();
                 });
 
-                var socket = new net.Socket();
                 socket.connect({ host: '127.0.0.1', port: PORT }, function() {
                     socket.write(RAW_REQUEST, 'utf-8', function(err2, data) {
                         assert.ifError(err2);


### PR DESCRIPTION
The close event from the request object is not guaranteed to fire on the
same order across major versions of Node.js, the more accurate way to
look if the connection was closed is to listen to the event on the
socket. Fixes tests on v16.

Ref: https://github.com/nodejs/node/issues/38924
