### PR TITLE
Bump formidable to v2

### DIFF
--- a/docs/_api/plugins.md
+++ b/docs/_api/plugins.md
@@ -1366,7 +1366,7 @@ Returns **any** value stored in context
 
 [46]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
 
-[47]: https://github.com/felixge/node-formidable
+[47]: https://github.com/node-formidable/formidable
 
 [48]: https://github.com/trentm/node-bunyan
 

--- a/lib/plugins/bodyParser.js
+++ b/lib/plugins/bodyParser.js
@@ -47,7 +47,7 @@ var UnsupportedMediaTypeError = errors.UnsupportedMediaTypeError;
  * parsed parameters from HTTP body.
  * @param {Boolean} [options.mapFiles] - if `req.params` should be filled with
  * the contents of files sent through a multipart request.
- * [formidable](https://github.com/felixge/node-formidable) is used internally
+ * [formidable](https://github.com/node-formidable/formidable) is used internally
  * for parsing, and a file is denoted as a multipart part with the `filename`
  * option set in its `Content-Disposition`. This will only be performed if
  * `mapParams` is true.

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "escape-regexp-component": "^1.0.2",
     "ewma": "^2.0.1",
     "find-my-way": "^2.0.1",
-    "formidable": "^1.2.1",
+    "formidable": "^2.0.1",
     "http-signature": "^1.2.0",
     "lodash": "^4.17.11",
     "lru-cache": "^5.1.1",


### PR DESCRIPTION
According to the [version notes](https://github.com/node-formidable/formidable/blob/master/VERSION_NOTES.md), it should be compatible with v1.
