### PR TITLE
chore: bump version of http-signature to ^1.3.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "ewma": "^2.0.1",
     "find-my-way": "^2.0.1",
     "formidable": "^1.2.1",
-    "http-signature": "^1.2.0",
+    "http-signature": "^1.3.6",
     "lodash": "^4.17.11",
     "lru-cache": "^5.1.1",
     "mime": "^2.4.3",


### PR DESCRIPTION
## Pre-Submission Checklist

- [ x ] Opened an issue discussing these changes before opening the PR
- [ x ] Ran the linter and tests via `make prepush`
- [ n/a ] Included comprehensive and convincing tests for changes

## Issues

- Helps address vulnerability in serenity-js as part of [issue #1062](https://github.com/serenity-js/serenity-js/issues/1062#issuecomment-989428443)

> Summarize the issues that discussed these changes

# Changes

> What does this PR do?

- bumps version of http-signature to ^1.3.6
