### PR TITLE
feat: allow custom alternatives to domains

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -36,6 +36,27 @@ patchRequest(http.IncomingMessage);
 
 var sprintf = util.format;
 
+// Run in domain to catch async errors
+// It has significant negative performance impact
+// Warning: this feature depends on the deprecated domains module
+function handleWithDomain(req, res, onError, next) {
+    // In Node v12.x requiring the domain module has a negative performance
+    // impact. As using domains in restify is optional and only required
+    // with the `handleUncaughtExceptions` options, we apply a singleton
+    // pattern to avoid any performance regression in the default scenario.
+    if (!domain) {
+        domain = require('domain');
+    }
+
+    var handlerDomain = domain.create();
+    handlerDomain.add(req);
+    handlerDomain.add(res);
+    handlerDomain.on('error', onError);
+    handlerDomain.run(function run() {
+        next(req, res);
+    });
+}
+
 ///--- API
 
 /**
@@ -57,10 +78,17 @@ var sprintf = util.format;
  * pass in a PEM-encoded certificate and key.
  * @param {Object} [options.formatters] - Custom response formatters for
  * `res.send()`.
- * @param {Boolean} [options.handleUncaughtExceptions=false] - When true restify
- * will use a domain to catch and respond to any uncaught
- * exceptions that occur in its handler stack.
- * Comes with significant negative performance impact.
+ * @param {Boolean|Function} [options.handleUncaughtExceptions=false] - When
+ * true restify will use a domain to catch and respond to any uncaught
+ * exceptions that occur in its handler stack. Comes with significant negative
+ * performance impact.
+ * Can also receive a function with signature (req, res, onError, next),
+ * allowing for domains alternatives. onError should be called by the custom
+ * error handler, and next must be called at the end of this function. THIS
+ * FUNCTION IS NOT INTENDED TO BE USED TO HANDLE ERRORS DIRECTLY, IT IS ONLY
+ * INTENDED AS AN ALTERNATIVE TO `domains`.
+ *   onError signature: (err, req, res)
+ *   next signature: (res, res)
  * @param {Object} [options.spdy] - Any options accepted by
  * [node-spdy](https://github.com/indutny/node-spdy).
  * @param {Object} [options.http2] - Any options accepted by
@@ -99,10 +127,6 @@ function Server(options) {
     assert.object(options.log, 'options.log');
     assert.object(options.router, 'options.router');
     assert.string(options.name, 'options.name');
-    assert.optionalBool(
-        options.handleUncaughtExceptions,
-        'options.handleUncaughtExceptions'
-    );
     assert.optionalBool(options.dtrace, 'options.dtrace');
     assert.optionalBool(options.socketio, 'options.socketio');
     assert.optionalBool(options.onceNext, 'options.onceNext');
@@ -126,7 +150,20 @@ function Server(options) {
     });
     this.log = options.log;
     this.name = options.name;
-    this.handleUncaughtExceptions = options.handleUncaughtExceptions || false;
+    this.handleUncaughtExceptions = false;
+    const { handleUncaughtExceptions } = options;
+    if (options.handleUncaughtExceptions) {
+        const handleType = typeof handleUncaughtExceptions;
+        if (handleType === 'boolean') {
+            this.handleUncaughtExceptions = handleWithDomain;
+        } else if (handleType === 'function') {
+            this.handleUncaughtExceptions = handleUncaughtExceptions;
+        } else {
+            // prettier-ignore
+            // eslint-disable-next-line max-len
+            assert.fail(`typeof opts.handleUncaughtException (${handleType}) should be boolean OR function`);
+        }
+    }
     this.router = options.router;
     this.secure = false;
     this.socketio = options.socketio || false;
@@ -992,27 +1029,13 @@ Server.prototype._onRequest = function _onRequest(req, res) {
     // Decorate req and res objects
     self._setupRequest(req, res);
 
-    // Run in domain to catch async errors
-    // It has significant negative performance impact
-    // Warning: this feature depends on the deprecated domains module
     if (self.handleUncaughtExceptions) {
-        // In Node v12.x requiring the domain module has a negative performance
-        // impact. As using domains in restify is optional and only required
-        // with the `handleUncaughtExceptions` options, we apply a singleton
-        // pattern to avoid any performance regression in the default scenario.
-        if (!domain) {
-            domain = require('domain');
-        }
-
-        var handlerDomain = domain.create();
-        handlerDomain.add(req);
-        handlerDomain.add(res);
-        handlerDomain.on('error', function onError(err) {
-            self._onHandlerError(err, req, res, true);
-        });
-        handlerDomain.run(function run() {
-            self._runPre(req, res);
-        });
+        self.handleUncaughtExceptions(
+            req,
+            res,
+            err => this._onHandlerError(err, req, res, true),
+            self._runPre.bind(self)
+        );
     } else {
         self._runPre(req, res);
     }

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -3,6 +3,7 @@
 'use strict';
 /* eslint-disable func-names */
 
+const { AsyncLocalStorage } = require('async_hooks');
 var assert = require('assert-plus');
 var childprocess = require('child_process');
 var http = require('http');
@@ -2992,5 +2993,67 @@ test('req and res should use own logger by if set during .first', function(t) {
 
     CLIENT.get('/ping', function() {
         t.end();
+    });
+});
+
+test('should throw if handleUncaughtExceptions is invalid', function(t) {
+    t.throws(() => {
+        restify.createServer({
+            handleUncaughtExceptions: 'this is invalid'
+        });
+    });
+    t.end();
+});
+
+test('should use custom function for error handling', function(t) {
+    const asl = new AsyncLocalStorage();
+    let callOnError;
+    var server = restify.createServer({
+        dtrace: helper.dtrace,
+        strictNext: true,
+        handleUncaughtExceptions: (req, res, onError, next) => {
+            callOnError = err => {
+                const newErr = new Error('new error');
+                newErr.orig = err;
+                onError(newErr);
+            };
+            asl.run({}, next, req, res);
+        },
+        log: helper.getLog('server')
+    });
+    var client;
+    var port;
+
+    server.listen(PORT + 1, '127.0.0.1', function() {
+        port = server.address().port;
+        client = restifyClients.createJsonClient({
+            url: 'http://127.0.0.1:' + port,
+            dtrace: helper.dtrace,
+            retry: false
+        });
+
+        const expectedErr = new Error('foo');
+        server.get('/throw', function(req, res, next) {
+            // We don't really need to throw to test, and catching the throw is
+            // hard because nodeunit messes with uncaughtException event
+            callOnError(expectedErr);
+        });
+
+        server.on('uncaughtException', function(req, res, route, err) {
+            t.ok(err);
+            t.strictEqual(err.orig, expectedErr);
+            t.equal(err.message, 'new error');
+            res.send(err);
+        });
+
+        client.get('/throw', function(err, _, res) {
+            t.ok(err);
+            t.equal(res.statusCode, 500);
+
+            client.close();
+            server.close(function() {
+                t.end();
+            });
+        });
     });
 });


### PR DESCRIPTION
domains is deprecated, but there isn't a standard alternative in the ecosystem as of right now. Instead of implementing a bespoke alternative to it, let users create their own alternatives (or use libraries) by providing a generic way to replace domains in the error handling workflow. Note: unless you know what you're doing, you should NOT be using this feature.
