### PR TITLE
fix: destroyed async/await handler

### DIFF
--- a/lib/chain.js
+++ b/lib/chain.js
@@ -140,7 +140,7 @@ Chain.prototype.run = function run(req, res, done) {
         var handler = self._stack[index++];
 
         // all done or request closed
-        if (!handler || req.connectionState() === 'close') {
+        if (!handler || req.connectionState() === 'close' || res.destroyed) {
             process.nextTick(function nextTick() {
                 return done(err, req, res);
             });


### PR DESCRIPTION
## Pre-Submission Checklist

- [x] Opened an issue discussing these changes before opening the PR
- [x] Ran the linter and tests via `make prepush`
- [x] Included comprehensive and convincing tests for changes

## Issues

Closes:

* Issue #1935  

# Changes

Fix unstopped chain-handler when response already destroyed.
