### PR TITLE
ci: bump npm-publish  nodejs version

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20.x
+          node-version: 22.x
           cache: npm
 
       - name: verify release version
@@ -83,7 +83,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20.x
+          node-version: 26.x
           registry-url: https://registry.npmjs.org
 
       - name: publish to npm


### PR DESCRIPTION
npm-publish workflow previously failed at the `npm publish` step due to incorrect node/npm versions.

Npm official requirement is npm 11.5.1 or later and Node >=22.14