### PR TITLE
fix: use close event on response instead of socket

### DIFF
--- a/lib/plugins/bodyReader.js
+++ b/lib/plugins/bodyReader.js
@@ -186,7 +186,7 @@ function bodyReader(options) {
         // add 'close and 'aborted' event handlers so that requests (and their
         // corresponding memory) don't leak if client stops sending data half
         // way through a POST request
-        req.socket.once('close', next);
+        res.once('close', next);
         req.once('aborted', next);
         req.resume();
     }


### PR DESCRIPTION
In #1880, we switched from using the close event on `req` to close on
`req.socket`. This addressed the intended issue but can trigger frequent
warnings when keep-alive is used due to a listener being added for each
request on the same socket.

By using the close event on `res` instead, we address both the issue of
event ordering in Node.js >= 16 that the original change was targeting
and the event emitter warning leak.

Fixes #1883.