### PR TITLE
fix: don't create empty clientError listener for http.Server

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -142,7 +142,6 @@ function Server(options) {
     this.acceptable = fmt.acceptable;
     this.formatters = fmt.formatters;
     this.proxyEvents = [
-        'clientError',
         'close',
         'connection',
         'error',

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -2514,13 +2514,13 @@ test('should have proxy event handlers as instance', function(t) {
     var server = restify.createServer({
         handleUpgrades: false
     });
-    t.equal(server.proxyEvents.length, 7);
+    t.equal(server.proxyEvents.length, 6);
 
     server = restify.createServer({
         handleUpgrades: true
     });
 
-    t.equal(server.proxyEvents.length, 6);
+    t.equal(server.proxyEvents.length, 5);
     server.close(function() {
         t.end();
     });


### PR DESCRIPTION
## Pre-Submission Checklist

- [x] Opened an issue discussing these changes before opening the PR #1894
- [x] Ran the linter and tests via `make prepush`
- [ ] Included comprehensive and convincing tests for changes

## Issues

Closes:

* Issue #1894

# Changes

> What does this PR do?

- NOT create empty `clientError` listener for `http.Server`.
