### PR TITLE
Update uuid to 8.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "semver": "^6.1.1",
     "send": "^0.17.1",
     "spdy": "^4.0.0",
-    "uuid": "^3.3.2",
+    "uuid": "^8.3.2",
     "vasync": "^2.2.0"
   },
   "optionalDependencies": {


### PR DESCRIPTION
[Breaking changes](https://github.com/uuidjs/uuid/blob/main/CHANGELOG.md) include changes in exports, which don't seem to affect restify as it uses it today.

This PR resolves the following install warning:
> npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.