### PR TITLE
[Fix issue #1604] Make Restify ServeStatic default observed as expected

### DIFF
--- a/lib/plugins/static.js
+++ b/lib/plugins/static.js
@@ -189,6 +189,10 @@ function serveStatic(options) {
             }
         }
 
+        if (opts.default && !fs.existsSync(file)){
+            file = path.join(opts.directory, decodeURIComponent(opts.default));
+        }
+
         if (req.method !== 'GET' && req.method !== 'HEAD') {
             next(new MethodNotAllowedError('%s', req.method));
             return;


### PR DESCRIPTION
This makes the behaviour match what is stated in the [Restify docs](
http://restify.com/docs/plugins-api/#servestatic)

If a default file is specified and the file we would otherwise serve does not exist, attempt to load the specified default file.

## Issues

Previously, the default value was just ignored, now this is correctly handled, if the file we attempt to access does not exist, it will now use the default, as specified in the documentation.

Closes:

* Issue #1604 

> Summarize the issues that discussed these changes

I opened an issue in 2018 about Restify serveStatic not ignoring the issue. It seems to still be an issue.

# Changes

> What does this PR do?
In the static function, before returning the file, the function should try to check if the file exists. If it does, return that path instead.