### PR TITLE
feat: replace module.parent with explicit module param in test helper

### DIFF
--- a/examples/todoapp/lib/server.js
+++ b/examples/todoapp/lib/server.js
@@ -278,7 +278,10 @@ function listTodos(req, res, next) {
  */
 function putTodo(req, res, next) {
     if (!req.body.task) {
-        req.log.warn({ params: req.params, body: req.body }, 'putTodo: missing task');
+        req.log.warn(
+            { params: req.params, body: req.body },
+            'putTodo: missing task'
+        );
         next(new MissingTaskError());
         return;
     }

--- a/examples/todoapp/test/todo.test.js
+++ b/examples/todoapp/test/todo.test.js
@@ -15,28 +15,28 @@ var SOCK = '/tmp/.todo_sock';
 
 ///--- Tests
 
-describe('todoapp', function () {
+describe('todoapp', function() {
     var CLIENT;
     var SERVER;
 
-    before(function (done) {
+    before(function(done) {
         var log = pino({
             name: 'todo_unit_test',
             level: process.env.LOG_LEVEL || 'info'
         });
-    
+
         fs.mkdir(DIR, function(err) {
             if (err && err.code !== 'EEXIST') {
                 console.error('unable to mkdir: ' + err.stack);
                 process.exit(1);
             }
-    
+
             SERVER = todo.createServer({
                 directory: DIR,
                 log: log.child({ component: 'server' }, true),
                 noAudit: true
             });
-    
+
             assert.ok(SERVER);
             SERVER.listen(SOCK, function() {
                 CLIENT = todo.createClient({
@@ -46,15 +46,15 @@ describe('todoapp', function () {
                 assert.ok(CLIENT);
                 done();
             });
-        });    
+        });
     });
 
-    it('should return an empty list', function (done) {
+    it('should return an empty list', function(done) {
         CLIENT.list(function(err, todos) {
             assert.ifError(err);
             assert.ok(todos);
             assert.ok(Array.isArray(todos));
-    
+
             if (todos) {
                 assert.equal(todos.length, 0);
             }
@@ -62,12 +62,12 @@ describe('todoapp', function () {
         });
     });
 
-    it('should create a new task', function (done) {
+    it('should create a new task', function(done) {
         var task = 'check that unit test works';
         CLIENT.create(task, function(err, todo) {
             assert.ifError(err);
             assert.ok(todo);
-    
+
             if (todo) {
                 assert.ok(todo.name);
                 assert.equal(todo.task, task);
@@ -76,12 +76,12 @@ describe('todoapp', function () {
         });
     });
 
-    it('should list and get', function (done) {
+    it('should list and get', function(done) {
         CLIENT.list(function(err, todos) {
             assert.ifError(err);
             assert.ok(todos);
             assert.ok(Array.isArray(todos));
-    
+
             if (todos) {
                 assert.equal(todos.length, 1);
                 CLIENT.get(todos[0], function(err2, todo) {
@@ -95,15 +95,15 @@ describe('todoapp', function () {
         });
     });
 
-    it('should update', function (done) {
+    it('should update', function(done) {
         CLIENT.list(function(err, todos) {
             assert.ifError(err);
             assert.ok(todos);
             assert.ok(Array.isArray(todos));
-    
+
             if (todos) {
                 assert.equal(todos.length, 1);
-    
+
                 var todo = {
                     name: todos[0],
                     task: 'something else'
@@ -122,7 +122,7 @@ describe('todoapp', function () {
         CLIENT.del(function(err) {
             assert.ifError(err);
             CLIENT.client.close();
-            SERVER.close(function () {
+            SERVER.close(function() {
                 fs.rmdir(DIR, function(err) {
                     assert.ifError(err);
                     done();

--- a/test/chain.test.js
+++ b/test/chain.test.js
@@ -13,7 +13,7 @@ var helper = require('./lib/helper.js');
 
 var test = helper.test;
 
-test('calls all the handlers', function(t) {
+test(module, 'calls all the handlers', function(t) {
     var chain = new Chain();
     var counter = 0;
 
@@ -41,7 +41,7 @@ test('calls all the handlers', function(t) {
     );
 });
 
-test('abort with Error in next', function(t) {
+test(module, 'abort with Error in next', function(t) {
     var chain = new Chain();
     var counter = 0;
     var myError = new Error('Foo');
@@ -71,7 +71,7 @@ test('abort with Error in next', function(t) {
     );
 });
 
-test('abort with false in next', function(t) {
+test(module, 'abort with false in next', function(t) {
     var chain = new Chain();
 
     chain.add(function(req, res, next) {
@@ -97,7 +97,7 @@ test('abort with false in next', function(t) {
     );
 });
 
-test('abort with closed request', function(t) {
+test(module, 'abort with closed request', function(t) {
     var chain = new Chain();
     var closed = false;
 
@@ -124,7 +124,7 @@ test('abort with closed request', function(t) {
     );
 });
 
-test('cals error middleware', function(t) {
+test(module, 'cals error middleware', function(t) {
     t.expect(2);
     var chain = new Chain();
     var myError = new Error('Foo');
@@ -155,7 +155,7 @@ test('cals error middleware', function(t) {
     );
 });
 
-test('onceNext prevents double next calls', function(t) {
+test(module, 'onceNext prevents double next calls', function(t) {
     var doneCalled = 0;
     var chain = new Chain({
         onceNext: true
@@ -184,7 +184,9 @@ test('onceNext prevents double next calls', function(t) {
     );
 });
 
-test('throws error for double next calls in strictNext mode', function(t) {
+test(module, 'throws error for double next calls in strictNext mode', function(
+    t
+) {
     t.expect(1);
     var chain = new Chain({
         strictNext: true
@@ -220,7 +222,7 @@ test('throws error for double next calls in strictNext mode', function(t) {
     });
 });
 
-test('calls req.startHandlerTimer', function(t) {
+test(module, 'calls req.startHandlerTimer', function(t) {
     var chain = new Chain();
 
     chain.add(function foo(req, res, next) {
@@ -243,7 +245,7 @@ test('calls req.startHandlerTimer', function(t) {
     );
 });
 
-test('calls req.endHandlerTimer', function(t) {
+test(module, 'calls req.endHandlerTimer', function(t) {
     var chain = new Chain();
 
     chain.add(function foo(req, res, next) {
@@ -266,7 +268,9 @@ test('calls req.endHandlerTimer', function(t) {
     );
 });
 
-test('count returns with the number of registered handlers', function(t) {
+test(module, 'count returns with the number of registered handlers', function(
+    t
+) {
     var chain = new Chain();
     chain.add(function(req, res, next) {});
     chain.add(function(req, res, next) {});
@@ -274,7 +278,7 @@ test('count returns with the number of registered handlers', function(t) {
     t.end();
 });
 
-test('getHandlers returns with the array of handlers', function(t) {
+test(module, 'getHandlers returns with the array of handlers', function(t) {
     var chain = new Chain();
     var handlers = [function(req, res, next) {}, function(req, res, next) {}];
     chain.add(handlers[0]);
@@ -283,7 +287,7 @@ test('getHandlers returns with the array of handlers', function(t) {
     t.end();
 });
 
-test('waits async handlers', function(t) {
+test(module, 'waits async handlers', function(t) {
     const chain = new Chain();
     let counter = 0;
 
@@ -311,7 +315,7 @@ test('waits async handlers', function(t) {
     );
 });
 
-test('abort with rejected promise', function(t) {
+test(module, 'abort with rejected promise', function(t) {
     const myError = new Error('Foo');
     const chain = new Chain();
     let counter = 0;
@@ -342,7 +346,7 @@ test('abort with rejected promise', function(t) {
     );
 });
 
-test('abort with rejected promise without error', function(t) {
+test(module, 'abort with rejected promise without error', function(t) {
     const chain = new Chain();
     let counter = 0;
 
@@ -377,7 +381,7 @@ test('abort with rejected promise without error', function(t) {
     );
 });
 
-test('abort with throw inside async function', function(t) {
+test(module, 'abort with throw inside async function', function(t) {
     const myError = new Error('Foo');
     const chain = new Chain();
     let counter = 0;
@@ -408,7 +412,7 @@ test('abort with throw inside async function', function(t) {
     );
 });
 
-test('fails to add non async function with arity 2', function(t) {
+test(module, 'fails to add non async function with arity 2', function(t) {
     var handler = function getLunch(req, res) {
         res.send('ok');
     };
@@ -419,7 +423,7 @@ test('fails to add non async function with arity 2', function(t) {
     t.end();
 });
 
-test('fails to add async function with arity 3', function(t) {
+test(module, 'fails to add async function with arity 3', function(t) {
     var handler = async function getBreakfast(req, res, next) {
         res.send('ok');
     };

--- a/test/chainComposer.test.js
+++ b/test/chainComposer.test.js
@@ -11,56 +11,64 @@ var helper = require('./lib/helper.js');
 var test = helper.test;
 var composer = require('../lib/helpers/chainComposer');
 
-test('chainComposer creates a valid chain for a handler array ', function(t) {
-    var counter = 0;
-    var handlers = [];
-    handlers.push(function(req, res, next) {
-        counter++;
-        next();
-    });
+test(
+    module,
+    'chainComposer creates a valid chain for a handler array ',
+    function(t) {
+        var counter = 0;
+        var handlers = [];
+        handlers.push(function(req, res, next) {
+            counter++;
+            next();
+        });
 
-    handlers.push(function(req, res, next) {
-        counter++;
-        next();
-    });
+        handlers.push(function(req, res, next) {
+            counter++;
+            next();
+        });
 
-    var chain = composer(handlers);
-    chain(
-        {
-            startHandlerTimer: function() {},
-            endHandlerTimer: function() {},
-            connectionState: function() {
-                return '';
+        var chain = composer(handlers);
+        chain(
+            {
+                startHandlerTimer: function() {},
+                endHandlerTimer: function() {},
+                connectionState: function() {
+                    return '';
+                }
+            },
+            {},
+            function() {
+                t.equal(counter, 2);
+                t.done();
             }
-        },
-        {},
-        function() {
-            t.equal(counter, 2);
-            t.done();
-        }
-    );
-});
+        );
+    }
+);
 
-test('chainComposer creates a valid chain for a single handler', function(t) {
-    var counter = 0;
-    var handlers = function(req, res, next) {
-        counter++;
-        next();
-    };
+test(
+    module,
+    'chainComposer creates a valid chain for a single handler',
+    function(t) {
+        var counter = 0;
+        var handlers = function(req, res, next) {
+            counter++;
+            next();
+        };
 
-    var chain = composer(handlers);
-    chain(
-        {
-            startHandlerTimer: function() {},
-            endHandlerTimer: function() {},
-            connectionState: function() {
-                return '';
+        var chain = composer(handlers);
+        chain(
+            {
+                startHandlerTimer: function() {},
+                endHandlerTimer: function() {},
+                connectionState: function() {
+                    return '';
+                }
+            },
+            {},
+            function() {
+                t.equal(counter, 1);
+                t.done();
             }
-        },
-        {},
-        function() {
-            t.equal(counter, 1);
-            t.done();
-        }
-    );
-});
+        );
+    }
+);

--- a/test/formatter-optional.test.js
+++ b/test/formatter-optional.test.js
@@ -23,7 +23,7 @@ var SERVER;
 
 ///--- Tests
 
-before(function(callback) {
+before(module, function(callback) {
     try {
         SERVER = restify.createServer({
             handleUncaughtExceptions: true,
@@ -46,7 +46,7 @@ before(function(callback) {
     }
 });
 
-after(function(callback) {
+after(module, function(callback) {
     try {
         SERVER.close(callback);
         CLIENT.close();
@@ -56,20 +56,24 @@ after(function(callback) {
     }
 });
 
-test('send 200 on formatter missing and strictFormatters false', function(t) {
-    // When server is passed "strictFormatters: false" at creation time,
-    // res.send still sends a successful response even when a formatter is
-    // not set up for a specific content-type.
-    SERVER.get('/11', function handle(req, res, next) {
-        res.header('content-type', 'application/hal+json');
-        res.send(200, JSON.stringify({ hello: 'world' }));
-        return next();
-    });
+test(
+    module,
+    'send 200 on formatter missing and strictFormatters false',
+    function(t) {
+        // When server is passed "strictFormatters: false" at creation time,
+        // res.send still sends a successful response even when a formatter is
+        // not set up for a specific content-type.
+        SERVER.get('/11', function handle(req, res, next) {
+            res.header('content-type', 'application/hal+json');
+            res.send(200, JSON.stringify({ hello: 'world' }));
+            return next();
+        });
 
-    CLIENT.get(LOCALHOST + '/11', function(err, _, res) {
-        t.ifError(err);
-        t.equal(res.statusCode, 200);
-        t.equal(res.headers['content-type'], 'application/hal+json');
-        t.end();
-    });
-});
+        CLIENT.get(LOCALHOST + '/11', function(err, _, res) {
+            t.ifError(err);
+            t.equal(res.statusCode, 200);
+            t.equal(res.headers['content-type'], 'application/hal+json');
+            t.end();
+        });
+    }
+);

--- a/test/formatter.test.js
+++ b/test/formatter.test.js
@@ -27,7 +27,7 @@ var SERVER;
 
 ///--- Tests
 
-before(function(callback) {
+before(module, function(callback) {
     try {
         SERVER = restify.createServer({
             handleUncaughtExceptions: true,
@@ -86,7 +86,7 @@ before(function(callback) {
     }
 });
 
-after(function(callback) {
+after(module, function(callback) {
     try {
         SERVER.close(callback);
     } catch (e) {
@@ -95,7 +95,7 @@ after(function(callback) {
     }
 });
 
-test('GH-845: sync formatter', function(t) {
+test(module, 'GH-845: sync formatter', function(t) {
     CLIENT.get(
         {
             path: '/sync',
@@ -113,7 +113,7 @@ test('GH-845: sync formatter', function(t) {
     );
 });
 
-test('GH-845: sync formatter should blow up', function(t) {
+test(module, 'GH-845: sync formatter should blow up', function(t) {
     SERVER.once('uncaughtException', function(req, res, route, err) {
         t.ok(err);
         t.equal(err.name, 'ReferenceError');
@@ -136,30 +136,34 @@ test('GH-845: sync formatter should blow up', function(t) {
     );
 });
 
-test('sync formatter should handle expected errors gracefully', function(t) {
-    SERVER.once('uncaughtException', function(req, res, route, err) {
-        throw new Error('Should not reach');
-    });
+test(
+    module,
+    'sync formatter should handle expected errors gracefully',
+    function(t) {
+        SERVER.once('uncaughtException', function(req, res, route, err) {
+            throw new Error('Should not reach');
+        });
 
-    CLIENT.get(
-        {
-            path: '/sync',
-            headers: {
-                accept: 'text/syncerror_expected'
+        CLIENT.get(
+            {
+                path: '/sync',
+                headers: {
+                    accept: 'text/syncerror_expected'
+                }
+            },
+            function(err, req, res, data) {
+                t.ok(err);
+                t.ok(req);
+                t.ok(res);
+                t.equal(res.statusCode, 500);
+                SERVER.removeAllListeners('uncaughtException');
+                t.end();
             }
-        },
-        function(err, req, res, data) {
-            t.ok(err);
-            t.ok(req);
-            t.ok(res);
-            t.equal(res.statusCode, 500);
-            SERVER.removeAllListeners('uncaughtException');
-            t.end();
-        }
-    );
-});
+        );
+    }
+);
 
-test('q-val priority', function(t) {
+test(module, 'q-val priority', function(t) {
     var opts = {
         path: '/sync',
         headers: {
@@ -175,7 +179,7 @@ test('q-val priority', function(t) {
     });
 });
 
-test('GH-771 q-val priority on */*', function(t) {
+test(module, 'GH-771 q-val priority on */*', function(t) {
     var opts = {
         path: '/sync',
         headers: {
@@ -196,6 +200,7 @@ test('GH-771 q-val priority on */*', function(t) {
 });
 
 test(
+    module,
     'GH-937 should return 406 when no content-type header set on response ' +
         'matching an acceptable type found by matching client',
     function(t) {
@@ -218,6 +223,7 @@ test(
 );
 
 test(
+    module,
     'GH-937 should return 500 when no default formatter found ' +
         'and octet-stream is not available',
     function(t) {
@@ -240,60 +246,69 @@ test(
 );
 
 // eslint-disable-next-line
-test('default jsonp formatter should escape line and paragraph separators', function(t) {
-    // ensure client accepts only a type not specified by server
-    var opts = {
-        path: '/jsonpSeparators',
-        headers: {
-            accept: 'application/javascript'
-        }
-    };
+test(
+    module,
+    'default jsonp formatter should escape line and paragraph separators',
+    function(t) {
+        // ensure client accepts only a type not specified by server
+        var opts = {
+            path: '/jsonpSeparators',
+            headers: {
+                accept: 'application/javascript'
+            }
+        };
 
-    CLIENT.get(opts, function(err, req, res, data) {
-        t.ifError(err);
-        t.ok(req);
-        t.ok(res);
-        t.equal(data, '"\\u2028\\u2029"');
-        t.end();
-    });
-});
+        CLIENT.get(opts, function(err, req, res, data) {
+            t.ifError(err);
+            t.ok(req);
+            t.ok(res);
+            t.equal(data, '"\\u2028\\u2029"');
+            t.end();
+        });
+    }
+);
 
 // eslint-disable-next-line
-test('default json formatter should wrap & throw InternalServer error on unserializable bodies', function(t) {
-    t.expect(2);
+test(
+    module,
+    // eslint-disable-next-line max-len
+    'default json formatter should wrap & throw InternalServer error on unserializable bodies',
+    function(t) {
+        t.expect(2);
 
-    sinon.spy(JSON, 'stringify');
+        sinon.spy(JSON, 'stringify');
 
-    SERVER.once('uncaughtException', function(req, res, route, err) {
-        console.log(err.stack); // For convenience
-        throw new Error('Should not reach');
-    });
-
-    var opts = {
-        path: '/badJSON',
-        name: 'badJSON'
-    };
-
-    SERVER.get(opts, function(req, res, next) {
-        var body = {};
-        // Add unserializable circular reference
-        body.body = body;
-
-        try {
-            jsonFormatter(req, res, body);
+        SERVER.once('uncaughtException', function(req, res, route, err) {
+            console.log(err.stack); // For convenience
             throw new Error('Should not reach');
-        } catch (e) {
-            t.ok(e instanceof errors.InternalServerError);
-            t.ok(JSON.stringify.threw(e.cause()));
-        }
+        });
 
-        res.send();
-    });
+        var opts = {
+            path: '/badJSON',
+            name: 'badJSON'
+        };
 
-    CLIENT.get('/badJSON', function(err, req, res, data) {
-        SERVER.rm('badJSON');
-        SERVER.removeAllListeners('uncaughtException');
-        JSON.stringify.restore();
-        t.end();
-    });
-});
+        SERVER.get(opts, function(req, res, next) {
+            var body = {};
+            // Add unserializable circular reference
+            body.body = body;
+
+            try {
+                jsonFormatter(req, res, body);
+                throw new Error('Should not reach');
+            } catch (e) {
+                t.ok(e instanceof errors.InternalServerError);
+                t.ok(JSON.stringify.threw(e.cause()));
+            }
+
+            res.send();
+        });
+
+        CLIENT.get('/badJSON', function(err, req, res, data) {
+            SERVER.rm('badJSON');
+            SERVER.removeAllListeners('uncaughtException');
+            JSON.stringify.restore();
+            t.end();
+        });
+    }
+);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -16,7 +16,7 @@ var test = helper.test;
 
 ///--- Tests
 
-test('httpDate', function(t) {
+test(module, 'httpDate', function(t) {
     var d = httpDate();
     var regex = /\w{3}, \d{1,2} \w{3} \d{4} \d{2}:\d{2}:\d{2} GMT/;
     t.ok(regex.test(d));

--- a/test/lib/helper.js
+++ b/test/lib/helper.js
@@ -15,8 +15,8 @@ var once = require('once');
 ///--- Exports
 
 module.exports = {
-    after: function after(teardown) {
-        module.parent.exports.tearDown = function _teardown(callback) {
+    after: function after(callerModule, teardown) {
+        callerModule.exports.tearDown = function _teardown(callback) {
             var d = domain.create();
             var self = this;
 
@@ -31,8 +31,8 @@ module.exports = {
         };
     },
 
-    before: function before(setup) {
-        module.parent.exports.setUp = function _setup(callback) {
+    before: function before(callerModule, setup) {
+        callerModule.exports.setUp = function _setup(callback) {
             var d = domain.create();
             var self = this;
 
@@ -47,8 +47,8 @@ module.exports = {
         };
     },
 
-    test: function test(name, tester) {
-        module.parent.exports[name] = function _(t) {
+    test: function test(callerModule, name, tester) {
+        callerModule.exports[name] = function _(t) {
             var d = domain.create();
             var self = this;
 

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -21,7 +21,7 @@ var PORT = process.env.UNIT_TEST_PORT || 0;
 var CLIENT;
 var SERVER;
 
-before(function(cb) {
+before(module, function(cb) {
     try {
         SERVER = restify.createServer({
             dtrace: helper.dtrace,
@@ -43,7 +43,7 @@ before(function(cb) {
     }
 });
 
-after(function(cb) {
+after(module, function(cb) {
     try {
         CLIENT.close();
         SERVER.close(function() {
@@ -57,7 +57,7 @@ after(function(cb) {
     }
 });
 
-test('query should return empty string', function(t) {
+test(module, 'query should return empty string', function(t) {
     SERVER.get('/emptyQs', function(req, res, next) {
         t.equal(req.query(), '');
         t.equal(req.getQuery(), '');
@@ -72,7 +72,7 @@ test('query should return empty string', function(t) {
     });
 });
 
-test('query should return raw query string string', function(t) {
+test(module, 'query should return raw query string string', function(t) {
     SERVER.get('/qs', function(req, res, next) {
         t.equal(req.query(), 'a=1&b=2');
         t.equal(req.getQuery(), 'a=1&b=2');
@@ -87,7 +87,7 @@ test('query should return raw query string string', function(t) {
     });
 });
 
-test('should generate request id on first req.id() call', function(t) {
+test(module, 'should generate request id on first req.id() call', function(t) {
     SERVER.get('/ping', function(req, res, next) {
         t.equal(typeof req.id(), 'string');
         t.equal(validator.isUUID(req.id(), 4), true);
@@ -102,7 +102,7 @@ test('should generate request id on first req.id() call', function(t) {
     });
 });
 
-test('should set request id', function(t) {
+test(module, 'should set request id', function(t) {
     SERVER.pre(function setId(req, res, next) {
         var newId = req.id('lagavulin');
         t.equal(newId, 'lagavulin');
@@ -123,29 +123,33 @@ test('should set request id', function(t) {
     });
 });
 
-test('should throw when setting request id after autogeneration', function(t) {
-    SERVER.get('/ping', function(req, res, next) {
-        t.equal(typeof req.id(), 'string');
-        t.equal(validator.isUUID(req.id(), 4), true);
-        t.throws(
-            function() {
-                req.id('blowup');
-            },
-            Error,
-            'request id is immutable, cannot be set again!'
-        );
-        res.send();
-        return next();
-    });
+test(
+    module,
+    'should throw when setting request id after autogeneration',
+    function(t) {
+        SERVER.get('/ping', function(req, res, next) {
+            t.equal(typeof req.id(), 'string');
+            t.equal(validator.isUUID(req.id(), 4), true);
+            t.throws(
+                function() {
+                    req.id('blowup');
+                },
+                Error,
+                'request id is immutable, cannot be set again!'
+            );
+            res.send();
+            return next();
+        });
 
-    CLIENT.get('/ping', function(err, _, res) {
-        t.ifError(err);
-        t.equal(res.statusCode, 200);
-        t.end();
-    });
-});
+        CLIENT.get('/ping', function(err, _, res) {
+            t.ifError(err);
+            t.equal(res.statusCode, 200);
+            t.end();
+        });
+    }
+);
 
-test('should throw when setting request id twice', function(t) {
+test(module, 'should throw when setting request id twice', function(t) {
     SERVER.get('/ping', function(req, res, next) {
         req.id('lagavulin');
         t.throws(
@@ -166,7 +170,7 @@ test('should throw when setting request id twice', function(t) {
     });
 });
 
-test('should provide route object', function(t) {
+test(module, 'should provide route object', function(t) {
     SERVER.get('/ping/:name', function(req, res, next) {
         /*
          req.getRoute() should return something like this :
@@ -192,7 +196,7 @@ test('should provide route object', function(t) {
     });
 });
 
-test('should provide time when request started', function(t) {
+test(module, 'should provide time when request started', function(t) {
     SERVER.get('/ping/:name', function(req, res, next) {
         t.equal(typeof req.time(), 'number');
         t.ok(req.time() > Date.now() - 1000);
@@ -208,7 +212,7 @@ test('should provide time when request started', function(t) {
     });
 });
 
-test('should provide date when request started', function(t) {
+test(module, 'should provide date when request started', function(t) {
     SERVER.get('/ping/:name', function(req, res, next) {
         t.ok(req.date() instanceof Date);
         t.ok(req.date().getTime() > Date.now() - 1000);
@@ -226,52 +230,60 @@ test('should provide date when request started', function(t) {
 
 // restifyDone is emitted at the same time when server's after event is emitted,
 // you can find more comprehensive testing for `after` lives in server tests.
-test('should emit restifyDone event when request is fully served', function(t) {
-    var restifyDoneCalled = false;
+test(
+    module,
+    'should emit restifyDone event when request is fully served',
+    function(t) {
+        var restifyDoneCalled = false;
 
-    SERVER.get('/', function(req, res, next) {
-        req.on('restifyDone', function(route, err) {
-            t.ifError(err);
-            t.ok(route);
-            setImmediate(function() {
-                restifyDoneCalled = true;
+        SERVER.get('/', function(req, res, next) {
+            req.on('restifyDone', function(route, err) {
+                t.ifError(err);
+                t.ok(route);
+                setImmediate(function() {
+                    restifyDoneCalled = true;
+                });
             });
+
+            res.send('hello');
+            return next();
         });
 
-        res.send('hello');
-        return next();
-    });
-
-    CLIENT.get('/', function(err, _, res) {
-        t.ifError(err);
-        t.equal(res.statusCode, 200);
-        t.ok(restifyDoneCalled);
-        t.end();
-    });
-});
+        CLIENT.get('/', function(err, _, res) {
+            t.ifError(err);
+            t.equal(res.statusCode, 200);
+            t.ok(restifyDoneCalled);
+            t.end();
+        });
+    }
+);
 
 // eslint-disable-next-line max-len
-test('should emit restifyDone event when request is fully served with error', function(t) {
-    var clientDone = false;
+test(
+    module,
+    'should emit restifyDone event when request is fully served with error',
+    function(t) {
+        var clientDone = false;
 
-    SERVER.get('/', function(req, res, next) {
-        var myErr = new Error('My Error');
+        SERVER.get('/', function(req, res, next) {
+            var myErr = new Error('My Error');
 
-        req.on('restifyDone', function(route, err) {
-            t.ok(route);
-            t.deepEqual(err, myErr);
-            setImmediate(function() {
-                t.ok(clientDone);
-                t.end();
+            req.on('restifyDone', function(route, err) {
+                t.ok(route);
+                t.deepEqual(err, myErr);
+                setImmediate(function() {
+                    t.ok(clientDone);
+                    t.end();
+                });
             });
+
+            return next(myErr);
         });
 
-        return next(myErr);
-    });
-
-    CLIENT.get('/', function(err, _, res) {
-        t.ok(err);
-        t.equal(res.statusCode, 500);
-        clientDone = true;
-    });
-});
+        CLIENT.get('/', function(err, _, res) {
+            t.ok(err);
+            t.equal(res.statusCode, 500);
+            clientDone = true;
+        });
+    }
+);

--- a/test/response.test.js
+++ b/test/response.test.js
@@ -26,7 +26,7 @@ var SERVER;
 var LOCALHOST;
 var SLOCALHOST;
 
-before(function(cb) {
+before(module, function(cb) {
     try {
         SERVER = restify.createServer({
             dtrace: helper.dtrace,
@@ -58,7 +58,7 @@ before(function(cb) {
     }
 });
 
-after(function(cb) {
+after(module, function(cb) {
     try {
         CLIENT.close();
         STRING_CLIENT.close();
@@ -79,7 +79,7 @@ function join() {
     return args.join('');
 }
 
-test('redirect to new string url as-is', function(t) {
+test(module, 'redirect to new string url as-is', function(t) {
     SERVER.get('/1', function(req, res, next) {
         res.redirect('www.foo.com', next);
     });
@@ -92,7 +92,7 @@ test('redirect to new string url as-is', function(t) {
     });
 });
 
-test('redirect to new relative string url as-is', function(t) {
+test(module, 'redirect to new relative string url as-is', function(t) {
     SERVER.get('/20', function(req, res, next) {
         res.redirect('/1', next);
     });
@@ -105,7 +105,7 @@ test('redirect to new relative string url as-is', function(t) {
     });
 });
 
-test('redirect to current url (reload)', function(t) {
+test(module, 'redirect to current url (reload)', function(t) {
     SERVER.get('/2', function(req, res, next) {
         res.redirect(
             {
@@ -123,7 +123,7 @@ test('redirect to current url (reload)', function(t) {
     });
 });
 
-test('redirect to current url from http -> https', function(t) {
+test(module, 'redirect to current url from http -> https', function(t) {
     SERVER.get('/3', function(req, res, next) {
         res.redirect(
             {
@@ -141,7 +141,7 @@ test('redirect to current url from http -> https', function(t) {
     });
 });
 
-test('redirect to current url from https -> http', function(t) {
+test(module, 'redirect to current url from https -> http', function(t) {
     SERVER.get('/3', function(req, res, next) {
         res.redirect(
             {
@@ -160,7 +160,7 @@ test('redirect to current url from https -> http', function(t) {
     });
 });
 
-test('redirect by changing path', function(t) {
+test(module, 'redirect by changing path', function(t) {
     SERVER.get('/4', function(req, res, next) {
         res.redirect(
             {
@@ -179,6 +179,7 @@ test('redirect by changing path', function(t) {
 });
 
 test(
+    module,
     'GH-1494: redirect should succeed even if req.url does not specify host' +
         ' or protocol',
     function(t) {
@@ -210,7 +211,7 @@ test(
     }
 );
 
-test('redirect should add query params', function(t) {
+test(module, 'redirect should add query params', function(t) {
     SERVER.get('/5', function(req, res, next) {
         res.redirect(
             {
@@ -230,7 +231,7 @@ test('redirect should add query params', function(t) {
     });
 });
 
-test('redirect should extend existing query params', function(t) {
+test(module, 'redirect should extend existing query params', function(t) {
     SERVER.get('/6', function(req, res, next) {
         res.redirect(
             {
@@ -258,7 +259,7 @@ test('redirect should extend existing query params', function(t) {
     });
 });
 
-test('redirect should stomp over existing query params', function(t) {
+test(module, 'redirect should stomp over existing query params', function(t) {
     SERVER.get('/7', function(req, res, next) {
         res.redirect(
             {
@@ -279,7 +280,7 @@ test('redirect should stomp over existing query params', function(t) {
     });
 });
 
-test('redirect with 301 status code', function(t) {
+test(module, 'redirect with 301 status code', function(t) {
     SERVER.get('/8', function(req, res, next) {
         res.redirect(
             {
@@ -297,7 +298,7 @@ test('redirect with 301 status code', function(t) {
     });
 });
 
-test('redirect with 301 status code ising string url', function(t) {
+test(module, 'redirect with 301 status code ising string url', function(t) {
     SERVER.get('/30', function(req, res, next) {
         res.redirect(301, '/foo', next);
     });
@@ -310,7 +311,7 @@ test('redirect with 301 status code ising string url', function(t) {
     });
 });
 
-test('redirect using options.url', function(t) {
+test(module, 'redirect using options.url', function(t) {
     SERVER.get('/8', function(req, res, next) {
         res.redirect(
             {
@@ -332,7 +333,7 @@ test('redirect using options.url', function(t) {
     });
 });
 
-test('redirect using opts.port', function(t) {
+test(module, 'redirect using opts.port', function(t) {
     SERVER.get('/9', function(req, res, next) {
         res.redirect(
             {
@@ -351,7 +352,7 @@ test('redirect using opts.port', function(t) {
     });
 });
 
-test('redirect using external url and custom port', function(t) {
+test(module, 'redirect using external url and custom port', function(t) {
     SERVER.get('/9', function(req, res, next) {
         res.redirect(
             {
@@ -374,7 +375,7 @@ test('redirect using external url and custom port', function(t) {
     });
 });
 
-test('redirect using default hostname with custom port', function(t) {
+test(module, 'redirect using default hostname with custom port', function(t) {
     SERVER.get('/9', function(req, res, next) {
         res.redirect(
             {
@@ -397,51 +398,59 @@ test('redirect using default hostname with custom port', function(t) {
 });
 
 // eslint-disable-next-line
-test('redirect should cause InternalError when invoked without next', function(t) {
-    SERVER.get('/9', function(req, res, next) {
-        res.redirect();
-    });
+test(
+    module,
+    'redirect should cause InternalError when invoked without next',
+    function(t) {
+        SERVER.get('/9', function(req, res, next) {
+            res.redirect();
+        });
 
-    CLIENT.get(join(LOCALHOST, '/9'), function(err, _, res, body) {
-        t.equal(res.statusCode, 500);
+        CLIENT.get(join(LOCALHOST, '/9'), function(err, _, res, body) {
+            t.equal(res.statusCode, 500);
 
-        // json parse the response
-        t.equal(body.code, 'Internal');
-        t.end();
-    });
-});
+            // json parse the response
+            t.equal(body.code, 'Internal');
+            t.end();
+        });
+    }
+);
 
 // eslint-disable-next-line
-test('redirect should call next with false to stop handler stack execution', function(t) {
-    var wasRun = false;
+test(
+    module,
+    'redirect should call next with false to stop handler stack execution',
+    function(t) {
+        var wasRun = false;
 
-    function A(req, res, next) {
-        req.a = 1;
-        next();
+        function A(req, res, next) {
+            req.a = 1;
+            next();
+        }
+        function B(req, res, next) {
+            req.b = 2;
+            wasRun = true;
+            next();
+        }
+        function redirect(req, res, next) {
+            res.redirect('/10', next);
+        }
+
+        SERVER.get('/10', [A, redirect, B]);
+
+        CLIENT.get(join(LOCALHOST, '/10'), function(err, _, res) {
+            t.ifError(err);
+            t.equal(res.statusCode, 302);
+            t.equal(res.headers.location, '/10');
+
+            // handler B should not be executed
+            t.equal(wasRun, false);
+            t.end();
+        });
     }
-    function B(req, res, next) {
-        req.b = 2;
-        wasRun = true;
-        next();
-    }
-    function redirect(req, res, next) {
-        res.redirect('/10', next);
-    }
+);
 
-    SERVER.get('/10', [A, redirect, B]);
-
-    CLIENT.get(join(LOCALHOST, '/10'), function(err, _, res) {
-        t.ifError(err);
-        t.equal(res.statusCode, 302);
-        t.equal(res.headers.location, '/10');
-
-        // handler B should not be executed
-        t.equal(wasRun, false);
-        t.end();
-    });
-});
-
-test('redirect should emit a redirect event', function(t) {
+test(module, 'redirect should emit a redirect event', function(t) {
     var wasEmitted = false;
     var redirectLocation;
 
@@ -470,7 +479,7 @@ test('redirect should emit a redirect event', function(t) {
     });
 });
 
-test('writeHead should emit a header event', function(t) {
+test(module, 'writeHead should emit a header event', function(t) {
     var wasEmitted = false;
     var payloadPlaceholder;
 
@@ -497,7 +506,7 @@ test('writeHead should emit a header event', function(t) {
     });
 });
 
-test('should fail to set header due to missing formatter', function(t) {
+test(module, 'should fail to set header due to missing formatter', function(t) {
     // when a formatter is not set up for a specific content-type, restify will
     // default to octet-stream.
 
@@ -515,7 +524,7 @@ test('should fail to set header due to missing formatter', function(t) {
     });
 });
 
-test('should not fail to send null as body', function(t) {
+test(module, 'should not fail to send null as body', function(t) {
     SERVER.get('/12', function handle(req, res, next) {
         res.send(200, null);
         return next();
@@ -528,36 +537,44 @@ test('should not fail to send null as body', function(t) {
     });
 });
 
-test('should not fail to send null as body without status code', function(t) {
-    SERVER.get('/13', function handle(req, res, next) {
-        res.send(null);
-        return next();
-    });
+test(
+    module,
+    'should not fail to send null as body without status code',
+    function(t) {
+        SERVER.get('/13', function handle(req, res, next) {
+            res.send(null);
+            return next();
+        });
 
-    CLIENT.get(join(LOCALHOST, '/13'), function(err, _, res) {
-        t.ifError(err);
-        t.equal(res.statusCode, 200);
-        t.end();
-    });
-});
+        CLIENT.get(join(LOCALHOST, '/13'), function(err, _, res) {
+            t.ifError(err);
+            t.equal(res.statusCode, 200);
+            t.end();
+        });
+    }
+);
 
-test('should prefer explicit status code over error status code', function(t) {
-    SERVER.get('/14', function handle(req, res, next) {
-        res.send(200, new errs.InternalServerError('boom'));
-        return next();
-    });
+test(
+    module,
+    'should prefer explicit status code over error status code',
+    function(t) {
+        SERVER.get('/14', function handle(req, res, next) {
+            res.send(200, new errs.InternalServerError('boom'));
+            return next();
+        });
 
-    CLIENT.get(join(LOCALHOST, '/14'), function(err, _, res, body) {
-        t.ifError(err);
-        t.equal(res.statusCode, 200);
-        // ensure error body was still sent
-        t.equal(body.code, 'InternalServer');
-        t.equal(body.message, 'boom');
-        t.end();
-    });
-});
+        CLIENT.get(join(LOCALHOST, '/14'), function(err, _, res, body) {
+            t.ifError(err);
+            t.equal(res.statusCode, 200);
+            // ensure error body was still sent
+            t.equal(body.code, 'InternalServer');
+            t.equal(body.message, 'boom');
+            t.end();
+        });
+    }
+);
 
-test('GH-951: should send without formatting', function(t) {
+test(module, 'GH-951: should send without formatting', function(t) {
     SERVER.get('/15', function handle(req, res, next) {
         res.header('content-type', 'application/json');
         res.sendRaw(
@@ -581,7 +598,7 @@ test('GH-951: should send without formatting', function(t) {
     });
 });
 
-test('GH-951: sendRaw accepts only strings or buffers', function(t) {
+test(module, 'GH-951: sendRaw accepts only strings or buffers', function(t) {
     SERVER.on('uncaughtException', function(req, res, route, err) {
         t.ok(err);
         // Node v8 uses static error codes
@@ -605,7 +622,9 @@ test('GH-951: sendRaw accepts only strings or buffers', function(t) {
     STRING_CLIENT.get(join(LOCALHOST, '/16'));
 });
 
-test('GH-1429: setting code with res.status not respected', function(t) {
+test(module, 'GH-1429: setting code with res.status not respected', function(
+    t
+) {
     SERVER.get('/404', function(req, res, next) {
         res.status(404);
         res.send(null);
@@ -617,7 +636,7 @@ test('GH-1429: setting code with res.status not respected', function(t) {
     });
 });
 
-test('should support multiple set-cookie headers', function(t) {
+test(module, 'should support multiple set-cookie headers', function(t) {
     SERVER.get('/set-cookie', function(req, res, next) {
         res.header('Set-Cookie', 'a=1');
         res.header('Set-Cookie', 'b=2');
@@ -630,7 +649,9 @@ test('should support multiple set-cookie headers', function(t) {
     });
 });
 
-test('GH-1607: should send bools with explicit status code', function(t) {
+test(module, 'GH-1607: should send bools with explicit status code', function(
+    t
+) {
     SERVER.get('/bool/:value', function(req, res, next) {
         res.send(200, req.params.value === 'true' ? true : false);
         return next();
@@ -656,7 +677,9 @@ test('GH-1607: should send bools with explicit status code', function(t) {
     });
 });
 
-test('GH-1607: should send numbers with explicit status code', function(t) {
+test(module, 'GH-1607: should send numbers with explicit status code', function(
+    t
+) {
     SERVER.get('/zero', function(req, res, next) {
         res.send(200, 0);
         return next();
@@ -681,7 +704,7 @@ test('GH-1607: should send numbers with explicit status code', function(t) {
     });
 });
 
-test('GH-1791: should send 0 as 0 with application/json', function(t) {
+test(module, 'GH-1791: should send 0 as 0 with application/json', function(t) {
     SERVER.get('/zero', function(req, res, next) {
         res.contentType = 'application/json';
         res.send(200, 0);
@@ -694,61 +717,99 @@ test('GH-1791: should send 0 as 0 with application/json', function(t) {
     });
 });
 
-test('GH-1791: should send false as false with application/json', function(t) {
-    SERVER.get('/false', function(req, res, next) {
-        res.contentType = 'application/json';
-        res.send(200, false);
-        return next();
-    });
+test(
+    module,
+    'GH-1791: should send false as false with application/json',
+    function(t) {
+        SERVER.get('/false', function(req, res, next) {
+            res.contentType = 'application/json';
+            res.send(200, false);
+            return next();
+        });
 
-    STRING_CLIENT.get(join(LOCALHOST, '/false'), function(err, req, res, data) {
-        t.equal(data, 'false');
-        t.end();
-    });
-});
-
-// eslint-disable-next-line
-test('GH-1791: should send empty string as "" with application/json', function(t) {
-    SERVER.get('/empty', function(req, res, next) {
-        res.contentType = 'application/json';
-        res.send(200, '');
-        return next();
-    });
-
-    STRING_CLIENT.get(join(LOCALHOST, '/empty'), function(err, req, res, data) {
-        t.equal(data, '""');
-        t.end();
-    });
-});
-
-test('GH-1791: should send null as null with application/json', function(t) {
-    SERVER.get('/null', function(req, res, next) {
-        res.contentType = 'application/json';
-        res.send(200, null);
-        return next();
-    });
-
-    STRING_CLIENT.get(join(LOCALHOST, '/null'), function(err, req, res, data) {
-        t.equal(data, 'null');
-        t.end();
-    });
-});
+        STRING_CLIENT.get(join(LOCALHOST, '/false'), function(
+            err,
+            req,
+            res,
+            data
+        ) {
+            t.equal(data, 'false');
+            t.end();
+        });
+    }
+);
 
 // eslint-disable-next-line
-test('GH-1791: should send undefined as empty with application/json', function(t) {
-    SERVER.get('/undef', function(req, res, next) {
-        res.contentType = 'application/json';
-        res.send(200, undefined);
-        return next();
-    });
+test(
+    module,
+    'GH-1791: should send empty string as "" with application/json',
+    function(t) {
+        SERVER.get('/empty', function(req, res, next) {
+            res.contentType = 'application/json';
+            res.send(200, '');
+            return next();
+        });
 
-    STRING_CLIENT.get(join(LOCALHOST, '/undef'), function(err, req, res, data) {
-        t.equal(data, '');
-        t.end();
-    });
-});
+        STRING_CLIENT.get(join(LOCALHOST, '/empty'), function(
+            err,
+            req,
+            res,
+            data
+        ) {
+            t.equal(data, '""');
+            t.end();
+        });
+    }
+);
 
-test('GH-1791: should send NaN as null with application/json', function(t) {
+test(
+    module,
+    'GH-1791: should send null as null with application/json',
+    function(t) {
+        SERVER.get('/null', function(req, res, next) {
+            res.contentType = 'application/json';
+            res.send(200, null);
+            return next();
+        });
+
+        STRING_CLIENT.get(join(LOCALHOST, '/null'), function(
+            err,
+            req,
+            res,
+            data
+        ) {
+            t.equal(data, 'null');
+            t.end();
+        });
+    }
+);
+
+// eslint-disable-next-line
+test(
+    module,
+    'GH-1791: should send undefined as empty with application/json',
+    function(t) {
+        SERVER.get('/undef', function(req, res, next) {
+            res.contentType = 'application/json';
+            res.send(200, undefined);
+            return next();
+        });
+
+        STRING_CLIENT.get(join(LOCALHOST, '/undef'), function(
+            err,
+            req,
+            res,
+            data
+        ) {
+            t.equal(data, '');
+            t.end();
+        });
+    }
+);
+
+test(module, 'GH-1791: should send NaN as null with application/json', function(
+    t
+) {
     SERVER.get('/nan', function(req, res, next) {
         res.contentType = 'application/json';
         res.send(200, NaN);

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -29,7 +29,7 @@ var mockRes = {
 
 ///--- Tests
 
-test('mounts a route', function(t) {
+test(module, 'mounts a route', function(t) {
     function handler(req, res, next) {
         res.send('Hello world');
     }
@@ -54,7 +54,7 @@ test('mounts a route', function(t) {
     t.done();
 });
 
-test('unmounts a route', function(t) {
+test(module, 'unmounts a route', function(t) {
     function handler(req, res, next) {
         res.send('Hello world');
     }
@@ -94,7 +94,7 @@ test('unmounts a route', function(t) {
     t.end();
 });
 
-test('unmounts a route that does not exist', function(t) {
+test(module, 'unmounts a route that does not exist', function(t) {
     function handler(req, res, next) {
         res.send('Hello world');
     }
@@ -109,7 +109,7 @@ test('unmounts a route that does not exist', function(t) {
     t.end();
 });
 
-test('clean up xss for 404', function(t) {
+test(module, 'clean up xss for 404', function(t) {
     var server = restify.createServer();
 
     server.listen(3000, function(listenErr) {
@@ -143,7 +143,7 @@ test('clean up xss for 404', function(t) {
     });
 });
 
-test('lookupByName runs a route by name and calls next', function(t) {
+test(module, 'lookupByName runs a route by name and calls next', function(t) {
     var router = new Router({
         log: {}
     });
@@ -164,7 +164,7 @@ test('lookupByName runs a route by name and calls next', function(t) {
     });
 });
 
-test('lookupByName calls next with err', function(t) {
+test(module, 'lookupByName calls next with err', function(t) {
     var router = new Router({
         log: {}
     });
@@ -184,7 +184,7 @@ test('lookupByName calls next with err', function(t) {
     });
 });
 
-test('lookup runs a route chain by path and calls next', function(t) {
+test(module, 'lookup runs a route chain by path and calls next', function(t) {
     var router = new Router({
         log: {}
     });
@@ -215,7 +215,7 @@ test('lookup runs a route chain by path and calls next', function(t) {
     });
 });
 
-test('lookup calls next with err', function(t) {
+test(module, 'lookup calls next with err', function(t) {
     var router = new Router({
         log: {}
     });
@@ -246,7 +246,7 @@ test('lookup calls next with err', function(t) {
     });
 });
 
-test('route handles 404', function(t) {
+test(module, 'route handles 404', function(t) {
     var router = new Router({
         log: {}
     });
@@ -268,7 +268,7 @@ test('route handles 404', function(t) {
     );
 });
 
-test('route handles method not allowed (405)', function(t) {
+test(module, 'route handles method not allowed (405)', function(t) {
     var router = new Router({
         log: {}
     });
@@ -296,7 +296,7 @@ test('route handles method not allowed (405)', function(t) {
     );
 });
 
-test('prints debug info', function(t) {
+test(module, 'prints debug info', function(t) {
     function handler1(req, res, next) {
         res.send('Hello world');
     }
@@ -327,7 +327,7 @@ test('prints debug info', function(t) {
     t.end();
 });
 
-test('toString()', function(t) {
+test(module, 'toString()', function(t) {
     function handler(req, res, next) {
         res.send('Hello world');
     }
@@ -350,7 +350,7 @@ test('toString()', function(t) {
     t.end();
 });
 
-test('toString() with ignoreTrailingSlash', function(t) {
+test(module, 'toString() with ignoreTrailingSlash', function(t) {
     function handler(req, res, next) {
         res.send('Hello world');
     }
@@ -379,7 +379,7 @@ var mockResponse = function respond(req, res, next) {
     res.send(200);
 };
 
-test('render route', function(t) {
+test(module, 'render route', function(t) {
     var server = restify.createServer();
     server.get({ name: 'countries', path: '/countries' }, mockResponse);
     server.get({ name: 'country', path: '/countries/:name' }, mockResponse);
@@ -403,7 +403,7 @@ test('render route', function(t) {
     t.end();
 });
 
-test('render route (missing params)', function(t) {
+test(module, 'render route (missing params)', function(t) {
     var server = restify.createServer();
     server.get(
         { name: 'cities', path: '/countries/:name/states/:state/cities' },
@@ -421,7 +421,7 @@ test('render route (missing params)', function(t) {
     t.end();
 });
 
-test('GH #704: render route (special charaters)', function(t) {
+test(module, 'GH #704: render route (special charaters)', function(t) {
     var server = restify.createServer();
     server.get({ name: 'my-route', path: '/countries/:name' }, mockResponse);
 
@@ -432,7 +432,7 @@ test('GH #704: render route (special charaters)', function(t) {
     t.end();
 });
 
-test('GH #704: render route (with sub-regex param)', function(t) {
+test(module, 'GH #704: render route (with sub-regex param)', function(t) {
     var server = restify.createServer();
     server.get(
         {
@@ -451,7 +451,9 @@ test('GH #704: render route (with sub-regex param)', function(t) {
     t.end();
 });
 
-test('GH-796: render route (with multiple sub-regex param)', function(t) {
+test(module, 'GH-796: render route (with multiple sub-regex param)', function(
+    t
+) {
     var server = restify.createServer();
     server.get(
         {
@@ -466,7 +468,7 @@ test('GH-796: render route (with multiple sub-regex param)', function(t) {
     t.end();
 });
 
-test('render route (with encode)', function(t) {
+test(module, 'render route (with encode)', function(t) {
     var server = restify.createServer();
     server.get({ name: 'my-route', path: '/countries/:name' }, mockResponse);
 
@@ -476,7 +478,7 @@ test('render route (with encode)', function(t) {
     t.end();
 });
 
-test('render route (query string)', function(t) {
+test(module, 'render route (query string)', function(t) {
     var server = restify.createServer();
     server.get({ name: 'country', path: '/countries/:name' }, mockResponse);
 

--- a/test/routerRegistryRadix.test.js
+++ b/test/routerRegistryRadix.test.js
@@ -29,7 +29,7 @@ function getTestRoute(opts) {
 
 ///--- Tests
 
-test('adds a route', function(t) {
+test(module, 'adds a route', function(t) {
     var registry = new RouterRegistryRadix();
     registry.add(getTestRoute({ method: 'GET', path: '/' }));
     registry.add(getTestRoute({ method: 'POST', path: '/' }));
@@ -40,7 +40,7 @@ test('adds a route', function(t) {
     t.done();
 });
 
-test('removes a route', function(t) {
+test(module, 'removes a route', function(t) {
     var registry = new RouterRegistryRadix();
 
     // Mount
@@ -59,7 +59,7 @@ test('removes a route', function(t) {
     t.end();
 });
 
-test('lookups a route', function(t) {
+test(module, 'lookups a route', function(t) {
     var registry = new RouterRegistryRadix();
     var route = getTestRoute({ method: 'GET', path: '/a/:b' });
     registry.add(route);
@@ -75,7 +75,7 @@ test('lookups a route', function(t) {
     t.done();
 });
 
-test('get registered routes', function(t) {
+test(module, 'get registered routes', function(t) {
     var registry = new RouterRegistryRadix();
     registry.add(getTestRoute({ method: 'GET', path: '/' }));
     registry.add(getTestRoute({ method: 'GET', path: '/a' }));
@@ -86,7 +86,7 @@ test('get registered routes', function(t) {
     t.end();
 });
 
-test('toString()', function(t) {
+test(module, 'toString()', function(t) {
     var registry = new RouterRegistryRadix();
     registry.add(getTestRoute({ method: 'GET', path: '/' }));
     registry.add(getTestRoute({ method: 'GET', path: '/a' }));
@@ -103,7 +103,7 @@ test('toString()', function(t) {
     t.end();
 });
 
-test('toString() with ignoreTrailingSlash', function(t) {
+test(module, 'toString() with ignoreTrailingSlash', function(t) {
     var registry = new RouterRegistryRadix({ ignoreTrailingSlash: true });
     registry.add(getTestRoute({ method: 'GET', path: '/' }));
     registry.add(getTestRoute({ method: 'GET', path: '/a' }));

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -43,7 +43,7 @@ if (SKIP_IP_V6) {
 
 ///--- Tests
 
-before(function(cb) {
+before(module, function(cb) {
     try {
         LOG_BUFFER = new StreamRecorder();
         SERVER = restify.createServer({
@@ -75,7 +75,7 @@ before(function(cb) {
     }
 });
 
-after(function(cb) {
+after(module, function(cb) {
     try {
         CLIENT.close();
         FAST_CLIENT.close();
@@ -91,7 +91,7 @@ after(function(cb) {
     }
 });
 
-test('listen and close (port only)', function(t) {
+test(module, 'listen and close (port only)', function(t) {
     var server = restify.createServer();
     server.listen(0, function() {
         server.close(function() {
@@ -100,7 +100,9 @@ test('listen and close (port only)', function(t) {
     });
 });
 
-test('listen and close (port only) w/ port number as string', function(t) {
+test(module, 'listen and close (port only) w/ port number as string', function(
+    t
+) {
     var server = restify.createServer();
     server.listen(String(0), function() {
         server.close(function() {
@@ -109,7 +111,7 @@ test('listen and close (port only) w/ port number as string', function(t) {
     });
 });
 
-test('listen and close (socketPath)', function(t) {
+test(module, 'listen and close (socketPath)', function(t) {
     var server = restify.createServer();
     server.listen('/tmp/.' + uuid.v4(), function() {
         server.close(function() {
@@ -134,7 +136,7 @@ if (!SKIP_IP_V6) {
     });
 }
 
-test('get (path only)', function(t) {
+test(module, 'get (path only)', function(t) {
     var r = SERVER.get('/foo/:id', function echoId(req, res, next) {
         t.ok(req.params);
         t.equal(req.params.id, 'bar');
@@ -164,7 +166,7 @@ test('get (path only)', function(t) {
     });
 });
 
-test('get (path only - with trailing slash)', function(t) {
+test(module, 'get (path only - with trailing slash)', function(t) {
     SERVER.get('/foo/', function echoId(req, res, next) {
         res.send();
         next();
@@ -191,7 +193,9 @@ test('get (path only - with trailing slash)', function(t) {
     });
 });
 
-test('get (path only - with trailing slash and nested route)', function(t) {
+test(module, 'get (path only - with trailing slash and nested route)', function(
+    t
+) {
     SERVER.get('/foo/', function echoId(req, res, next) {
         res.statusCode = 200;
         res.send();
@@ -243,7 +247,7 @@ test('get (path only - with trailing slash and nested route)', function(t) {
     });
 });
 
-test('use + get (path only)', function(t) {
+test(module, 'use + get (path only)', function(t) {
     SERVER.use(function(req, res, next) {
         next();
     });
@@ -261,7 +265,7 @@ test('use + get (path only)', function(t) {
     });
 });
 
-test('rm', function(t) {
+test(module, 'rm', function(t) {
     var routeName = SERVER.get('/foo/:id', function foosy(req, res, next) {
         next();
     });
@@ -287,6 +291,7 @@ test('rm', function(t) {
 });
 
 test(
+    module,
     '_routeErrorResponse does not cause uncaughtException when called when' +
         'header has already been sent',
     function(t) {
@@ -314,7 +319,7 @@ test(
     }
 );
 
-test('use - throws TypeError on non function as argument', function(t) {
+test(module, 'use - throws TypeError on non function as argument', function(t) {
     var errMsg = 'handler (function) is required';
 
     t.throws(
@@ -352,7 +357,7 @@ test('use - throws TypeError on non function as argument', function(t) {
     t.end();
 });
 
-test('405', function(t) {
+test(module, '405', function(t) {
     SERVER.post('/foo/:id', function posty(req, res, next) {
         t.ok(req.params);
         t.equal(req.params.id, 'bar');
@@ -368,7 +373,7 @@ test('405', function(t) {
     });
 });
 
-test('PUT ok', function(t) {
+test(module, 'PUT ok', function(t) {
     SERVER.put('/foo/:id', function tester(req, res, next) {
         t.ok(req.params);
         t.equal(req.params.id, 'bar');
@@ -384,7 +389,7 @@ test('PUT ok', function(t) {
     });
 });
 
-test('PATCH ok', function(t) {
+test(module, 'PATCH ok', function(t) {
     SERVER.patch('/foo/:id', function tester(req, res, next) {
         t.ok(req.params);
         t.equal(req.params.id, 'bar');
@@ -409,7 +414,7 @@ test('PATCH ok', function(t) {
     }).end();
 });
 
-test('HEAD ok', function(t) {
+test(module, 'HEAD ok', function(t) {
     SERVER.head('/foo/:id', function tester(req, res, next) {
         t.ok(req.params);
         t.equal(req.params.id, 'bar');
@@ -436,7 +441,7 @@ test('HEAD ok', function(t) {
     }).end();
 });
 
-test('DELETE ok', function(t) {
+test(module, 'DELETE ok', function(t) {
     SERVER.del('/foo/:id', function tester(req, res, next) {
         t.ok(req.params);
         t.equal(req.params.id, 'bar');
@@ -461,7 +466,7 @@ test('DELETE ok', function(t) {
     }).end();
 });
 
-test('OPTIONS', function(t) {
+test(module, 'OPTIONS', function(t) {
     ['get', 'post', 'put', 'del'].forEach(function(method) {
         SERVER[method]('/foo/:id', function tester(req, res, next) {
             t.ok(req.params);
@@ -484,7 +489,7 @@ test('OPTIONS', function(t) {
     }).end();
 });
 
-test('RegExp ok', function(t) {
+test(module, 'RegExp ok', function(t) {
     SERVER.get('/example/:file(^\\d+).png', function tester(req, res, next) {
         t.deepEqual(req.params, {
             file: '12'
@@ -501,7 +506,7 @@ test('RegExp ok', function(t) {
     });
 });
 
-test('get (path and version ok)', function(t) {
+test(module, 'get (path and version ok)', function(t) {
     SERVER.get(
         {
             url: '/foo/:id',
@@ -528,7 +533,7 @@ test('get (path and version ok)', function(t) {
     });
 });
 
-test('GH-63 res.send 204 is sending a body', function(t) {
+test(module, 'GH-63 res.send 204 is sending a body', function(t) {
     SERVER.del('/hello/:name', function tester(req, res, next) {
         res.send(204);
         next();
@@ -559,7 +564,7 @@ test('GH-63 res.send 204 is sending a body', function(t) {
     }).end();
 });
 
-test('GH-64 prerouting chain', function(t) {
+test(module, 'GH-64 prerouting chain', function(t) {
     SERVER.pre(function(req, res, next) {
         req.log.debug('testing log is set');
         req.headers.accept = 'application/json';
@@ -595,7 +600,7 @@ test('GH-64 prerouting chain', function(t) {
     }).end();
 });
 
-test('GH-64 prerouting chain with error', function(t) {
+test(module, 'GH-64 prerouting chain with error', function(t) {
     SERVER.pre(function(req, res, next) {
         next(
             new RestError(
@@ -620,7 +625,7 @@ test('GH-64 prerouting chain with error', function(t) {
     });
 });
 
-test('GH-67 extend access-control headers', function(t) {
+test(module, 'GH-67 extend access-control headers', function(t) {
     SERVER.get('/hello/:name', function tester(req, res, next) {
         res.header(
             'Access-Control-Allow-Headers',
@@ -640,7 +645,7 @@ test('GH-67 extend access-control headers', function(t) {
     });
 });
 
-test('GH-77 uncaughtException (default behavior)', function(t) {
+test(module, 'GH-77 uncaughtException (default behavior)', function(t) {
     SERVER.get('/', function(req, res, next) {
         throw new Error('Catch me!');
     });
@@ -653,44 +658,52 @@ test('GH-77 uncaughtException (default behavior)', function(t) {
 });
 
 // eslint-disable-next-line
-test('handleUncaughtExceptions should not call handler for internal errors', function(t) {
-    SERVER.get('/', function(req, res, next) {
-        // This route is not used for the test but at least one route needs to
-        // be registered to Restify in order for routing logic to be run
-        assert.fail('should not run');
-    });
+test(
+    module,
+    'handleUncaughtExceptions should not call handler for internal errors',
+    function(t) {
+        SERVER.get('/', function(req, res, next) {
+            // This route is not used for the test but at least one route needs to
+            // be registered to Restify in order for routing logic to be run
+            assert.fail('should not run');
+        });
 
-    SERVER.on('uncaughtException', function throwError(err) {
-        t.ifError(err);
-        t.end();
-    });
+        SERVER.on('uncaughtException', function throwError(err) {
+            t.ifError(err);
+            t.end();
+        });
 
-    CLIENT.head('/', function(err, _, res) {
-        t.ok(err);
-        t.equal(res.statusCode, 405);
-        t.end();
-    });
-});
+        CLIENT.head('/', function(err, _, res) {
+            t.ok(err);
+            t.equal(res.statusCode, 405);
+            t.end();
+        });
+    }
+);
 
 // eslint-disable-next-line
-test('handleUncaughtExceptions should not call handler for next(new Error())', function(t) {
-    SERVER.get('/', function(req, res, next) {
-        next(new Error('I am not fatal'));
-    });
+test(
+    module,
+    'handleUncaughtExceptions should not call handler for next(new Error())',
+    function(t) {
+        SERVER.get('/', function(req, res, next) {
+            next(new Error('I am not fatal'));
+        });
 
-    SERVER.on('uncaughtException', function throwError(err) {
-        t.ifError(err);
-        t.end();
-    });
+        SERVER.on('uncaughtException', function throwError(err) {
+            t.ifError(err);
+            t.end();
+        });
 
-    CLIENT.get('/', function(err, _, res) {
-        t.ok(err);
-        t.equal(res.statusCode, 500);
-        t.end();
-    });
-});
+        CLIENT.get('/', function(err, _, res) {
+            t.ok(err);
+            t.equal(res.statusCode, 500);
+            t.end();
+        });
+    }
+);
 
-test('GH-77 uncaughtException (with custom handler)', function(t) {
+test(module, 'GH-77 uncaughtException (with custom handler)', function(t) {
     SERVER.on('uncaughtException', function(req, res, route, err) {
         res.send(204);
     });
@@ -705,7 +718,7 @@ test('GH-77 uncaughtException (with custom handler)', function(t) {
     });
 });
 
-test('GH-180 can parse DELETE body', function(t) {
+test(module, 'GH-180 can parse DELETE body', function(t) {
     SERVER.use(restify.plugins.bodyParser({ mapParams: false }));
 
     SERVER.del('/', function(req, res, next) {
@@ -739,7 +752,7 @@ test('GH-180 can parse DELETE body', function(t) {
     }).end('{"param1": 1234}');
 });
 
-test('returning error from a handler (with domains)', function(t) {
+test(module, 'returning error from a handler (with domains)', function(t) {
     SERVER.get('/', function(req, res, next) {
         next(new errors.InternalError('bah!'));
     });
@@ -751,7 +764,7 @@ test('returning error from a handler (with domains)', function(t) {
     });
 });
 
-test('emitting error from a handler (with domains)', function(t) {
+test(module, 'emitting error from a handler (with domains)', function(t) {
     SERVER.get('/', function(req, res, next) {
         req.emit('error', new Error('bah!'));
     });
@@ -763,7 +776,7 @@ test('emitting error from a handler (with domains)', function(t) {
     });
 });
 
-test('re-emitting redirect from a response', function(t) {
+test(module, 're-emitting redirect from a response', function(t) {
     var redirectLocation;
 
     SERVER.on('redirect', function(payload) {
@@ -780,7 +793,7 @@ test('re-emitting redirect from a response', function(t) {
     });
 });
 
-test('throwing error from a handler (with domains)', function(t) {
+test(module, 'throwing error from a handler (with domains)', function(t) {
     SERVER.get('/', function(req, res, next) {
         process.nextTick(function() {
             throw new Error('bah!');
@@ -794,7 +807,7 @@ test('throwing error from a handler (with domains)', function(t) {
     });
 });
 
-test('gh-278 missing router error events (404)', function(t) {
+test(module, 'gh-278 missing router error events (404)', function(t) {
     SERVER.once('NotFound', function(req, res) {
         res.send(404, 'foo');
     });
@@ -807,7 +820,7 @@ test('gh-278 missing router error events (404)', function(t) {
     });
 });
 
-test('gh-278 missing router error events (405)', function(t) {
+test(module, 'gh-278 missing router error events (405)', function(t) {
     var p = '/' + uuid.v4();
     SERVER.post(p, function(req, res, next) {
         res.send(201);
@@ -825,7 +838,7 @@ test('gh-278 missing router error events (405)', function(t) {
     });
 });
 
-test('gh-329 wrong values in res.methods', function(t) {
+test(module, 'gh-329 wrong values in res.methods', function(t) {
     function route(req, res, next) {
         res.send(200);
         next();
@@ -849,7 +862,7 @@ test('gh-329 wrong values in res.methods', function(t) {
     });
 });
 
-test('GH #704: Route with a valid RegExp params', function(t) {
+test(module, 'GH #704: Route with a valid RegExp params', function(t) {
     SERVER.get(
         {
             name: 'regexp_param1',
@@ -869,7 +882,7 @@ test('GH #704: Route with a valid RegExp params', function(t) {
     });
 });
 
-test('GH #704: Route with an invalid RegExp params', function(t) {
+test(module, 'GH #704: Route with an invalid RegExp params', function(t) {
     SERVER.get(
         {
             name: 'regexp_param2',
@@ -889,7 +902,7 @@ test('GH #704: Route with an invalid RegExp params', function(t) {
     });
 });
 
-test('run param only with existing req.params', function(t) {
+test(module, 'run param only with existing req.params', function(t) {
     var count = 0;
 
     SERVER.param('name', function(req, res, next) {
@@ -914,7 +927,7 @@ test('run param only with existing req.params', function(t) {
     });
 });
 
-test('run param only with existing req.params', function(t) {
+test(module, 'run param only with existing req.params', function(t) {
     var count = 0;
 
     SERVER.param('name', function(req, res, next) {
@@ -941,7 +954,7 @@ test('run param only with existing req.params', function(t) {
     });
 });
 
-test('next("string") returns InternalServer', function(t) {
+test(module, 'next("string") returns InternalServer', function(t) {
     var count = 0;
 
     SERVER.use(function(req, res, next) {
@@ -968,34 +981,38 @@ test('next("string") returns InternalServer', function(t) {
     });
 });
 
-test('next("string") from a use plugin returns InternalServer', function(t) {
-    var count = 0;
+test(
+    module,
+    'next("string") from a use plugin returns InternalServer',
+    function(t) {
+        var count = 0;
 
-    SERVER.use(function plugin(req, res, next) {
-        count++;
-        next('bar');
-    });
+        SERVER.use(function plugin(req, res, next) {
+            count++;
+            next('bar');
+        });
 
-    SERVER.get(
-        {
-            name: 'foo',
-            path: '/foo'
-        },
-        function getFoo(req, res, next) {
-            res.send(200);
-            next();
-        }
-    );
+        SERVER.get(
+            {
+                name: 'foo',
+                path: '/foo'
+            },
+            function getFoo(req, res, next) {
+                res.send(200);
+                next();
+            }
+        );
 
-    CLIENT.get('/foo', function(err, _, res) {
-        t.ok(err);
-        t.equal(res.statusCode, 500);
-        t.equal(count, 1);
-        t.end();
-    });
-});
+        CLIENT.get('/foo', function(err, _, res) {
+            t.ok(err);
+            t.equal(res.statusCode, 500);
+            t.equal(count, 1);
+            t.end();
+        });
+    }
+);
 
-test('res.charSet', function(t) {
+test(module, 'res.charSet', function(t) {
     SERVER.get('/foo', function getFoo(req, res, next) {
         res.charSet('ISO-8859-1');
         res.set('Content-Type', 'text/plain');
@@ -1012,7 +1029,7 @@ test('res.charSet', function(t) {
     });
 });
 
-test('res.charSet override', function(t) {
+test(module, 'res.charSet override', function(t) {
     SERVER.get('/foo', function getFoo(req, res, next) {
         res.charSet('ISO-8859-1');
         res.set('Content-Type', 'text/plain;charset=utf-8');
@@ -1029,7 +1046,7 @@ test('res.charSet override', function(t) {
     });
 });
 
-test('GH-384 res.json(200, {}) broken', function(t) {
+test(module, 'GH-384 res.json(200, {}) broken', function(t) {
     SERVER.get('/foo', function(req, res, next) {
         res.json(200, { foo: 'bar' });
         next();
@@ -1044,7 +1061,7 @@ test('GH-384 res.json(200, {}) broken', function(t) {
     });
 });
 
-test('explicitly sending a 403 with custom error', function(t) {
+test(module, 'explicitly sending a 403 with custom error', function(t) {
     function MyCustomError() {}
 
     MyCustomError.prototype = Object.create(Error.prototype);
@@ -1060,7 +1077,7 @@ test('explicitly sending a 403 with custom error', function(t) {
     });
 });
 
-test('explicitly sending a 403 on error', function(t) {
+test(module, 'explicitly sending a 403 on error', function(t) {
     SERVER.get('/', function(req, res, next) {
         res.send(403, new Error('bah!'));
     });
@@ -1072,7 +1089,7 @@ test('explicitly sending a 403 on error', function(t) {
     });
 });
 
-test('fire event on error', function(t) {
+test(module, 'fire event on error', function(t) {
     SERVER.once('InternalServer', function(req, res, err, cb) {
         t.ok(req);
         t.ok(res);
@@ -1094,7 +1111,7 @@ test('fire event on error', function(t) {
     });
 });
 
-test('error handler defers "after" event', async function(t) {
+test(module, 'error handler defers "after" event', async function(t) {
     let afterResolve;
     let clientResolve;
     t.expect(9);
@@ -1135,33 +1152,37 @@ test('error handler defers "after" event', async function(t) {
 });
 
 // eslint-disable-next-line
-test('gh-757 req.absoluteUri() defaults path segment to req.path()', function(t) {
-    SERVER.get('/the-original-path', function(req, res, next) {
-        var prefix = 'http://127.0.0.1:' + PORT;
-        t.equal(
-            req.absoluteUri('?key=value'),
-            prefix + '/the-original-path/?key=value'
-        );
-        t.equal(
-            req.absoluteUri('#fragment'),
-            prefix + '/the-original-path/#fragment'
-        );
-        t.equal(
-            req.absoluteUri('?key=value#fragment'),
-            prefix + '/the-original-path/?key=value#fragment'
-        );
-        res.send();
-        next();
-    });
+test(
+    module,
+    'gh-757 req.absoluteUri() defaults path segment to req.path()',
+    function(t) {
+        SERVER.get('/the-original-path', function(req, res, next) {
+            var prefix = 'http://127.0.0.1:' + PORT;
+            t.equal(
+                req.absoluteUri('?key=value'),
+                prefix + '/the-original-path/?key=value'
+            );
+            t.equal(
+                req.absoluteUri('#fragment'),
+                prefix + '/the-original-path/#fragment'
+            );
+            t.equal(
+                req.absoluteUri('?key=value#fragment'),
+                prefix + '/the-original-path/?key=value#fragment'
+            );
+            res.send();
+            next();
+        });
 
-    CLIENT.get('/the-original-path', function(err, _, res) {
-        t.ifError(err);
-        t.equal(res.statusCode, 200);
-        t.end();
-    });
-});
+        CLIENT.get('/the-original-path', function(err, _, res) {
+            t.ifError(err);
+            t.equal(res.statusCode, 200);
+            t.end();
+        });
+    }
+);
 
-test('GH-693 sending multiple response header values', function(t) {
+test(module, 'GH-693 sending multiple response header values', function(t) {
     SERVER.get('/', function(req, res, next) {
         res.link('/', 'self');
         res.link('/foo', 'foo');
@@ -1176,7 +1197,7 @@ test('GH-693 sending multiple response header values', function(t) {
     });
 });
 
-test('gh-762 res.noCache()', function(t) {
+test(module, 'gh-762 res.noCache()', function(t) {
     SERVER.get('/some-path', function(req, res, next) {
         res.noCache();
         res.send('data');
@@ -1193,7 +1214,7 @@ test('gh-762 res.noCache()', function(t) {
     });
 });
 
-test('gh-779 set-cookie fields should never have commas', function(t) {
+test(module, 'gh-779 set-cookie fields should never have commas', function(t) {
     SERVER.get('/set-cookie', function(req, res, next) {
         res.header('set-cookie', 'foo');
         res.header('set-cookie', 'bar');
@@ -1216,6 +1237,7 @@ test('gh-779 set-cookie fields should never have commas', function(t) {
 });
 
 test(
+    module,
     'gh-986 content-type fields should never have commas' +
         ' (via `res.header(...)`)',
     function(t) {
@@ -1239,6 +1261,7 @@ test(
 );
 
 test(
+    module,
     'gh-986 content-type fields should never have commas' +
         ' (via `res.setHeader(...)`)',
     function(t) {
@@ -1261,7 +1284,7 @@ test(
     }
 );
 
-test('GH-877 content-type should be case insensitive', function(t) {
+test(module, 'GH-877 content-type should be case insensitive', function(t) {
     SERVER.use(restify.plugins.bodyParser({ maxBodySize: 1024 }));
 
     SERVER.get('/cl', function(req, res, next) {
@@ -1289,7 +1312,7 @@ test('GH-877 content-type should be case insensitive', function(t) {
     client.end();
 });
 
-test('GH-882: route name is same as specified', function(t) {
+test(module, 'GH-882: route name is same as specified', function(t) {
     SERVER.get(
         {
             name: 'my-r$-%-x',
@@ -1308,6 +1331,7 @@ test('GH-882: route name is same as specified', function(t) {
 });
 
 test(
+    module,
     'GH-733 if request closed early, stop processing. ensure only ' +
         'relevant audit logs output.',
     function(t) {
@@ -1404,7 +1428,7 @@ test(
     }
 );
 
-test('GH-667 emit error event for generic Errors', function(t) {
+test(module, 'GH-667 emit error event for generic Errors', function(t) {
     var restifyErrorFired = 0;
     var notFoundFired = 0;
     var myErr = new errors.NotFoundError('foobar');
@@ -1463,25 +1487,29 @@ test('GH-667 emit error event for generic Errors', function(t) {
 });
 
 // eslint-disable-next-line
-test('GH-667 returning error in error handler should not do anything', function(t) {
-    SERVER.on('ImATeapot', function(req, res, err, cb) {
-        // attempt to pass a new error back
-        return cb(new errors.LockedError('oh noes'));
-    });
+test(
+    module,
+    'GH-667 returning error in error handler should not do anything',
+    function(t) {
+        SERVER.on('ImATeapot', function(req, res, err, cb) {
+            // attempt to pass a new error back
+            return cb(new errors.LockedError('oh noes'));
+        });
 
-    SERVER.get('/1', function(req, res, next) {
-        return next(new errors.ImATeapotError('foobar'));
-    });
+        SERVER.get('/1', function(req, res, next) {
+            return next(new errors.ImATeapotError('foobar'));
+        });
 
-    CLIENT.get('/1', function(err, req, res, data) {
-        t.ok(err);
-        // should still get the original error
-        t.equal(err.name, 'ImATeapotError');
-        t.end();
-    });
-});
+        CLIENT.get('/1', function(err, req, res, data) {
+            t.ok(err);
+            // should still get the original error
+            t.equal(err.name, 'ImATeapotError');
+            t.end();
+        });
+    }
+);
 
-test('GH-1024 disable uncaughtException handler', function(t) {
+test(module, 'GH-1024 disable uncaughtException handler', function(t) {
     // With uncaughtException handling disabled, the node process will abort,
     // so testing of this feature must occur in a separate node process.
 
@@ -1527,7 +1555,7 @@ test('GH-1024 disable uncaughtException handler', function(t) {
     serverProc.send({ task: 'serverPortRequest' });
 });
 
-test('GH-999 Custom 404 handler does not send response', function(t) {
+test(module, 'GH-999 Custom 404 handler does not send response', function(t) {
     // make the 404 handler act like other error handlers - must modify
     // err.body to send a custom response.
 
@@ -1550,78 +1578,90 @@ test('GH-999 Custom 404 handler does not send response', function(t) {
     });
 });
 
-test('calling next(false) should early exit from pre handlers', function(t) {
-    var afterFired = false;
+test(
+    module,
+    'calling next(false) should early exit from pre handlers',
+    function(t) {
+        var afterFired = false;
 
-    SERVER.pre(function(req, res, next) {
-        res.send('early exit');
-        return next(false);
-    });
+        SERVER.pre(function(req, res, next) {
+            res.send('early exit');
+            return next(false);
+        });
 
-    SERVER.get('/1', function(req, res, next) {
-        res.send('hello world');
-        return next();
-    });
+        SERVER.get('/1', function(req, res, next) {
+            res.send('hello world');
+            return next();
+        });
 
-    SERVER.on('after', function() {
-        afterFired = true;
-    });
+        SERVER.on('after', function() {
+            afterFired = true;
+        });
 
-    CLIENT.get('/1', function(err, req, res, data) {
-        t.ifError(err);
-        t.equal(data, 'early exit');
-        // ensure after event fired
-        t.ok(afterFired);
-        t.end();
-    });
-});
+        CLIENT.get('/1', function(err, req, res, data) {
+            t.ifError(err);
+            t.equal(data, 'early exit');
+            // ensure after event fired
+            t.ok(afterFired);
+            t.end();
+        });
+    }
+);
 
-test('calling next(false) should early exit from use handlers', function(t) {
-    var steps = 0;
+test(
+    module,
+    'calling next(false) should early exit from use handlers',
+    function(t) {
+        var steps = 0;
 
-    SERVER.use(function(req, res, next) {
-        res.send('early exit');
-        return next(false);
-    });
+        SERVER.use(function(req, res, next) {
+            res.send('early exit');
+            return next(false);
+        });
 
-    SERVER.get('/1', function(req, res, next) {
-        res.send('hello world');
-        return next();
-    });
+        SERVER.get('/1', function(req, res, next) {
+            res.send('hello world');
+            return next();
+        });
 
-    SERVER.on('after', function() {
-        steps++;
-        t.equal(steps, 1);
-        t.end();
-    });
+        SERVER.on('after', function() {
+            steps++;
+            t.equal(steps, 1);
+            t.end();
+        });
 
-    CLIENT.get('/1', function(err, req, res, data) {
-        t.ifError(err);
-        t.equal(data, 'early exit');
-        steps++;
-    });
-});
+        CLIENT.get('/1', function(err, req, res, data) {
+            t.ifError(err);
+            t.equal(data, 'early exit');
+            steps++;
+        });
+    }
+);
 
-test('calling next(err) from pre should still emit after event', function(t) {
-    setTimeout(function() {
-        t.fail('Timed out');
-        t.end();
-    }, 2000);
-    var error = new Error();
-    SERVER.pre(function(req, res, next) {
-        next(error);
-    });
-    SERVER.get('/', function(req, res, next) {
-        t.fail('should have aborted stack before routing');
-    });
-    SERVER.on('after', function(req, res, route, err) {
-        t.equal(err, error);
-        t.end();
-    });
-    CLIENT.get('/', function() {});
-});
+test(
+    module,
+    'calling next(err) from pre should still emit after event',
+    function(t) {
+        setTimeout(function() {
+            t.fail('Timed out');
+            t.end();
+        }, 2000);
+        var error = new Error();
+        SERVER.pre(function(req, res, next) {
+            next(error);
+        });
+        SERVER.get('/', function(req, res, next) {
+            t.fail('should have aborted stack before routing');
+        });
+        SERVER.on('after', function(req, res, route, err) {
+            t.equal(err, error);
+            t.end();
+        });
+        CLIENT.get('/', function() {});
+    }
+);
 
-test('GH-1078: server name should default to restify', function(t) {
+test(module, 'GH-1078: server name should default to restify', function(t) {
     var myServer = restify.createServer();
     var port = 3000;
 
@@ -1646,7 +1686,7 @@ test('GH-1078: server name should default to restify', function(t) {
     });
 });
 
-test('GH-1078: server name should be customizable', function(t) {
+test(module, 'GH-1078: server name should be customizable', function(t) {
     var myServer = restify.createServer({
         name: 'foo'
     });
@@ -1674,34 +1714,38 @@ test('GH-1078: server name should be customizable', function(t) {
 });
 
 // eslint-disable-next-line
-test('GH-1078: server name should be overridable and not sent down', function(t) {
-    var myServer = restify.createServer({
-        name: ''
-    });
-    var port = 3000;
-
-    myServer.get('/', function(req, res, next) {
-        res.send('hi');
-        return next();
-    });
-
-    var myClient = restifyClients.createStringClient({
-        url: 'http://127.0.0.1:' + port,
-        headers: {
-            connection: 'close'
-        }
-    });
-
-    myServer.listen(port, function() {
-        myClient.get('/', function(err, req, res, data) {
-            t.ifError(err);
-            t.equal(res.headers.hasOwnProperty('server'), false);
-            myServer.close(t.end);
+test(
+    module,
+    'GH-1078: server name should be overridable and not sent down',
+    function(t) {
+        var myServer = restify.createServer({
+            name: ''
         });
-    });
-});
+        var port = 3000;
 
-test("should emit 'after' on successful request", function(t) {
+        myServer.get('/', function(req, res, next) {
+            res.send('hi');
+            return next();
+        });
+
+        var myClient = restifyClients.createStringClient({
+            url: 'http://127.0.0.1:' + port,
+            headers: {
+                connection: 'close'
+            }
+        });
+
+        myServer.listen(port, function() {
+            myClient.get('/', function(err, req, res, data) {
+                t.ifError(err);
+                t.equal(res.headers.hasOwnProperty('server'), false);
+                myServer.close(t.end);
+            });
+        });
+    }
+);
+
+test(module, "should emit 'after' on successful request", function(t) {
     SERVER.on('after', function(req, res, route, err) {
         t.ifError(err);
         t.end();
@@ -1718,7 +1762,9 @@ test("should emit 'after' on successful request", function(t) {
     });
 });
 
-test("should emit 'after' on successful request with work", function(t) {
+test(module, "should emit 'after' on successful request with work", function(
+    t
+) {
     SERVER.on('after', function(req, res, route, err) {
         t.ifError(err);
         t.end();
@@ -1741,7 +1787,7 @@ test("should emit 'after' on successful request with work", function(t) {
     });
 });
 
-test("should emit 'after' on errored request", function(t) {
+test(module, "should emit 'after' on errored request", function(t) {
     SERVER.on('after', function(req, res, route, err) {
         t.ok(err);
         t.end();
@@ -1757,7 +1803,7 @@ test("should emit 'after' on errored request", function(t) {
     });
 });
 
-test("should emit 'after' on uncaughtException", function(t) {
+test(module, "should emit 'after' on uncaughtException", function(t) {
     SERVER.on('after', function(req, res, route, err) {
         t.ok(err);
         t.equal(err.message, 'oh noes');
@@ -1774,28 +1820,33 @@ test("should emit 'after' on uncaughtException", function(t) {
     });
 });
 
-test("should emit 'after' when sending res on uncaughtException", function(t) {
-    SERVER.on('after', function(req, res, route, err) {
-        t.ok(err);
-        t.equal(err.message, 'oh noes');
-    });
+test(
+    module,
+    "should emit 'after' when sending res on uncaughtException",
+    function(t) {
+        SERVER.on('after', function(req, res, route, err) {
+            t.ok(err);
+            t.equal(err.message, 'oh noes');
+        });
 
-    SERVER.on('uncaughtException', function(req, res, route, err) {
-        res.send(504, 'boom');
-    });
+        SERVER.on('uncaughtException', function(req, res, route, err) {
+            res.send(504, 'boom');
+        });
 
-    SERVER.get('/foobar', function(req, res, next) {
-        throw new Error('oh noes');
-    });
+        SERVER.get('/foobar', function(req, res, next) {
+            throw new Error('oh noes');
+        });
 
-    CLIENT.get('/foobar', function(err, _, res) {
-        t.ok(err);
-        t.equal(err.name, 'GatewayTimeoutError');
-        t.end();
-    });
-});
+        CLIENT.get('/foobar', function(err, _, res) {
+            t.ok(err);
+            t.equal(err.name, 'GatewayTimeoutError');
+            t.end();
+        });
+    }
+);
 
 test(
+    module,
     "should emit 'after' on client closed request " +
         "(req.connectionState(): 'close')",
     function(t) {
@@ -1826,48 +1877,58 @@ test(
 // specifically tests the edge case of an exception being thrown from a route
 // handler _after_ the response is considered to be "flushed" (for instance when
 // the request is aborted before a response is sent and an exception is thrown).
-// eslint-disable-next-line max-len
-test("should emit 'after' on uncaughtException after response closed with custom uncaughtException listener", function(t) {
-    var ERR_MSG = 'foo';
-    var gotAfter = false;
-    var gotReqCallback = false;
+test(
+    module,
+    // eslint-disable-next-line max-len
+    "should emit 'after' on uncaughtException after response closed with custom uncaughtException listener",
+    function(t) {
+        var ERR_MSG = 'foo';
+        var gotAfter = false;
+        var gotReqCallback = false;
 
-    SERVER.on('after', function(req, res, route, err) {
-        gotAfter = true;
-        t.ok(err);
-        t.equal(req.connectionState(), 'close');
-        t.equal(res.statusCode, 444);
-        t.equal(err.name, 'Error');
-        t.equal(err.message, ERR_MSG);
-        if (gotReqCallback) {
-            t.end();
-        }
-    });
-
-    SERVER.on('uncaughtException', function(req, res, route, err, callback) {
-        callback();
-    });
-
-    SERVER.get('/foobar', function(req, res, next) {
-        res.on('close', function onResClose() {
-            // We throw this error in the response's close event handler on
-            // purpose to exercise the code path where we mark the route
-            // handlers as finished _after_ the response is marked as flushed.
-            throw new Error(ERR_MSG);
+        SERVER.on('after', function(req, res, route, err) {
+            gotAfter = true;
+            t.ok(err);
+            t.equal(req.connectionState(), 'close');
+            t.equal(res.statusCode, 444);
+            t.equal(err.name, 'Error');
+            t.equal(err.message, ERR_MSG);
+            if (gotReqCallback) {
+                t.end();
+            }
         });
-    });
 
-    FAST_CLIENT.get('/foobar', function(err, _, res) {
-        gotReqCallback = true;
-        t.ok(err);
-        t.equal(err.name, 'RequestTimeoutError');
-        if (gotAfter) {
-            t.end();
-        }
-    });
-});
+        SERVER.on('uncaughtException', function(
+            req,
+            res,
+            route,
+            err,
+            callback
+        ) {
+            callback();
+        });
 
-test('should increment/decrement inflight request count', function(t) {
+        SERVER.get('/foobar', function(req, res, next) {
+            res.on('close', function onResClose() {
+                // We throw this error in the response's close event handler on
+                // purpose to exercise the code path where we mark the route
+                // handlers as finished _after_ the response is marked as flushed.
+                throw new Error(ERR_MSG);
+            });
+        });
+
+        FAST_CLIENT.get('/foobar', function(err, _, res) {
+            gotReqCallback = true;
+            t.ok(err);
+            t.equal(err.name, 'RequestTimeoutError');
+            if (gotAfter) {
+                t.end();
+            }
+        });
+    }
+);
+
+test(module, 'should increment/decrement inflight request count', function(t) {
     SERVER.get('/foo', function(req, res, next) {
         t.equal(SERVER.inflightRequests(), 1);
         res.send();
@@ -1887,37 +1948,41 @@ test('should increment/decrement inflight request count', function(t) {
 });
 
 // eslint-disable-next-line
-test('should increment/decrement inflight request count for concurrent reqs', function(t) {
-    SERVER.get('/foo1', function(req, res, next) {
-        // other request is already sent
-        t.equal(SERVER.inflightRequests() >= 1, true);
-        setTimeout(function() {
+test(
+    module,
+    'should increment/decrement inflight request count for concurrent reqs',
+    function(t) {
+        SERVER.get('/foo1', function(req, res, next) {
+            // other request is already sent
+            t.equal(SERVER.inflightRequests() >= 1, true);
+            setTimeout(function() {
+                res.send();
+                return next();
+            }, 250);
+        });
+
+        SERVER.get('/foo2', function(req, res, next) {
+            t.equal(SERVER.inflightRequests(), 2);
             res.send();
             return next();
-        }, 250);
-    });
+        });
 
-    SERVER.get('/foo2', function(req, res, next) {
-        t.equal(SERVER.inflightRequests(), 2);
-        res.send();
-        return next();
-    });
+        CLIENT.get('/foo1', function(err, _, res) {
+            t.ifError(err);
+            t.equal(res.statusCode, 200);
+            t.equal(SERVER.inflightRequests(), 0);
+            t.end();
+        });
 
-    CLIENT.get('/foo1', function(err, _, res) {
-        t.ifError(err);
-        t.equal(res.statusCode, 200);
-        t.equal(SERVER.inflightRequests(), 0);
-        t.end();
-    });
+        CLIENT.get('/foo2', function(err, _, res) {
+            t.ifError(err);
+            t.equal(res.statusCode, 200);
+            t.equal(SERVER.inflightRequests(), 1);
+        });
+    }
+);
 
-    CLIENT.get('/foo2', function(err, _, res) {
-        t.ifError(err);
-        t.equal(res.statusCode, 200);
-        t.equal(SERVER.inflightRequests(), 1);
-    });
-});
-
-test("should emit 'close' on server close", function(t) {
+test(module, "should emit 'close' on server close", function(t) {
     var server = restify.createServer();
 
     server.listen(PORT + 1, '127.0.0.1', function() {
@@ -1928,7 +1993,9 @@ test("should emit 'close' on server close", function(t) {
     });
 });
 
-test('should cleanup inflight requests count for 404s', async function(t) {
+test(module, 'should cleanup inflight requests count for 404s', async function(
+    t
+) {
     let afterResolve;
     let clientResolve;
     SERVER.get('/foo1', function(req, res, next) {
@@ -1968,7 +2035,9 @@ test('should cleanup inflight requests count for 404s', async function(t) {
     t.end();
 });
 
-test('should cleanup inflight requests count for timeouts', function(t) {
+test(module, 'should cleanup inflight requests count for timeouts', function(
+    t
+) {
     t.equal(SERVER.inflightRequests(), 0);
 
     SERVER.get('/foo1', function(req, res, next) {
@@ -2008,24 +2077,28 @@ test('should cleanup inflight requests count for timeouts', function(t) {
 });
 
 // eslint-disable-next-line
-test('should cleanup inflight requests count on uncaughtExceptions', function(t) {
-    SERVER.on('uncaughtException', function(req, res, route, err) {
-        res.send(500, 'asplode');
-    });
+test(
+    module,
+    'should cleanup inflight requests count on uncaughtExceptions',
+    function(t) {
+        SERVER.on('uncaughtException', function(req, res, route, err) {
+            res.send(500, 'asplode');
+        });
 
-    SERVER.get('/foo1', function(req, res, next) {
-        t.equal(SERVER.inflightRequests(), 1);
-        throw new Error('oh noes');
-    });
+        SERVER.get('/foo1', function(req, res, next) {
+            t.equal(SERVER.inflightRequests(), 1);
+            throw new Error('oh noes');
+        });
 
-    CLIENT.get('/foo1', function(err, _, res) {
-        t.ok(err);
-        t.equal(SERVER.inflightRequests(), 0);
-        t.end();
-    });
-});
+        CLIENT.get('/foo1', function(err, _, res) {
+            t.ok(err);
+            t.equal(SERVER.inflightRequests(), 0);
+            t.end();
+        });
+    }
+);
 
-test('should show debug information', function(t) {
+test(module, 'should show debug information', function(t) {
     SERVER.pre(function pre(req, res, next) {
         return next();
     });
@@ -2126,7 +2199,7 @@ test('should show debug information', function(t) {
     t.end();
 });
 
-test("should emit 'pre' event on a 200", function(t) {
+test(module, "should emit 'pre' event on a 200", function(t) {
     SERVER.get('/foo/:id', function echoId(req, res, next) {
         t.ok(req.params);
         t.equal(req.params.id, 'bar');
@@ -2147,7 +2220,7 @@ test("should emit 'pre' event on a 200", function(t) {
     });
 });
 
-test("should emit 'pre' event on 404", function(t) {
+test(module, "should emit 'pre' event on 404", function(t) {
     SERVER.get('/foo/:id', function echoId(req, res, next) {
         t.ok(req.params);
         t.equal(req.params.id, 'bar');
@@ -2168,7 +2241,7 @@ test("should emit 'pre' event on 404", function(t) {
     });
 });
 
-test("should emit 'routed' event on a 200", function(t) {
+test(module, "should emit 'routed' event on a 200", function(t) {
     SERVER.get('/foo/:id', function echoId(req, res, next) {
         t.ok(req.params);
         t.equal(req.params.id, 'bar');
@@ -2190,7 +2263,7 @@ test("should emit 'routed' event on a 200", function(t) {
     });
 });
 
-test("should not emit 'routed' event on 404", function(t) {
+test(module, "should not emit 'routed' event on 404", function(t) {
     SERVER.get('/foo/:id', function echoId(req, res, next) {
         t.ok(req.params);
         t.equal(req.params.id, 'bar');
@@ -2210,7 +2283,7 @@ test("should not emit 'routed' event on 404", function(t) {
     });
 });
 
-test('should emit restifyError even for router errors', function(t) {
+test(module, 'should emit restifyError even for router errors', function(t) {
     var notFoundFired = false;
     var restifyErrFired = false;
 
@@ -2240,48 +2313,53 @@ test('should emit restifyError even for router errors', function(t) {
     });
 });
 
-test('should emit error with multiple next calls with strictNext', function(t) {
-    var server = restify.createServer({
-        dtrace: helper.dtrace,
-        strictNext: true,
-        handleUncaughtExceptions: true,
-        log: helper.getLog('server')
-    });
-    var client;
-    var port;
-
-    server.listen(PORT + 1, '127.0.0.1', function() {
-        port = server.address().port;
-        client = restifyClients.createJsonClient({
-            url: 'http://127.0.0.1:' + port,
+test(
+    module,
+    'should emit error with multiple next calls with strictNext',
+    function(t) {
+        var server = restify.createServer({
             dtrace: helper.dtrace,
-            retry: false
+            strictNext: true,
+            handleUncaughtExceptions: true,
+            log: helper.getLog('server')
         });
+        var client;
+        var port;
 
-        server.get('/strict-next', function(req, res, next) {
-            next();
-            next();
-        });
+        server.listen(PORT + 1, '127.0.0.1', function() {
+            port = server.address().port;
+            client = restifyClients.createJsonClient({
+                url: 'http://127.0.0.1:' + port,
+                dtrace: helper.dtrace,
+                retry: false
+            });
 
-        server.on('uncaughtException', function(req, res, route, err) {
-            t.ok(err);
-            t.equal(err.message, "next shouldn't be called more than once");
-            res.send(err);
-        });
+            server.get('/strict-next', function(req, res, next) {
+                next();
+                next();
+            });
 
-        client.get('/strict-next', function(err, _, res) {
-            t.ok(err);
-            t.equal(res.statusCode, 500);
+            server.on('uncaughtException', function(req, res, route, err) {
+                t.ok(err);
+                t.equal(err.message, "next shouldn't be called more than once");
+                res.send(err);
+            });
 
-            client.close();
-            server.close(function() {
-                t.end();
+            client.get('/strict-next', function(err, _, res) {
+                t.ok(err);
+                t.equal(res.statusCode, 500);
+
+                client.close();
+                server.close(function() {
+                    t.end();
+                });
             });
         });
-    });
-});
+    }
+);
 
 test(
+    module,
     'should send 500 if we reached the end of handler chain w/o sending ' +
         'headers',
     function(t) {
@@ -2323,37 +2401,41 @@ test(
     }
 );
 
-test('uncaughtException should not trigger named routeHandler', function(t) {
-    SERVER.get(
-        {
-            name: 'foo',
-            path: '/foo'
-        },
-        function(req, res, next) {
-            throw 'bar'; //eslint-disable-line no-throw-literal
-        }
-    );
+test(
+    module,
+    'uncaughtException should not trigger named routeHandler',
+    function(t) {
+        SERVER.get(
+            {
+                name: 'foo',
+                path: '/foo'
+            },
+            function(req, res, next) {
+                throw 'bar'; //eslint-disable-line no-throw-literal
+            }
+        );
 
-    SERVER.get(
-        {
-            name: 'bar',
-            path: '/bar'
-        },
-        function(req, res, next) {
-            // This code should not run, but we can test against the status code
-            res.send(200);
-            next();
-        }
-    );
+        SERVER.get(
+            {
+                name: 'bar',
+                path: '/bar'
+            },
+            function(req, res, next) {
+                // This code should not run, but we can test against the status code
+                res.send(200);
+                next();
+            }
+        );
 
-    CLIENT.get('/foo', function(err, _, res) {
-        t.ok(err);
-        t.equal(res.statusCode, 500);
-        t.end();
-    });
-});
+        CLIENT.get('/foo', function(err, _, res) {
+            t.ok(err);
+            t.equal(res.statusCode, 500);
+            t.end();
+        });
+    }
+);
 
-test('uncaughtException should handle thrown null', function(t) {
+test(module, 'uncaughtException should handle thrown null', function(t) {
     SERVER.get(
         {
             name: 'foo',
@@ -2384,38 +2466,44 @@ test('uncaughtException should handle thrown null', function(t) {
     });
 });
 
-test('uncaughtException should handle thrown undefined literal', function(t) {
-    SERVER.get(
-        {
-            name: 'foo',
-            path: '/foo'
-        },
-        function(req, res, next) {
-            throw undefined; //eslint-disable-line no-throw-literal
-        }
-    );
+test(
+    module,
+    'uncaughtException should handle thrown undefined literal',
+    function(t) {
+        SERVER.get(
+            {
+                name: 'foo',
+                path: '/foo'
+            },
+            function(req, res, next) {
+                throw undefined; //eslint-disable-line no-throw-literal
+            }
+        );
 
-    SERVER.get(
-        {
-            name: 'bar',
-            path: '/bar'
-        },
-        function(req, res, next) {
-            // This code should not run, but we can test against the status code
-            res.send(200);
-            next();
-        }
-    );
+        SERVER.get(
+            {
+                name: 'bar',
+                path: '/bar'
+            },
+            function(req, res, next) {
+                // This code should not run, but we can test against the status code
+                res.send(200);
+                next();
+            }
+        );
 
-    CLIENT.get('/foo', function(err, _, res, data) {
-        t.ok(err);
-        t.equal(res.statusCode, 500);
-        t.equal(data.message, 'undefined');
-        t.end();
-    });
-});
+        CLIENT.get('/foo', function(err, _, res, data) {
+            t.ok(err);
+            t.equal(res.statusCode, 500);
+            t.equal(data.message, 'undefined');
+            t.end();
+        });
+    }
+);
 
-test('uncaughtException should handle thrown falsy number', function(t) {
+test(module, 'uncaughtException should handle thrown falsy number', function(
+    t
+) {
     SERVER.get(
         {
             name: 'foo',
@@ -2446,38 +2534,42 @@ test('uncaughtException should handle thrown falsy number', function(t) {
     });
 });
 
-test('uncaughtException should handle thrown non falsy number', function(t) {
-    SERVER.get(
-        {
-            name: 'foo',
-            path: '/foo'
-        },
-        function(req, res, next) {
-            throw 1; //eslint-disable-line no-throw-literal
-        }
-    );
+test(
+    module,
+    'uncaughtException should handle thrown non falsy number',
+    function(t) {
+        SERVER.get(
+            {
+                name: 'foo',
+                path: '/foo'
+            },
+            function(req, res, next) {
+                throw 1; //eslint-disable-line no-throw-literal
+            }
+        );
 
-    SERVER.get(
-        {
-            name: 'bar',
-            path: '/bar'
-        },
-        function(req, res, next) {
-            // This code should not run, but we can test against the status code
-            res.send(200);
-            next();
-        }
-    );
+        SERVER.get(
+            {
+                name: 'bar',
+                path: '/bar'
+            },
+            function(req, res, next) {
+                // This code should not run, but we can test against the status code
+                res.send(200);
+                next();
+            }
+        );
 
-    CLIENT.get('/foo', function(err, _, res, data) {
-        t.ok(err);
-        t.equal(data.message, '1');
-        t.equal(res.statusCode, 500);
-        t.end();
-    });
-});
+        CLIENT.get('/foo', function(err, _, res, data) {
+            t.ok(err);
+            t.equal(data.message, '1');
+            t.equal(res.statusCode, 500);
+            t.end();
+        });
+    }
+);
 
-test('uncaughtException should handle thrown boolean', function(t) {
+test(module, 'uncaughtException should handle thrown boolean', function(t) {
     SERVER.get(
         {
             name: 'foo',
@@ -2508,7 +2600,9 @@ test('uncaughtException should handle thrown boolean', function(t) {
     });
 });
 
-test('uncaughtException should handle thrown falsy boolean', function(t) {
+test(module, 'uncaughtException should handle thrown falsy boolean', function(
+    t
+) {
     SERVER.get(
         {
             name: 'foo',
@@ -2539,7 +2633,7 @@ test('uncaughtException should handle thrown falsy boolean', function(t) {
     });
 });
 
-test('should have proxy event handlers as instance', function(t) {
+test(module, 'should have proxy event handlers as instance', function(t) {
     var server = restify.createServer({
         handleUpgrades: false
     });
@@ -2555,7 +2649,7 @@ test('should have proxy event handlers as instance', function(t) {
     });
 });
 
-test('first chain should get to reject requests', function(t) {
+test(module, 'first chain should get to reject requests', function(t) {
     SERVER.get('/foobar', function(req, res, next) {
         t.fail('should not call handler');
     });
@@ -2572,7 +2666,7 @@ test('first chain should get to reject requests', function(t) {
     });
 });
 
-test('first chain should get to allow requests', function(t) {
+test(module, 'first chain should get to allow requests', function(t) {
     SERVER.get('/foobar', function(req, res, next) {
         res.send(413, 'Im a teapot');
         return next();
@@ -2588,7 +2682,7 @@ test('first chain should get to allow requests', function(t) {
     });
 });
 
-test('first chain should allow multiple handlers', function(t) {
+test(module, 'first chain should allow multiple handlers', function(t) {
     SERVER.get('/foobar', function(req, res, next) {
         res.send(413, 'Im a teapot');
         return next();
@@ -2609,7 +2703,7 @@ test('first chain should allow multiple handlers', function(t) {
     });
 });
 
-test('first chain should allow any handler to reject', function(t) {
+test(module, 'first chain should allow any handler to reject', function(t) {
     SERVER.get('/foobar', function(req, res, next) {
         res.send(200, 'Handled');
         return next();
@@ -2640,7 +2734,7 @@ test('first chain should allow any handler to reject', function(t) {
     });
 });
 
-test('inflightRequest accounting stable with firstChain', function(t) {
+test(module, 'inflightRequest accounting stable with firstChain', function(t) {
     // Make 3 requests, shed the second, and ensure inflightRequest accounting
     // for all the requests
     var request = 0;
@@ -2711,7 +2805,7 @@ test('inflightRequest accounting stable with firstChain', function(t) {
     CLIENT.get('/foobar', getDone);
 });
 
-test('async prerouting chain with error', function(t) {
+test(module, 'async prerouting chain with error', function(t) {
     SERVER.pre(async function(req, res) {
         await helper.sleep(10);
         throw new RestError({ statusCode: 400, restCode: 'BadRequest' }, 'bum');
@@ -2729,7 +2823,7 @@ test('async prerouting chain with error', function(t) {
     });
 });
 
-test('async prerouting chain with empty rejection', function(t) {
+test(module, 'async prerouting chain with empty rejection', function(t) {
     SERVER.pre(async function(req, res) {
         await helper.sleep(10);
         return Promise.reject();
@@ -2754,7 +2848,7 @@ test('async prerouting chain with empty rejection', function(t) {
     });
 });
 
-test('async use chain with error', function(t) {
+test(module, 'async use chain with error', function(t) {
     SERVER.use(async function(req, res) {
         await helper.sleep(10);
         throw new RestError({ statusCode: 400, restCode: 'BadRequest' }, 'bum');
@@ -2772,7 +2866,7 @@ test('async use chain with error', function(t) {
     });
 });
 
-test('async handler with error', function(t) {
+test(module, 'async handler with error', function(t) {
     SERVER.get('/hello/:name', async function tester(req, res) {
         await helper.sleep(10);
         throw new RestError({ statusCode: 400, restCode: 'BadRequest' }, 'bum');
@@ -2785,7 +2879,7 @@ test('async handler with error', function(t) {
     });
 });
 
-test('async handler with error after send succeeds', function(t) {
+test(module, 'async handler with error after send succeeds', function(t) {
     SERVER.get('/hello/:name', async function tester(req, res) {
         await helper.sleep(10);
         res.send(req.params.name);
@@ -2799,7 +2893,7 @@ test('async handler with error after send succeeds', function(t) {
     });
 });
 
-test('async handler with error after send succeeds', function(t) {
+test(module, 'async handler with error after send succeeds', function(t) {
     SERVER.get('/hello/:name', async function tester(req, res) {
         res.send(req.params.name);
         await helper.sleep(20);
@@ -2817,7 +2911,7 @@ test('async handler with error after send succeeds', function(t) {
     });
 });
 
-test('async handler without next', function(t) {
+test(module, 'async handler without next', function(t) {
     SERVER.get('/hello/:name', async function tester(req, res) {
         await helper.sleep(10);
         res.send(req.params.name);
@@ -2835,7 +2929,7 @@ test('async handler without next', function(t) {
     });
 });
 
-test('async handler should discard value', function(t) {
+test(module, 'async handler should discard value', function(t) {
     SERVER.get('/hello/:name', async function tester(req, res) {
         await helper.sleep(10);
         res.send(req.params.name);
@@ -2850,7 +2944,7 @@ test('async handler should discard value', function(t) {
     });
 });
 
-test('Server returns 400 on invalid method', function(t) {
+test(module, 'Server returns 400 on invalid method', function(t) {
     SERVER.get('/snickers/bar', function echoId(req, res, next) {
         res.send();
         next();
@@ -2875,7 +2969,7 @@ test('Server returns 400 on invalid method', function(t) {
     }).end();
 });
 
-test('Server returns 4xx when header size is too large', function(t) {
+test(module, 'Server returns 4xx when header size is too large', function(t) {
     SERVER.get('/jellybeans', function echoId(req, res, next) {
         res.send();
         next();
@@ -2908,7 +3002,7 @@ test('Server returns 4xx when header size is too large', function(t) {
     }).end();
 });
 
-test('Server supports adding custom clientError listener', function(t) {
+test(module, 'Server supports adding custom clientError listener', function(t) {
     SERVER.get('/popcorn', function echoId(req, res, next) {
         res.send();
         next();
@@ -2942,45 +3036,51 @@ test('Server supports adding custom clientError listener', function(t) {
     }).end();
 });
 
-test('Server correctly handles multiple clientError listeners', function(t) {
-    SERVER.get('/popcorn', function echoId(req, res, next) {
-        res.send();
-        next();
-    });
-
-    let numListenerCalls = 0;
-    SERVER.on('clientError', function(err, socket) {
-        socket.write("HTTP/1.1 418 I'm a teapot\r\nConnection: close\r\n\r\n");
-        numListenerCalls += 1;
-    });
-    SERVER.on('clientError', function(err, socket) {
-        if (numListenerCalls !== 1) {
-            t.fail('listener was called ' + numListenerCalls + ' times');
-        }
-        socket.destroy(err);
-    });
-
-    var opts = {
-        hostname: '127.0.0.1',
-        port: PORT,
-        path: '/popcorn',
-        method: 'GET',
-        agent: false,
-        headers: {
-            'jellybean-colors': 'purple,green,red,black,pink,'.repeat(1000)
-        }
-    };
-    http.request(opts, function(res) {
-        t.equal(res.statusCode, 418);
-        t.equal(res.statusMessage, "I'm a teapot");
-        res.on('data', function() {});
-        res.on('end', function() {
-            t.end();
+test(
+    module,
+    'Server correctly handles multiple clientError listeners',
+    function(t) {
+        SERVER.get('/popcorn', function echoId(req, res, next) {
+            res.send();
+            next();
         });
-    }).end();
-});
 
-test('req and res should use server logger by default', function(t) {
+        let numListenerCalls = 0;
+        SERVER.on('clientError', function(err, socket) {
+            socket.write(
+                "HTTP/1.1 418 I'm a teapot\r\nConnection: close\r\n\r\n"
+            );
+            numListenerCalls += 1;
+        });
+        SERVER.on('clientError', function(err, socket) {
+            if (numListenerCalls !== 1) {
+                t.fail('listener was called ' + numListenerCalls + ' times');
+            }
+            socket.destroy(err);
+        });
+
+        var opts = {
+            hostname: '127.0.0.1',
+            port: PORT,
+            path: '/popcorn',
+            method: 'GET',
+            agent: false,
+            headers: {
+                'jellybean-colors': 'purple,green,red,black,pink,'.repeat(1000)
+            }
+        };
+        http.request(opts, function(res) {
+            t.equal(res.statusCode, 418);
+            t.equal(res.statusMessage, "I'm a teapot");
+            res.on('data', function() {});
+            res.on('end', function() {
+                t.end();
+            });
+        }).end();
+    }
+);
+
+test(module, 'req and res should use server logger by default', function(t) {
     SERVER.get('/ping', function echoId(req, res, next) {
         t.ok(req.log);
         t.strictEqual(req.log, SERVER.log);
@@ -2997,31 +3097,37 @@ test('req and res should use server logger by default', function(t) {
     });
 });
 
-test('req and res should use own logger by if set during .first', function(t) {
-    const buffer = new StreamRecorder();
-    SERVER.first(function first(req, res) {
-        req.log = helper.getLog('server', buffer, 'info');
-    });
+test(
+    module,
+    'req and res should use own logger by if set during .first',
+    function(t) {
+        const buffer = new StreamRecorder();
+        SERVER.first(function first(req, res) {
+            req.log = helper.getLog('server', buffer, 'info');
+        });
 
-    SERVER.get('/ping', function echoId(req, res, next) {
-        LOG_BUFFER.flushRecords();
-        t.ok(req.log);
-        t.notStrictEqual(req.log, SERVER.log);
-        req.log.info('foo');
-        t.equal(buffer.records[buffer.length - 1].msg, 'foo');
-        res.log.info('bar');
-        t.equal(buffer.records[buffer.length - 1].msg, 'bar');
-        t.equal(LOG_BUFFER.records.length, 0);
-        res.send();
-        next();
-    });
+        SERVER.get('/ping', function echoId(req, res, next) {
+            LOG_BUFFER.flushRecords();
+            t.ok(req.log);
+            t.notStrictEqual(req.log, SERVER.log);
+            req.log.info('foo');
+            t.equal(buffer.records[buffer.length - 1].msg, 'foo');
+            res.log.info('bar');
+            t.equal(buffer.records[buffer.length - 1].msg, 'bar');
+            t.equal(LOG_BUFFER.records.length, 0);
+            res.send();
+            next();
+        });
 
-    CLIENT.get('/ping', function() {
-        t.end();
-    });
-});
+        CLIENT.get('/ping', function() {
+            t.end();
+        });
+    }
+);
 
-test('should throw if handleUncaughtExceptions is invalid', function(t) {
+test(module, 'should throw if handleUncaughtExceptions is invalid', function(
+    t
+) {
     t.throws(() => {
         restify.createServer({
             handleUncaughtExceptions: 'this is invalid'
@@ -3030,7 +3136,7 @@ test('should throw if handleUncaughtExceptions is invalid', function(t) {
     t.end();
 });
 
-test('should use custom function for error handling', function(t) {
+test(module, 'should use custom function for error handling', function(t) {
     const asl = new AsyncLocalStorage();
     let callOnError;
     var server = restify.createServer({

--- a/test/serverHttp2.test.js
+++ b/test/serverHttp2.test.js
@@ -39,7 +39,7 @@ var SERVER;
 
 ///--- Tests
 
-before(function(cb) {
+before(module, function(cb) {
     try {
         SERVER = restify.createServer({
             dtrace: helper.dtrace,
@@ -65,7 +65,7 @@ before(function(cb) {
     }
 });
 
-after(function(cb) {
+after(module, function(cb) {
     try {
         CLIENT.destroy();
         SERVER.close(function() {
@@ -79,7 +79,7 @@ after(function(cb) {
     }
 });
 
-test('get (path only)', function(t) {
+test(module, 'get (path only)', function(t) {
     SERVER.get('/foo/:id', function echoId(req, res, next) {
         t.ok(req.params);
         t.equal(req.params.id, 'bar');

--- a/test/upgrade.test.js
+++ b/test/upgrade.test.js
@@ -75,7 +75,7 @@ function finish_latch(_test, _names) {
 
 ///--- Tests
 
-before(function(cb) {
+before(module, function(cb) {
     try {
         SERVER = restify.createServer({
             dtrace: helper.dtrace,
@@ -99,7 +99,7 @@ before(function(cb) {
     }
 });
 
-after(function(cb) {
+after(module, function(cb) {
     try {
         CLIENT.close();
         SERVER.close(function() {
@@ -117,7 +117,7 @@ after(function(cb) {
     }
 });
 
-test('GET without upgrade headers', function(t) {
+test(module, 'GET without upgrade headers', function(t) {
     var done = finish_latch(t, {
         'client response': 1,
         'server response': 1
@@ -158,7 +158,7 @@ test('GET without upgrade headers', function(t) {
     });
 });
 
-test('Dueling upgrade and response handling 1', function(t) {
+test(module, 'Dueling upgrade and response handling 1', function(t) {
     var done = finish_latch(t, {
         'expected requestUpgrade error': 1,
         'client response': 1
@@ -214,7 +214,7 @@ test('Dueling upgrade and response handling 1', function(t) {
     });
 });
 
-test('Dueling upgrade and response handling 2', function(t) {
+test(module, 'Dueling upgrade and response handling 2', function(t) {
     var done = finish_latch(t, {
         'expected res.send error': 1,
         'expected server to reset': 1
@@ -258,7 +258,7 @@ test('Dueling upgrade and response handling 2', function(t) {
     });
 });
 
-test('GET with upgrade headers', function(t) {
+test(module, 'GET with upgrade headers', function(t) {
     var done = finish_latch(t, {
         'client shed end': 1,
         'server shed end': 1
@@ -320,7 +320,7 @@ test('GET with upgrade headers', function(t) {
     });
 });
 
-test('GET with some websocket traffic', function(t) {
+test(module, 'GET with some websocket traffic', function(t) {
     var done = finish_latch(t, {
         'client shed end': 1,
         'server shed end': 1,

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -12,7 +12,9 @@ var helper = require('./lib/helper.js');
 
 var test = helper.test;
 
-test('merge qs', function(t) {
+// mergeQs
+
+test(module, 'merge qs', function(t) {
     var qs1 = mergeQs(undefined, { a: 1 });
     t.deepEqual(qs1, { a: 1 });
 


### PR DESCRIPTION
<!--
Thank you for taking the time to open an PR for restify! If this is your first
time here, welcome to our community! We are a group of developers who work on
restify in our free-time. Some of us do it as a hobby, others are using restify
at work. When asking for help here, keep in mind most of us are volunteers
contributing our daily work back to the community at no cost (and often for no
reward). Please be respectful!

Below you will find a checklist to help you create the best PR possible. While
the checklist items aren't all _strictly_ required, they dramatically increase
the probability of your PR getting a response and getting merged. Often times,
the least time consuming part of maintaining and open source project is writing
code, its the process and discussions that happen around the code base that
consume a majority of the maintainers' time. By spending a few moments to
adhere to this template, you are not only improve the quality of your PR, you
are also helping save the maintainers a considerable amount of time when trying
to understand and review your changes.

And remember, positive vibes are met with positive vibes. Kindness helps Free
Software go round, pay it forward!
-->

## Pre-Submission Checklist

- [ ] Opened an issue discussing these changes before opening the PR
- [ ] Ran the linter and tests via `make prepush`
- [ ] Included comprehensive and convincing tests for changes

## Issues

Closes:

* Issue #
* Issue #
* Issue #

> Summarize the issues that discussed these changes

# Changes

## Deprecated API Fixes
- `module.parent` — removed in Node.js 26. Replaced with `require.main === module`.
  Affected: `benchmark/benchmarks/*.js`, `test/lib/helper.js`.

