### PR TITLE
feat!: use req.log on audit plugin

### DIFF
--- a/lib/plugins/audit.js
+++ b/lib/plugins/audit.js
@@ -260,16 +260,6 @@ function auditLogger(opts) {
 
     var serializers = Object.assign({}, DEFAULT_SERIALIZERS, opts.serializers);
 
-    var log = opts.log.child(
-        {
-            audit: true,
-            component: opts.event
-        },
-        {
-            serializers: serializers
-        }
-    );
-
     function audit(req, res, route, err) {
         var latency = res.get('Response-Time');
 
@@ -295,7 +285,17 @@ function auditLogger(opts) {
             obj.context = opts.context(req, res, route, err);
         }
 
-        if (printLog) {
+        const origLog = (req && req.log) || opts.log;
+        if (printLog && origLog) {
+            const log = origLog.child(
+                {
+                    audit: true,
+                    component: opts.event
+                },
+                {
+                    serializers: serializers
+                }
+            );
             switch (opts.event) {
                 case 'after':
                     log.info(obj, 'handled: %d', res.statusCode);

--- a/lib/server.js
+++ b/lib/server.js
@@ -1294,7 +1294,13 @@ Server.prototype._setupRequest = function _setupRequest(req, res) {
 
     // Extend request
     req._dtraceId = dtrace.nextId();
-    req.log = res.log = self.log;
+    // if log is set on .first, don't override it
+    if (req.log === undefined) {
+        req.log = self.log;
+    }
+    if (res.log === undefined) {
+        res.log = req.log;
+    }
     req._date = new Date();
     req._timeStart = process.hrtime();
     req.serverName = self.name;

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -4,10 +4,10 @@
 /* eslint-disable func-names */
 
 var assert = require('assert-plus');
-var pino = require('pino');
 var childprocess = require('child_process');
 var http = require('http');
 
+var pino = require('pino');
 var errors = require('restify-errors');
 var restifyClients = require('restify-clients');
 var uuid = require('uuid');
@@ -32,6 +32,7 @@ var PORT = process.env.UNIT_TEST_PORT || 0;
 var CLIENT;
 var FAST_CLIENT;
 var SERVER;
+let LOG_BUFFER;
 
 var NODE_MAJOR_VERSION = process.versions.node.split('.')[0];
 
@@ -43,10 +44,11 @@ if (SKIP_IP_V6) {
 
 before(function(cb) {
     try {
+        LOG_BUFFER = new StreamRecorder();
         SERVER = restify.createServer({
             dtrace: helper.dtrace,
             handleUncaughtExceptions: true,
-            log: helper.getLog('server'),
+            log: helper.getLog('server', LOG_BUFFER, 'info'),
             version: ['2.0.0', '0.5.4', '1.4.3'],
             ignoreTrailingSlash: true
         });
@@ -1327,11 +1329,10 @@ test(
         ]);
 
         // set up audit logs
-        var buffer = new StreamRecorder();
         SERVER.on(
             'after',
             restify.plugins.auditLogger({
-                log: pino({ name: 'audit' }, buffer),
+                log: pino({ name: 'audit' }),
                 event: 'after'
             })
         );
@@ -1343,15 +1344,15 @@ test(
                 t.equal(err.name, 'RequestCloseError');
 
                 // check records
-                t.ok(buffer.records[0], 'no log records');
+                t.ok(LOG_BUFFER.records[0], 'no log records');
                 t.equal(
-                    buffer.records.length,
+                    LOG_BUFFER.records.length,
                     1,
                     'should only have 1 log record'
                 );
 
                 // check timers
-                var handlers = Object.keys(buffer.records[0].req.timers);
+                var handlers = Object.keys(LOG_BUFFER.records[0].req.timers);
                 t.equal(handlers.length, 2, 'should only have 2 req timers');
                 t.equal(
                     handlers[0],
@@ -1380,7 +1381,7 @@ test(
             // reset numCount
             numCount = 0;
             //reset stream-recorder
-            buffer.flushRecords();
+            LOG_BUFFER.flushRecords();
 
             FAST_CLIENT.get('/audit?v=2', function(err2, req2, res2, data2) {
                 t.ok(err2);


### PR DESCRIPTION
So it's consistent with other plugins, and to allow child loggers
attached to req to be used on audit.

<!--
Thank you for taking the time to open an PR for restify! If this is your first
time here, welcome to our community! We are a group of developers who work on
restify in our free-time. Some of us do it as a hobby, others are using restify
at work. When asking for help here, keep in mind most of us are volunteers
contributing our daily work back to the community at no cost (and often for no
reward). Please be respectful!

Below you will find a checklist to help you create the best PR possible. While
the checklist items aren't all _strictly_ required, they dramatically increase
the probability of your PR getting a response and getting merged. Often times,
the least time consuming part of maintaining and open source project is writing
code, its the process and discussions that happen around the code base that
consume a majority of the maintainers' time. By spending a few moments to
adhere to this template, you are not only improve the quality of your PR, you
are also helping save the maintainers a considerable amount of time when trying
to understand and review your changes.

And remember, positive vibes are met with positive vibes. Kindness helps Free
Software go round, pay it forward!
-->

## Pre-Submission Checklist

- [ ] Opened an issue discussing these changes before opening the PR
- [ ] Ran the linter and tests via `make prepush`
- [ ] Included comprehensive and convincing tests for changes

## Issues

Closes:

* Issue #
* Issue #
* Issue #

> Summarize the issues that discussed these changes

# Changes

> What does this PR do?
