### PR TITLE
feat!: make `Response.status()` chainable

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -596,7 +596,7 @@ function patch(Response) {
         assert.number(code, 'code');
 
         this.statusCode = code;
-        return code;
+        return this;
     };
 
     /**

--- a/test/response.test.js
+++ b/test/response.test.js
@@ -760,3 +760,15 @@ test('GH-1791: should send NaN as null with application/json', function(t) {
         t.end();
     });
 });
+
+test('GH-1851: res.status should be chainable', function(t) {
+    SERVER.get('/418', function(req, res, next) {
+        res.status(418).json({ teapot: true });
+    });
+
+    CLIENT.get(join(LOCALHOST, '/418'), function(err, _, res, data) {
+        t.equal(res.statusCode, 418);
+        t.ok(data.teapot);
+        t.end();
+    });
+});


### PR DESCRIPTION
BREAKING CHANGE: improves compatibility with express
@see: https://github.com/expressjs/express/blob/master/lib/response.js#L67-L73

Closes:

* https://github.com/restify/node-restify/issues/1851
