### PR TITLE
chore: drop support for node 10

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,7 +12,7 @@ var config = {
         es6: true
     },
     parserOptions: {
-        ecmaVersion: 2018
+        ecmaVersion: 2019
     },
     rules: {}
 };

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "report-latency": "./bin/report-latency"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "dependencies": {
     "assert-plus": "^1.0.0",


### PR DESCRIPTION
BREAKING CHANGE: drops support for node 10 and updates linting rules

<!--
Thank you for taking the time to open an PR for restify! If this is your first
time here, welcome to our community! We are a group of developers who work on
restify in our free-time. Some of us do it as a hobby, others are using restify
at work. When asking for help here, keep in mind most of us are volunteers
contributing our daily work back to the community at no cost (and often for no
reward). Please be respectful!

Below you will find a checklist to help you create the best PR possible. While
the checklist items aren't all _strictly_ required, they dramatically increase
the probability of your PR getting a response and getting merged. Often times,
the least time consuming part of maintaining and open source project is writing
code, its the process and discussions that happen around the code base that
consume a majority of the maintainers' time. By spending a few moments to
adhere to this template, you are not only improve the quality of your PR, you
are also helping save the maintainers a considerable amount of time when trying
to understand and review your changes.

And remember, positive vibes are met with positive vibes. Kindness helps Free
Software go round, pay it forward!
-->

## Pre-Submission Checklist

- [X] Opened an issue discussing these changes before opening the PR
- [X] Ran the linter and tests via `make prepush`
- [ ] Included comprehensive and convincing tests for changes

## Issues

Closes: #1921

* Issue #1921, drop deprecated/unmaintained nodejs 10

> Summarize the issues that discussed these changes

# Changes

> What does this PR do?

Removes support for Node.js 10, which is not maintained by Node.js, and updates the language version to es2019.

# Notes

Description & changes modeled after removal of Node 8 support commit, https://github.com/restify/node-restify/commit/bd349884321d3e8af549f4d9da4456774e82ac8b .