### PR TITLE
feat: replace deprecated node apis

### DIFF
--- a/lib/formatters/binary.js
+++ b/lib/formatters/binary.js
@@ -16,7 +16,7 @@
  */
 function formatBinary(req, res, body) {
     if (!Buffer.isBuffer(body)) {
-        body = new Buffer(body.toString());
+        body = Buffer.from(body.toString());
     }
 
     res.setHeader('Content-Length', body.length);

--- a/lib/plugins/audit.js
+++ b/lib/plugins/audit.js
@@ -271,8 +271,8 @@ function auditLogger(opts) {
         }
 
         var obj = {
-            remoteAddress: req.connection.remoteAddress,
-            remotePort: req.connection.remotePort,
+            remoteAddress: req.socket.remoteAddress,
+            remotePort: req.socket.remotePort,
             [requestIdFieldName]: req.getId(),
             req: req,
             res: res,

--- a/lib/plugins/authorization.js
+++ b/lib/plugins/authorization.js
@@ -28,7 +28,7 @@ function parseBasic(string) {
     var index;
     var pieces;
 
-    decoded = new Buffer(string, 'base64').toString('utf8');
+    decoded = Buffer.from(string, 'base64').toString('utf8');
 
     if (!decoded) {
         throw new InvalidHeaderError('Authorization header invalid');

--- a/lib/plugins/bodyReader.js
+++ b/lib/plugins/bodyReader.js
@@ -36,7 +36,7 @@ function createBodyWriter(req) {
         isText = true;
     }
 
-    req.body = new Buffer(0);
+    req.body = Buffer.alloc(0);
     return {
         write: function write(chunk) {
             buffers.push(chunk);

--- a/lib/plugins/throttle.js
+++ b/lib/plugins/throttle.js
@@ -261,7 +261,7 @@ function throttle(options) {
         var rate = options.rate;
 
         if (options.ip) {
-            attr = req.connection.remoteAddress;
+            attr = req.socket.remoteAddress;
         } else if (options.xff) {
             attr = req.headers['x-forwarded-for'];
         } else if (options.username) {
@@ -316,7 +316,7 @@ function throttle(options) {
         if (tooManyRequests) {
             req.log.info(
                 {
-                    address: req.connection.remoteAddress || '?',
+                    address: req.socket.remoteAddress || '?',
                     method: req.method,
                     url: req.url,
                     user: req.username || '?'

--- a/lib/request.js
+++ b/lib/request.js
@@ -633,7 +633,7 @@ function patch(Request) {
             return this._secure;
         }
 
-        this._secure = this.connection.encrypted ? true : false;
+        this._secure = this.socket.encrypted ? true : false;
         return this._secure;
     };
 

--- a/test/plugins/authorization.test.js
+++ b/test/plugins/authorization.test.js
@@ -46,7 +46,7 @@ describe('authorization parser', function() {
     });
 
     it('should accept basic authorization', function(done) {
-        var authz = 'Basic ' + new Buffer('user:secret').toString('base64');
+        var authz = 'Basic ' + Buffer.from('user:secret').toString('base64');
         var opts = {
             path: '/',
             headers: {

--- a/test/plugins/multipart.test.js
+++ b/test/plugins/multipart.test.js
@@ -215,7 +215,7 @@ describe('multipart parser', function() {
             '/multipart/:id',
             restify.plugins.bodyParser({
                 multipartHandler: function(part) {
-                    var buffer = new Buffer(0);
+                    var buffer = Buffer.alloc(0);
                     part.on('data', function(data) {
                         buffer = Buffer.concat([data]);
                     });
@@ -226,7 +226,7 @@ describe('multipart parser', function() {
                     });
                 },
                 multipartFileHandler: function(part) {
-                    var buffer = new Buffer(0);
+                    var buffer = Buffer.alloc(0);
                     part.on('data', function(data) {
                         buffer = Buffer.concat([data]);
                     });

--- a/test/plugins/userAgent.test.js
+++ b/test/plugins/userAgent.test.js
@@ -115,7 +115,7 @@ describe('userAgent pre-route handler', function() {
                 // destroy the socket explicitly now since the request was
                 // explicitly requesting to not destroy the socket by setting
                 // its connection header to 'keep-alive'.
-                req.abort();
+                req.destroy();
 
                 done();
             }


### PR DESCRIPTION
<!--
Thank you for taking the time to open an PR for restify! If this is your first
time here, welcome to our community! We are a group of developers who work on
restify in our free-time. Some of us do it as a hobby, others are using restify
at work. When asking for help here, keep in mind most of us are volunteers
contributing our daily work back to the community at no cost (and often for no
reward). Please be respectful!

Below you will find a checklist to help you create the best PR possible. While
the checklist items aren't all _strictly_ required, they dramatically increase
the probability of your PR getting a response and getting merged. Often times,
the least time consuming part of maintaining and open source project is writing
code, its the process and discussions that happen around the code base that
consume a majority of the maintainers' time. By spending a few moments to
adhere to this template, you are not only improve the quality of your PR, you
are also helping save the maintainers a considerable amount of time when trying
to understand and review your changes.

And remember, positive vibes are met with positive vibes. Kindness helps Free
Software go round, pay it forward!
-->

## Pre-Submission Checklist

- [ ] Opened an issue discussing these changes before opening the PR
- [ ] Ran the linter and tests via `make prepush`
- [ ] Included comprehensive and convincing tests for changes

## Issues

Closes:

* Issue #
* Issue #
* Issue #

> Summarize the issues that discussed these changes

# Changes

## Deprecated API Fixes
- `request.connection` — removed in Node.js 24. Replaced with `request.socket`.
  Affected: `lib/request.js`, `lib/plugins/audit.js`, `lib/plugins/throttle.js`.
- `new Buffer()` — removed in Node.js 26. Replaced with `Buffer.from()` / `Buffer.alloc()`.
  Affected: `lib/formatters/binary.js`, `lib/plugins/authorization.js`, `lib/plugins/bodyReader.js`.
- `request.abort()` — removed in Node.js 26. Replaced with `request.destroy()`.
  Affected: `test/plugins/userAgent.test.js`.
