### PR TITLE
chore: bump find-my-way to ^7.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "csv": "^5.1.1",
     "escape-regexp-component": "^1.0.2",
     "ewma": "^2.0.1",
-    "find-my-way": "^2.0.1",
+    "find-my-way": "^7.2.0",
     "formidable": "^1.2.1",
     "http-signature": "^1.3.6",
     "lodash": "^4.17.11",

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -342,7 +342,11 @@ test('toString()', function(t) {
 
     t.deepEqual(
         router.toString(),
-        '└── / (GET|POST)\n' + '    └── a (GET)\n' + '        └── /b (GET)\n'
+        // prettier-ignore
+        '└── / (GET)\n' +
+        '    / (POST)\n' +
+        '    └── a (GET)\n' +
+        '        └── /b (GET)\n'
     );
     t.end();
 });
@@ -363,11 +367,11 @@ test('toString() with ignoreTrailingSlash', function(t) {
 
     t.deepEqual(
         router.toString(),
-        '└── / (GET|POST)\n' +
-            '    └── a (GET)\n' +
-            '        └── / (GET)\n' +
-            '            └── b (GET)\n' +
-            '                └── / (GET)\n'
+        // prettier-ignore
+        '└── / (GET)\n' +
+        '    / (POST)\n' +
+        '    └── a (GET)\n' +
+        '        └── /b (GET)\n'
     );
     t.end();
 });

--- a/test/routerRegistryRadix.test.js
+++ b/test/routerRegistryRadix.test.js
@@ -95,7 +95,11 @@ test('toString()', function(t) {
 
     t.deepEqual(
         registry.toString(),
-        '└── / (GET|POST)\n' + '    └── a (GET)\n' + '        └── /b (GET)\n'
+        // prettier-ignore
+        '└── / (GET)\n' +
+        '    / (POST)\n' +
+        '    └── a (GET)\n' +
+        '        └── /b (GET)\n'
     );
     t.end();
 });
@@ -109,11 +113,11 @@ test('toString() with ignoreTrailingSlash', function(t) {
 
     t.deepEqual(
         registry.toString(),
-        '└── / (GET|POST)\n' +
-            '    └── a (GET)\n' +
-            '        └── / (GET)\n' +
-            '            └── b (GET)\n' +
-            '                └── / (GET)\n'
+        // prettier-ignore
+        '└── / (GET)\n' +
+        '    / (POST)\n' +
+        '    └── a (GET)\n' +
+        '        └── /b (GET)\n'
     );
     t.end();
 });


### PR DESCRIPTION
<!--
Thank you for taking the time to open an PR for restify! If this is your first
time here, welcome to our community! We are a group of developers who work on
restify in our free-time. Some of us do it as a hobby, others are using restify
at work. When asking for help here, keep in mind most of us are volunteers
contributing our daily work back to the community at no cost (and often for no
reward). Please be respectful!

Below you will find a checklist to help you create the best PR possible. While
the checklist items aren't all _strictly_ required, they dramatically increase
the probability of your PR getting a response and getting merged. Often times,
the least time consuming part of maintaining and open source project is writing
code, its the process and discussions that happen around the code base that
consume a majority of the maintainers' time. By spending a few moments to
adhere to this template, you are not only improve the quality of your PR, you
are also helping save the maintainers a considerable amount of time when trying
to understand and review your changes.

And remember, positive vibes are met with positive vibes. Kindness helps Free
Software go round, pay it forward!
-->

## Pre-Submission Checklist

- [X] Opened an issue discussing these changes before opening the PR
- [X] Ran the linter and tests via `make prepush`
- [X] Included comprehensive and convincing tests for changes

## Issues

Closes:

https://github.com/restify/node-restify/issues/1811, https://github.com/restify/node-restify/issues/1873 and https://github.com/restify/node-restify/issues/1874

* closes #1900
* closes #1868
* potentially closes issue #1811
* potentially closes issue #1873
* potentially closes issue #1874

> Summarize the issues that discussed these changes

# Changes

> What does this PR do?

* Upgrades `find-my-way` routing library to latest ^7.2.0.
* Updates the `toString()` tests on routes to match new output.
