### PR TITLE
docs: fix handleUncaughtExceptions docs typos

### DIFF
--- a/docs/_api/server.md
+++ b/docs/_api/server.md
@@ -53,9 +53,7 @@ routes and handlers for incoming requests.
         `res.send()`.
     -   `options.handleUncaughtExceptions` **[Boolean][26]** When true restify
         will use a domain to catch and respond to any uncaught
-        exceptions that occur in it's handler stack.
-        [bunyan][27] instance.
-        response header, default is `restify`. Pass empty string to unset the header.
+        exceptions that occur in its handler stack.
         Comes with significant negative performance impact. (optional, default `false`)
     -   `options.spdy` **[Object][24]?** Any options accepted by
         [node-spdy][29].
@@ -118,10 +116,8 @@ Creates a new Server.
         `res.send()`.
     -   `options.handleUncaughtExceptions` **[Boolean][26]** When true restify
         will use a domain to catch and respond to any uncaught
-        exceptions that occur in it's handler stack.
+        exceptions that occur in its handler stack.
         Comes with significant negative performance impact.
-        [bunyan][27] instance.
-        response header, default is `restify`. Pass empty string to unset the header. (optional, default `false`)
     -   `options.spdy` **[Object][24]?** Any options accepted by
         [node-spdy][29].
     -   `options.http2` **[Object][24]?** Any options accepted by

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,9 +34,7 @@ var InternalError = errors.InternalError;
  * `res.send()`.
  * @param {Boolean} [options.handleUncaughtExceptions=false] - When true restify
  * will use a domain to catch and respond to any uncaught
- * exceptions that occur in it's handler stack.
- * [pino](https://github.com/pinojs/pino) instance.
- * response header, default is `restify`. Pass empty string to unset the header.
+ * exceptions that occur in its handler stack.
  * Comes with significant negative performance impact.
  * @param {Object} [options.spdy] - Any options accepted by
  * [node-spdy](https://github.com/indutny/node-spdy).

--- a/lib/server.js
+++ b/lib/server.js
@@ -59,10 +59,8 @@ var sprintf = util.format;
  * `res.send()`.
  * @param {Boolean} [options.handleUncaughtExceptions=false] - When true restify
  * will use a domain to catch and respond to any uncaught
- * exceptions that occur in it's handler stack.
+ * exceptions that occur in its handler stack.
  * Comes with significant negative performance impact.
- * [pino](https://github.com/pinojs/pino) instance.
- * response header, default is `restify`. Pass empty string to unset the header.
  * @param {Object} [options.spdy] - Any options accepted by
  * [node-spdy](https://github.com/indutny/node-spdy).
  * @param {Object} [options.http2] - Any options accepted by


### PR DESCRIPTION
There are a few lines in docs for `handleUncaughtExceptions` option,
both in markdown docs and in jsdoc, which seem irrelevant and
disconnected. This appears to be a mistake that has been copied to
several places.

