### PR TITLE
feat: deprecate req.closed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,6 @@ jobs:
         os:
           - ubuntu-latest
         node-version:
-          - 10.x
-          - 12.x
           - 14.x
           - 16.x
     runs-on: ${{matrix.os}}

--- a/README.md
+++ b/README.md
@@ -85,15 +85,7 @@ $ npm install restify
 
 ## Supported Node Versions
 
-Restify aims to support the Node.js LTS (Active and Maintenance) versions along with Node.js current stable version.
-
-| Node Release  | Supported in Current Version | Notes    |
-| :--:     | :---: | :---:       | 
-| 11.x | **Yes**      | Current stable | 
-| 10.x | **Yes**      | Active LTS | 
-| 8.x  | **Yes** | Maintenance LTS  | 
-| 6.x  | **No** | Use restify v7.x, team will backport critical issues only   | 
-| 4.x  | **No** | Use restify v7.x, team will backport critical issues only  | 
+Restify currently works on Node.js v14.x and v16.x.
 
 ## License
 

--- a/lib/chain.js
+++ b/lib/chain.js
@@ -140,7 +140,7 @@ Chain.prototype.run = function run(req, res, done) {
         var handler = self._stack[index++];
 
         // all done or request closed
-        if (!handler || req.closed()) {
+        if (!handler || req.connectionState() === 'close') {
             process.nextTick(function nextTick() {
                 return done(err, req, res);
             });

--- a/lib/plugins/static.js
+++ b/lib/plugins/static.js
@@ -93,7 +93,10 @@ function serveStatic(options) {
     var re = new RegExp('^' + escapeRE(p) + '/?.*');
 
     function serveFileFromStats(file, err, stats, isGzip, req, res, next) {
-        if (typeof req.closed === 'function' && req.closed()) {
+        if (
+            typeof req.connectionState === 'function' &&
+            req.connectionState() === 'close'
+        ) {
             next(false);
             return;
         }

--- a/lib/request.js
+++ b/lib/request.js
@@ -2,6 +2,7 @@
 
 'use strict';
 
+const { emitWarning } = require('node:process');
 var url = require('url');
 var sprintf = require('util').format;
 
@@ -846,6 +847,11 @@ function patch(Request) {
      * @returns {Boolean} is closed
      */
     Request.prototype.closed = function closed() {
+        emitWarning(
+            'restify req.closed is deprecated, will be removed on Restify 10',
+            'RestifyDeprecationWarning',
+            'RestifyDEPReqClosed'
+        );
         var self = this;
         return self.connectionState() === 'close';
     };

--- a/test/chain.test.js
+++ b/test/chain.test.js
@@ -29,8 +29,8 @@ test('calls all the handlers', function(t) {
         {
             startHandlerTimer: function() {},
             endHandlerTimer: function() {},
-            closed: function() {
-                return false;
+            connectionState: function() {
+                return '';
             }
         },
         {},
@@ -58,8 +58,8 @@ test('abort with Error in next', function(t) {
         {
             startHandlerTimer: function() {},
             endHandlerTimer: function() {},
-            closed: function() {
-                return false;
+            connectionState: function() {
+                return '';
             }
         },
         {},
@@ -85,7 +85,7 @@ test('abort with false in next', function(t) {
         {
             startHandlerTimer: function() {},
             endHandlerTimer: function() {},
-            closed: function() {
+            connectionState: function() {
                 return false;
             }
         },
@@ -112,8 +112,8 @@ test('abort with closed request', function(t) {
         {
             startHandlerTimer: function() {},
             endHandlerTimer: function() {},
-            closed: function() {
-                return closed;
+            connectionState: function() {
+                return closed ? 'close' : '';
             }
         },
         {},
@@ -143,8 +143,8 @@ test('cals error middleware', function(t) {
         {
             startHandlerTimer: function() {},
             endHandlerTimer: function() {},
-            closed: function() {
-                return false;
+            connectionState: function() {
+                return '';
             }
         },
         {},
@@ -170,8 +170,8 @@ test('onceNext prevents double next calls', function(t) {
         {
             startHandlerTimer: function() {},
             endHandlerTimer: function() {},
-            closed: function() {
-                return false;
+            connectionState: function() {
+                return '';
             }
         },
         {},
@@ -208,8 +208,8 @@ test('throws error for double next calls in strictNext mode', function(t) {
             {
                 startHandlerTimer: function() {},
                 endHandlerTimer: function() {},
-                closed: function() {
-                    return false;
+                connectionState: function() {
+                    return '';
                 }
             },
             {},
@@ -234,8 +234,8 @@ test('calls req.startHandlerTimer', function(t) {
                 t.done();
             },
             endHandlerTimer: function() {},
-            closed: function() {
-                return false;
+            connectionState: function() {
+                return '';
             }
         },
         {},
@@ -257,8 +257,8 @@ test('calls req.endHandlerTimer', function(t) {
                 t.equal(handleName, 'foo');
                 t.done();
             },
-            closed: function() {
-                return false;
+            connectionState: function() {
+                return '';
             }
         },
         {},
@@ -299,8 +299,8 @@ test('waits async handlers', function(t) {
         {
             startHandlerTimer: function() {},
             endHandlerTimer: function() {},
-            closed: function() {
-                return false;
+            connectionState: function() {
+                return '';
             }
         },
         {},
@@ -329,8 +329,8 @@ test('abort with rejected promise', function(t) {
         {
             startHandlerTimer: function() {},
             endHandlerTimer: function() {},
-            closed: function() {
-                return false;
+            connectionState: function() {
+                return '';
             }
         },
         {},
@@ -359,8 +359,8 @@ test('abort with rejected promise without error', function(t) {
         {
             startHandlerTimer: function() {},
             endHandlerTimer: function() {},
-            closed: function() {
-                return false;
+            connectionState: function() {
+                return '';
             },
             path: function() {
                 return '/';
@@ -395,8 +395,8 @@ test('abort with throw inside async function', function(t) {
         {
             startHandlerTimer: function() {},
             endHandlerTimer: function() {},
-            closed: function() {
-                return false;
+            connectionState: function() {
+                return '';
             }
         },
         {},

--- a/test/chainComposer.test.js
+++ b/test/chainComposer.test.js
@@ -29,8 +29,8 @@ test('chainComposer creates a valid chain for a handler array ', function(t) {
         {
             startHandlerTimer: function() {},
             endHandlerTimer: function() {},
-            closed: function() {
-                return false;
+            connectionState: function() {
+                return '';
             }
         },
         {},
@@ -53,8 +53,8 @@ test('chainComposer creates a valid chain for a single handler', function(t) {
         {
             startHandlerTimer: function() {},
             endHandlerTimer: function() {},
-            closed: function() {
-                return false;
+            connectionState: function() {
+                return '';
             }
         },
         {},

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -275,3 +275,27 @@ test('should emit restifyDone event when request is fully served with error', fu
         clientDone = true;
     });
 });
+
+test('should emit warning if closed is called', function(t) {
+    let warningCalled = false;
+    SERVER.get('/ping/:name', function(req, res, next) {
+        function testWarning(warning) {
+            t.equal(warning.name, 'RestifyDeprecationWarning');
+            t.equal(warning.code, 'RestifyDEPReqClosed');
+            t.ok(warning.stack);
+            warningCalled = true;
+
+            res.send('ok');
+            return next();
+        }
+        process.once('warning', testWarning);
+        t.notOk(req.closed());
+    });
+
+    CLIENT.get('/ping/lagavulin', function(err, _, res) {
+        t.ifError(err);
+        t.equal(res.statusCode, 200);
+        t.ok(warningCalled);
+        t.end();
+    });
+});

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -16,8 +16,8 @@ var helper = require('./lib/helper.js');
 var test = helper.test;
 var mockReq = {
     params: {},
-    closed: function() {
-        return false;
+    connectionState: function() {
+        return '';
     },
     startHandlerTimer: function() {},
     endHandlerTimer: function() {}


### PR DESCRIPTION
Node.js added `closed` getter-only property to streams. This commit deprecates req.closed to avoid monkey-patching something that might be used in Node.js core or user-land libraries.
`req.connectionState() === 'close'` can be used to achieve the same result moving forward. req.closed will be removed on Restify 10 to open way to support Node.js v18.

<!--
Thank you for taking the time to open an PR for restify! If this is your first
time here, welcome to our community! We are a group of developers who work on
restify in our free-time. Some of us do it as a hobby, others are using restify
at work. When asking for help here, keep in mind most of us are volunteers
contributing our daily work back to the community at no cost (and often for no
reward). Please be respectful!

Below you will find a checklist to help you create the best PR possible. While
the checklist items aren't all _strictly_ required, they dramatically increase
the probability of your PR getting a response and getting merged. Often times,
the least time consuming part of maintaining and open source project is writing
code, its the process and discussions that happen around the code base that
consume a majority of the maintainers' time. By spending a few moments to
adhere to this template, you are not only improve the quality of your PR, you
are also helping save the maintainers a considerable amount of time when trying
to understand and review your changes.

And remember, positive vibes are met with positive vibes. Kindness helps Free
Software go round, pay it forward!
-->

## Pre-Submission Checklist

- [ ] Opened an issue discussing these changes before opening the PR
- [ ] Ran the linter and tests via `make prepush`
- [ ] Included comprehensive and convincing tests for changes

## Issues

Closes:

* Issue #
* Issue #
* Issue #

> Summarize the issues that discussed these changes

# Changes

> What does this PR do?
