### PR TITLE
fix: do not throw from getUrl on an invalid Host or request target

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -458,6 +458,17 @@ function patch(Request) {
         if (this._cacheURL !== this.url) {
             var protocol = this.isSecure() ? 'https://' : 'http://';
             var base = protocol + (this.headers.host || 'localhost');
+
+            // The Host header and the request target are both client-supplied
+            // and Node's HTTP parser validates neither as a URL, so either can
+            // be something new URL() rejects - a "foo|bar" host, or an
+            // absolute-form target like "http://a:99999/x". getUrl() is called
+            // from Router.lookup on every request, where nothing catches, so
+            // throwing here takes down the process. Fall back instead.
+            if (!URL.canParse(base)) {
+                base = protocol + 'localhost';
+            }
+
             // For origin-form targets (starting with "/"), concatenate into
             // one URL string instead of new URL(this.url, base), which would
             // treat a leading "//" as a network-path reference and drop part
@@ -467,10 +478,16 @@ function patch(Request) {
             // path as "//evil.com/x" on the original host. Other forms
             // (e.g. "*" for "OPTIONS *") don't start with "/" and keep the
             // two-arg form.
-            this._url =
-                this.url.charAt(0) === '/'
+            if (this.url.charAt(0) === '/') {
+                this._url = URL.canParse(base + this.url)
                     ? new URL(base + this.url)
-                    : new URL(this.url, base);
+                    : new URL(base + '/');
+            } else {
+                this._url = URL.canParse(this.url, base)
+                    ? new URL(this.url, base)
+                    : new URL(base + '/');
+            }
+
             this._cacheURL = this.url;
         }
         return this._url;

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -1,6 +1,9 @@
 'use strict';
 /* eslint-disable func-names */
 
+var http = require('http');
+var net = require('net');
+
 var restifyClients = require('restify-clients');
 var validator = require('validator');
 
@@ -371,6 +374,60 @@ test(module, 'getUrl result is cached across calls', function(t) {
     CLIENT.get('/geturl-cache', function(err, _, res) {
         t.ifError(err);
         t.equal(res.statusCode, 200);
+        t.end();
+    });
+});
+
+test(module, 'should not crash when the Host header is not a valid URL host', function(t) {
+    SERVER.get('/hosthdr', function(req, res, next) {
+        res.send({ pathname: req.path() });
+        return next();
+    });
+
+    // The Host header is client-supplied and Node does not validate it as a
+    // URL authority. getUrl() must not throw on it: it is called from
+    // Router.lookup on every request, where nothing catches, so a throw
+    // here takes down the process.
+    var opts = {
+        agent: false,
+        headers: { Host: 'foo|bar' },
+        hostname: '127.0.0.1',
+        method: 'GET',
+        path: '/hosthdr',
+        port: PORT
+    };
+
+    http.request(opts, function(res) {
+        t.equal(res.statusCode, 200);
+        res.resume();
+        res.on('end', function() {
+            t.end();
+        });
+    }).end();
+});
+
+test(module, 'should not crash when the request target is not a valid URL', function(t) {
+    // An absolute-form request target is client-supplied and Node's HTTP
+    // parser does not validate it as a URL either, so getUrl() must not
+    // throw on it. Needs a raw socket: http.request only emits
+    // origin-form targets.
+    var response = '';
+    var socket = net.connect(PORT, '127.0.0.1', function() {
+        socket.write(
+            'GET http://a:99999/x HTTP/1.1\r\n' +
+                'Host: 127.0.0.1:' +
+                PORT +
+                '\r\n' +
+                'Connection: close\r\n\r\n'
+        );
+    });
+
+    socket.on('data', function(chunk) {
+        response += chunk;
+    });
+
+    socket.on('close', function() {
+        t.ok(/^HTTP\/1\.1 \d{3}/.test(response), 'server sent a response');
         t.end();
     });
 });


### PR DESCRIPTION
## Pre-Submission Checklist

- [x] Opened an issue discussing these changes before opening the PR
- [x] Ran the linter and tests via `make prepush`
- [x] Included comprehensive and convincing tests for changes

## Issues

Closes:

* Issue #2011

`getUrl()` builds a WHATWG `URL` from two client-supplied inputs — the `Host` header as the
authority, and the request target. Node's HTTP parser validates neither as a URL, so either
can make `new URL()` throw. `Router.lookup` calls `req.getUrl().pathname` on every request
before any handler runs, nothing on that path catches, and `createServer` defaults
`handleUncaughtExceptions` to `false` — so one malformed request exits the process.

Introduced in 12.0.0 by #1996. 11.1.0 is unaffected — `getUrl()` was `url.parse(this.url)`,
path-only, and never read the `Host` header.

# Changes

Guards both `new URL()` constructions with `URL.canParse` and falls back instead of throwing:

- an unparseable `Host` falls back to a placeholder authority
- an unparseable request target falls back to the base origin, so the request routes as `/`
  and gets a normal 404 rather than killing the server

### Tests

Two regression tests in `test/request.test.js`. Both confirmed to fail
against unpatched `lib/request.js` — the first takes the process down mid-suite, which is
the behaviour being fixed.

### Verification

`make prepush` green: 794 nodeunit assertions + 209 mocha.

Behaviour against 12.0.0, same server, raw sockets:

| request | before | after |
|---|---|---|
| `Host: foo\|bar` | process death | 200 |
| `GET http://a:99999/x` (valid `Host`) | process death | 404 |
| `GET http://[::1/x` | process death | 404 |
| `GET a://[` | process death | 404 |
| `GET http://other.example/x` (proxy style) | 200 | 200 |
| `OPTIONS *` | 200 | 200 |
| origin-form, valid `Host` | 200 | 200 |