### PR TITLE
stop handling `then` when `next` is called

### DIFF
--- a/lib/chain.js
+++ b/lib/chain.js
@@ -221,8 +221,12 @@ function call(handler, err, req, res, _next) {
     } else if (!hasError && arity < 4) {
         // request-handling middleware
         process.nextTick(function nextTick() {
-            const result = handler(req, res, next);
-            if (result && typeof result.then === 'function') {
+            let nextCalled = false;
+            const result = handler(req, res, (...params) => {
+                nextCalled = true;
+                next(...params);
+            });
+            if (!nextCalled && result && typeof result.then === 'function') {
                 result.then(resolve, reject);
             }
         });

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -2994,3 +2994,38 @@ test('req and res should use own logger by if set during .first', function(t) {
         t.end();
     });
 });
+
+test('should not call then when next called', function(t) {
+    let counter = 0;
+    SERVER.use(function first(req, res, next) {
+        next();
+        return Promise.resolve();
+    });
+
+    SERVER.get('/ping', function echoId(req, res, next) {
+        counter++;
+        t.equal(counter, 1);
+        next();
+    });
+
+    CLIENT.get('/ping', function() {
+        t.end();
+    });
+});
+
+test('should stop after next(false)', function(t) {
+    let counter = 0;
+    SERVER.use(function first(req, res, next) {
+        next(false);
+        return Promise.resolve();
+    });
+
+    SERVER.get('/ping', function echoId(req, res, next) {
+        counter++;
+        next();
+    });
+    CLIENT.get('/ping', function() {
+        t.equal(counter, 0);
+        t.end();
+    });
+});


### PR DESCRIPTION
<!--
Thank you for taking the time to open an PR for restify! If this is your first
time here, welcome to our community! We are a group of developers who work on
restify in our free-time. Some of us do it as a hobby, others are using restify
at work. When asking for help here, keep in mind most of us are volunteers
contributing our daily work back to the community at no cost (and often for no
reward). Please be respectful!

Below you will find a checklist to help you create the best PR possible. While
the checklist items aren't all _strictly_ required, they dramatically increase
the probability of your PR getting a response and getting merged. Often times,
the least time consuming part of maintaining and open source project is writing
code, its the process and discussions that happen around the code base that
consume a majority of the maintainers' time. By spending a few moments to
adhere to this template, you are not only improve the quality of your PR, you
are also helping save the maintainers a considerable amount of time when trying
to understand and review your changes.

And remember, positive vibes are met with positive vibes. Kindness helps Free
Software go round, pay it forward!
-->

## Pre-Submission Checklist

- [v] Opened an issue discussing these changes before opening the PR
- [v] Ran the linter and tests via `make prepush`
- [v] Included comprehensive and convincing tests for changes

## Issues

Closes:

* Issue #1935

> Summarize the issues that discussed these changes

currently, the async function handling does not meet user's expectation.
a function returning Promise can still have the next param and:

- it could get called twice.
- if user send out an error through the next, the promise could still resolve.

# Changes

add a local variable to check whether next is called and wrap the next function.

> What does this PR do?

- in `chain.js` prevent further Promise handling if next is called.
- add tests