### PR TITLE
avoid loading spdy if not used and prevent deprecation warning

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -27,6 +27,7 @@ var patchResponse = require('./response');
 
 var domain;
 var http2;
+var spdy;
 
 patchResponse(http.ServerResponse);
 patchRequest(http.IncomingMessage);
@@ -149,7 +150,7 @@ function Server(options) {
     ];
 
     if (options.spdy) {
-        var spdy = require('spdy');
+        spdy = require('spdy');
         this.spdy = true;
         this.server = spdy.createServer(options.spdy);
     } else if (options.http2) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -11,7 +11,6 @@ var _ = require('lodash');
 var assert = require('assert-plus');
 var errors = require('restify-errors');
 var mime = require('mime');
-var spdy = require('spdy');
 var vasync = require('vasync');
 
 var Chain = require('./chain');
@@ -150,6 +149,7 @@ function Server(options) {
     ];
 
     if (options.spdy) {
+        var spdy = require('spdy');
         this.spdy = true;
         this.server = spdy.createServer(options.spdy);
     } else if (options.http2) {


### PR DESCRIPTION
First of all, thanks for the great Restify!! 
I've been using it for years in several projects (including [this](https://github.com/nttgin/BGPalerter)).

## Pre-Submission Checklist

- [x ] Opened an issue discussing these changes before opening the PR
- [x ] Ran the linter and tests via `make prepush`
- [x ] Included comprehensive and convincing tests for changes (same coverage)

## Issues

Closes:

* Issue #1876

Support for Node14 will end in 2 months, we need to move to Node 16+.
However, restify imports spdy, which raises 
```
DeprecationWarning: Access to process.binding('http_parser') is deprecated.
```
The good news is that most of the time spdy is not used since you need to pass `options.spdy`.

# Changes

We can simply avoid deprecation warnings (and also avoid to run unused code) by importing spdy on request (as currently done for http2). This could be both a permanent or temporary solution waiting for spdy to be patched.