### PR TITLE
feat: allow alternate name for request id in logs

### DIFF
--- a/lib/plugins/audit.js
+++ b/lib/plugins/audit.js
@@ -52,6 +52,8 @@ function getResponseHeaders(res) {
  * via the logger.
  * @param {Object} [opts.serializers] - Override the default logger serializers
  * for err, req and res
+ * @param {String} [opts.requestIdFieldName] - The name of the request id property attached
+ * to log lines. Defaults to "req_id".
  * @returns {Function} Handler
  * @fires audit when an audit log has been generated
  * @example
@@ -195,6 +197,7 @@ function auditLogger(opts) {
 
     var server = opts.server;
     var printLog = opts.printLog;
+    const requestIdFieldName = opts.requestIdFieldName || 'req_id';
 
     if (typeof printLog === 'undefined') {
         printLog = true;
@@ -270,7 +273,7 @@ function auditLogger(opts) {
         var obj = {
             remoteAddress: req.connection.remoteAddress,
             remotePort: req.connection.remotePort,
-            req_id: req.getId(),
+            [requestIdFieldName]: req.getId(),
             req: req,
             res: res,
             err: err,

--- a/lib/plugins/requestLogger.js
+++ b/lib/plugins/requestLogger.js
@@ -25,6 +25,11 @@ var shallowCopy = require('./utils/shallowCopy');
  * @param    {Object}   [options] - an options object
  * @param    {Array}    [options.headers] - A list of headers to transfer from
  *                                  the request to top level props on the log.
+ * @param    {Object}   [options.properties] - A set of key-values to pass to the child logger
+ * @param    {Object}   [options.serializers] - Override serializers to use in the child logger
+ * @param    {Object}   [options.log] - A logger to use as a fallback if req.log is missing
+ * @param    {String}   [options.requestIdFieldName] - The name of the request id property attached
+ *                                   to log lines. Defaults to "req_id".
  * @returns  {Function} Handler
  * @example
  * server.use(restify.plugins.requestLogger({
@@ -51,6 +56,7 @@ function requestLogger(options) {
     }
 
     var headersToCopy = opts.headers || [];
+    const requestIdFieldName = opts.requestIdFieldName || 'req_id';
 
     return function logger(req, res, next) {
         if (!req.log && !opts.log) {
@@ -60,7 +66,8 @@ function requestLogger(options) {
 
         var log = req.log || opts.log;
 
-        props.req_id = req.getId();
+        props[requestIdFieldName] = req.getId();
+
         headersToCopy.forEach(function forEach(k) {
             if (req.headers[k]) {
                 props[k] = req.headers[k];
@@ -72,8 +79,8 @@ function requestLogger(options) {
         }
         req.log = log.child(props, childOptions);
 
-        if (props.req_id) {
-            delete props.req_id;
+        if (props[requestIdFieldName]) {
+            delete props[requestIdFieldName];
         }
 
         next();

--- a/test/plugins/audit.test.js
+++ b/test/plugins/audit.test.js
@@ -625,4 +625,38 @@ describe('audit logger', function() {
             function(err, req, res) {}
         );
     });
+
+    it('should set request id using supplied field name', function(done) {
+        SERVER.once(
+            'after',
+            restify.plugins.auditLogger({
+                log: pino({ name: 'audit' }),
+                server: SERVER,
+                event: 'after',
+                requestIdFieldName: 'traceId'
+            })
+        );
+
+        SERVER.once('audit', function(data) {
+            assert.ok(data);
+            assert.ok(data.traceId);
+            assert.notOk(data.req_id);
+            done();
+        });
+
+        SERVER.get('/audit', function(req, res, next) {
+            setTimeout(function() {
+                res.send();
+                next();
+            }, 150);
+        });
+
+        CLIENT.get(
+            {
+                path: '/audit',
+                requestTimeout: 50
+            },
+            function(err, req, res) {}
+        );
+    });
 });

--- a/test/plugins/plugins.test.js
+++ b/test/plugins/plugins.test.js
@@ -95,6 +95,39 @@ describe('all other plugins', function() {
                 done();
             });
         });
+
+        it('adds the request id to logs', function(done) {
+            SERVER.use(restify.plugins.requestLogger());
+            SERVER.get('/requestLogger/test', function(req, res, next) {
+                var childings = req.log[pino.symbols.chindingsSym];
+                assert.match(childings, /"req_id":"[0-9A-F-]+"/i);
+                res.send();
+                next();
+            });
+            CLIENT.get('/requestLogger/test', function(err, _, res) {
+                assert.equal(res.statusCode, 200);
+                assert.ifError(err);
+                done();
+            });
+        });
+
+        it('adds the request id with a custom field name', function(done) {
+            SERVER.use(
+                restify.plugins.requestLogger({ requestIdFieldName: 'traceId' })
+            );
+            SERVER.get('/requestLogger/test', function(req, res, next) {
+                var childings = req.log[pino.symbols.chindingsSym];
+                assert.match(childings, /"traceId":"[0-9A-F-]+"/i);
+                assert.notMatch(childings, /"req_id"/);
+                res.send();
+                next();
+            });
+            CLIENT.get('/requestLogger/test', function(err, _, res) {
+                assert.equal(res.statusCode, 200);
+                assert.ifError(err);
+                done();
+            });
+        });
     });
 
     describe('full response', function() {


### PR DESCRIPTION
Right now the child loggers add the request id attribute under the field name `req_id`. This change adds an option to override the field name.

This allows more customizable logs for easier integration with backend logging frameworks.
