### PR TITLE
Backport sendRaw into 4.x

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -272,14 +272,32 @@ Response.prototype.link = function link(l, rel) {
  * @param    {Object}                  headers  any add'l headers to set
  * @returns  {Object}                           self, the response object
  */
-Response.prototype.send = function send(code, body, headers) {
+ Response.prototype.send = function send(code, body, headers) {
+    return this.__send(code, body, headers, true);
+};
+
+/**
+ * sends the response object as-is without formatting. convenience method that
+ *     handles: writeHead(), write(), end()
+ * @public
+ * @function send
+ * @param    {Number} code                      http status code
+ * @param    {Object | Buffer | Error} body     the content to send
+ * @param    {Object}                  headers  any add'l headers to set
+ * @returns  {Object}                           self, the response object
+ */
+Response.prototype.sendRaw = function sendRaw(code, body, headers) {
+    return this.__send(code, body, headers, false);
+};
+
+Response.prototype.__send = function __send(code, body, headers, format) {
     var isHead = (this.req.method === 'HEAD');
     var log = this.log;
     var self = this;
 
     if (code === undefined) {
         this.statusCode = 200;
-    } else if (code.constructor.name === 'Number') {
+    } else if (typeof code === 'number') {
         this.statusCode = code;
 
         if (body instanceof Error) {
@@ -316,7 +334,7 @@ Response.prototype.send = function send(code, body, headers) {
         // know at this point what format to send the error as. Additionally,
         // the current 'after' event is emitted _before_ we send the response,
         // so there's no way to re-emit the error here. TODO: clean up 'after'
-        // even emitter so we pick up the error here.
+        // event emitter so we pick up the error here.
         if (err) {
             self._data = null;
             self.statusCode = 500;
@@ -341,10 +359,12 @@ Response.prototype.send = function send(code, body, headers) {
         }
     }
 
-    if (body !== undefined) {
+    if (body === undefined) {
+        _cb(null, null);
+    } else if (format) {
         this.format(body, _cb);
     } else {
-        _cb(null, null);
+        _cb(null, body);
     }
 
     return (this);

--- a/lib/response.js
+++ b/lib/response.js
@@ -272,7 +272,7 @@ Response.prototype.link = function link(l, rel) {
  * @param    {Object}                  headers  any add'l headers to set
  * @returns  {Object}                           self, the response object
  */
- Response.prototype.send = function send(code, body, headers) {
+Response.prototype.send = function send(code, body, headers) {
     return this.__send(code, body, headers, true);
 };
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "name": "restify",
   "homepage": "http://restifyjs.com",
   "description": "REST framework",
-  "version": "4.3.4",
+  "version": "4.3.5",
   "repository": {
     "type": "git",
     "url": "git://github.com/restify/node-restify.git"


### PR DESCRIPTION
## Pre-Submission Checklist

- [x] Opened an issue discussing these changes before opening the PR
- [x] Ran the linter and tests via `make prepush`
- [x] Included comprehensive and convincing tests for changes

## Issues

Closes:

* Issue #1918 

# Changes

- Adds `Response.sendRaw` into 4.x from 5.x, reasoning in the issue linked above.