### PR TITLE
fix: handle trailing slashes on root route and avoid crashes due to `AssertionError`s thrown by odd requests

### DIFF
--- a/lib/plugins/pre/prePath.js
+++ b/lib/plugins/pre/prePath.js
@@ -44,7 +44,7 @@ function strip(path) {
  */
 function sanitizePath() {
     function _sanitizePath(req, res, next) {
-        req.url = strip(req.url);
+        req.url = strip(req.url) || '/';
         next();
     }
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -72,6 +72,11 @@ util.inherits(Router, EventEmitter);
 Router.prototype.lookup = function lookup(req, res) {
     var pathname = req.getUrl().pathname;
 
+    // Handle unexpected url parsing result
+    if (!pathname) {
+        return undefined;
+    }
+
     // Find route
     var registryRoute = this._registry.lookup(req.method, pathname);
 
@@ -323,11 +328,16 @@ Router.prototype.defaultRoute = function defaultRoute(req, res, next) {
     }
 
     // Check for 405 instead of 404
-    var allowedMethods = http.METHODS.filter(function some(method) {
-        return method !== req.method && self._registry.lookup(method, pathname);
-    });
+    var allowedMethods;
+    if (pathname) {
+        allowedMethods = http.METHODS.filter(function some(method) {
+            return (
+                method !== req.method && self._registry.lookup(method, pathname)
+            );
+        });
+    }
 
-    if (allowedMethods.length) {
+    if (allowedMethods && allowedMethods.length) {
         res.methods = allowedMethods;
         res.setHeader('Allow', allowedMethods.join(', '));
         var methodErr = new MethodNotAllowedError(
@@ -340,7 +350,10 @@ Router.prototype.defaultRoute = function defaultRoute(req, res, next) {
 
     // clean up the url in case of potential xss
     // https://github.com/restify/node-restify/issues/1018
-    var err = new ResourceNotFoundError('%s does not exist', pathname);
+    var err = new ResourceNotFoundError(
+        '%s does not exist',
+        pathname || 'Requested path'
+    );
     next(err, req, res);
 };
 

--- a/test/plugins/plugins.test.js
+++ b/test/plugins/plugins.test.js
@@ -290,28 +290,40 @@ describe('all other plugins', function() {
         // Ensure it santizies potential edge cases correctly
         var tests = {
             input: [
+                '/', // basic path
+                '///', // excess on basic path
                 '////foo////', //excess padding on both ends
                 'bar/foo/', // trailing slash
                 'bar/foo/////', // multiple trailing slashes
                 'foo////bar', // multiple slashes inbetween
                 '////foo', // multiple at beginning
-                '/foo/bar' // don't mutate
+                '/foo/bar', // don't mutate
+                '/?test=1', // basic with query
+                '///foo///?test=1' // excess with query
             ],
             output: [
+                '/',
+                '/',
                 '/foo',
                 'bar/foo',
                 'bar/foo',
                 'foo/bar',
                 '/foo',
-                '/foo/bar'
+                '/foo/bar',
+                '/?test=1',
+                '/foo?test=1'
             ],
             description: [
+                'should give the root as a slash',
+                'dont give empty string for excess on root',
                 'should clean excess padding on both ends',
                 'should clean trailing slash',
                 'should clean multiple trailing slashes',
                 'should clean multiple slashes inbetween',
                 'should clean multiple at beginning',
-                'dont mutate correct urls'
+                'dont mutate correct urls',
+                'preserve query string with basic path',
+                'preserve query string with excess slashes'
             ]
         };
 

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -246,6 +246,26 @@ test('lookup calls next with err', function(t) {
     });
 });
 
+test('GH-1959: lookup returns undefined when no handler found', function(t) {
+    var router = new Router({
+        log: {}
+    });
+    var handlerFound = router.lookup(
+        Object.assign(
+            {
+                getUrl: function() {
+                    return { pathname: null };
+                },
+                method: 'GET'
+            },
+            mockReq
+        ),
+        mockRes
+    );
+    t.notOk(handlerFound);
+    t.end();
+});
+
 test('route handles 404', function(t) {
     var router = new Router({
         log: {}
@@ -268,7 +288,7 @@ test('route handles 404', function(t) {
     );
 });
 
-test('route handles 404 when pathname invalid', function(t) {
+test('GH-1959: route handles 404 when pathname invalid', function(t) {
     var router = new Router({
         log: {}
     });

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -268,6 +268,28 @@ test('route handles 404', function(t) {
     );
 });
 
+test('route handles 404 when pathname invalid', function(t) {
+    var router = new Router({
+        log: {}
+    });
+    router.defaultRoute(
+        Object.assign(
+            {
+                getUrl: function() {
+                    return { pathname: null };
+                },
+                method: 'GET'
+            },
+            mockReq
+        ),
+        mockRes,
+        function next(err) {
+            t.equal(err.statusCode, 404);
+            t.end();
+        }
+    );
+});
+
 test('route handles method not allowed (405)', function(t) {
     var router = new Router({
         log: {}


### PR DESCRIPTION
## Pre-Submission Checklist

- [x] Opened an issue discussing these changes before opening the PR
- [x] Ran the linter and tests via `make prepush`
- [x] Included comprehensive and convincing tests for changes

## Issues

Closes:

* Issue #1959 
* Issue #1953

> Summarize the issues that discussed these changes

The issues demonstrate how restify can crash the node process when using `server.pre(restify.pre.sanitizePath())` and a request with trailing slashes on root is received. I experienced this via intruder.io scanning against my production API application that uses restify. Please see the repro case [here](https://github.com/nexdrew/restify-repro-1959) as referenced in #1959.

# Changes

> What does this PR do?

This PR makes 3 basic changes, each with at least one new unit test:

1. Changes the `sanitizePath` middleware in _lib/plugins/pre/prePath.js_ to return a root url (`/`) instead of an empty string in the case where the actual url consists of more than one slash e.g. `//` or `///`. This helps avoid numbers 2 and 3 below.

2. Changes the `lookup` method in _lib/router.js_ to return `undefined` when `req.getUrl().pathname` is falsy. This helps avoid calling `this._registry.lookup(req.method, pathname)` which will result in an `AssertionError` in the case that the `pathname` is falsy, for whatever reason.

3. Changes the `defaultRoute` method in _lib/router.js_ to expect/handle a falsy `pathname` by skipping registry lookup (which would throw an `AssertionError`) and raising the standard `ResourceNotFoundError` (which results in 404 response) with the message "Requested path does not exist". This, along with number 2, allows restify to gracefully handle a falsy `pathname` for whatever reason.

All changes are covered by unit tests, namely:
1. `sanitizePath` in _test/plugins/plugins.test.js_
2. `GH-1959: lookup returns undefined when no handler found` in _test/router.test.js_
3. `GH-1959: route handles 404 when pathname invalid` in _test/router.test.js_

This is an attempt to make restify more robust and avoid crashes due to odd requests, if possible.

Please let me know if you have any questions or if you'd like me to change anything. Thanks!