### PR TITLE
fix: support node v18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
           - 12.x
           - 14.x
           - 16.x
+          - 18.x
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v2

--- a/lib/request.js
+++ b/lib/request.js
@@ -837,6 +837,16 @@ function patch(Request) {
     };
 
     /**
+     * Node v18 introduced a `closed` getter to Readable stream which breaks the API
+     * @see https://github.com/restify/node-restify/issues/1888
+     */
+    Object.defineProperty(Request.prototype, 'closed', {
+        get: function getter(x) {
+            return closed;
+        }
+    });
+
+    /**
      * Returns true when connection state is "close"
      *
      * @private
@@ -845,10 +855,14 @@ function patch(Request) {
      * @function closed
      * @returns {Boolean} is closed
      */
-    Request.prototype.closed = function closed() {
+    function closed() {
         var self = this;
-        return self.connectionState() === 'close';
-    };
+        if (this._readableState && 'close' in this._readableState) {
+            return this._readableState.closed;
+        } else {
+            return self.connectionState() === 'close';
+        }
+    }
 
     /**
      * Returns the route object to which the current request was matched to.

--- a/lib/server.js
+++ b/lib/server.js
@@ -257,7 +257,7 @@ function Server(options) {
 
         if (addr) {
             str +=
-                addr.family === 'IPv6'
+                addr.family === 'IPv6' || addr.family === 6
                     ? '[' + addr.address + ']'
                     : addr.address;
             str += ':';


### PR DESCRIPTION
* fix Request.prototype.closed() clash with new Reader.closed (fixes GH-1888)
* fix IPv6 url by supporting new server.address().family format
* add node 18 to GH Actions

## What?

Backward compatible change to support Node v18.

## Why?

Node v18 breaking changes:

- Added a `Reader.closed` getter that clashes with the `Request.prototype.closed()` patch.
- Changed the data type of `server.address().family` from `string` (`IPv6`) to a `number` (`6`)

## Drawbacks

I don't particularly like this change because it will be unexpected to people using Node18 that `closed` will be a method and not a getter. I would prefer to limit Restify 8.x to Node 17 and make a breaking change for 9.x by changing the method name to `isClosed()` or better yet, drop the method in favor of patching a getter for node v10~v17.

@restify/current-core please advise on the preferred action plan.